### PR TITLE
fix: lowercase city lookup sets to match validation normalization

### DIFF
--- a/gateway/utils/geo_normalize.py
+++ b/gateway/utils/geo_normalize.py
@@ -28,8 +28,8 @@ with open(_geo_path, 'r', encoding='utf-8') as _f:
 # Build sets for O(1) validation lookups
 VALID_COUNTRIES_SET = set(_geo_data['countries'])
 US_STATES_SET = set(_geo_data['us_states'].keys())
-US_CITIES_BY_STATE = {state: set(cities) for state, cities in _geo_data['us_states'].items()}
-CITIES_BY_COUNTRY = {country: set(cities) for country, cities in _geo_data['cities'].items()}
+US_CITIES_BY_STATE = {state: {c.lower() for c in cities} for state, cities in _geo_data['us_states'].items()}
+CITIES_BY_COUNTRY = {country: {c.lower() for c in cities} for country, cities in _geo_data['cities'].items()}
 STATE_ABBR_TO_NAME = _geo_data['state_abbr']
 
 # Build proper case mapping for US states (lowercase -> Proper Case)


### PR DESCRIPTION
## Summary
- `US_CITIES_BY_STATE` and `CITIES_BY_COUNTRY` retained original mixed-case entries from `geo_lookup_fast.json` (e.g. Holland, Lebanon, Spring Valley, Staatsburg, Jay)
- `_normalize_for_validation()` lowercases input before lookup, so these cities always failed validation
- Fix: lowercase city names when building the lookup sets at import time

## Change
```python
# Before
US_CITIES_BY_STATE = {state: set(cities) for ...}
CITIES_BY_COUNTRY = {country: set(cities) for ...}

# After
US_CITIES_BY_STATE = {state: {c.lower() for c in cities} for ...}
CITIES_BY_COUNTRY = {country: {c.lower() for c in cities} for ...}
```

## Testing
- Verified all 5 previously failing cities now pass `validate_location()`
- No behavioral change for already-lowercase entries