### PR TITLE
[codex] Preserve compute reimbursement on failed loops

### DIFF
--- a/env.example
+++ b/env.example
@@ -85,11 +85,15 @@ COMPANIES_HOUSE_API_KEY=your_companies_house_key_here
 RESEARCH_LAB_RAW_TRACE_S3_PREFIX=s3://your-bucket/research-lab
 # Scorer judgment breakdown artifacts
 RESEARCH_LAB_SCORER_TRACE_S3_PREFIX=s3://your-bucket/research-lab
+# Raw/scorer trace SSE-KMS key (required in production)
+RESEARCH_LAB_TRACE_KMS_KEY_ID=alias/your-trace-kms-key
 # Private-model in-container provider traces (prefix AND KMS key are both
 # required — unencrypted uploads are refused)
 RESEARCH_LAB_INCONTAINER_TRACE_S3_PREFIX=s3://your-bucket/research-lab/incontainer-traces
 RESEARCH_LAB_INCONTAINER_TRACE_KMS_KEY_ID=alias/your-kms-key
 # Supabase corpus projection (schema 27 tables) — required in production
 RESEARCH_LAB_TRAJECTORY_PROJECTOR_ENABLED=true
+# Explicit execution_traces -> research_trajectories join key (requires script 64)
+RESEARCH_LAB_EXECUTION_TRACE_TRAJECTORY_ID_ENABLED=true
 # Escape hatch: start a production worker with degraded capture (loud error)
 # RESEARCH_LAB_CAPTURE_HEALTH_ALLOW_DEGRADED=true

--- a/gateway/api/weights.py
+++ b/gateway/api/weights.py
@@ -27,6 +27,9 @@ import base64
 import hashlib
 import json
 import logging
+import re
+import urllib.error
+import urllib.request
 import uuid
 from datetime import datetime
 from typing import List, Optional, Set
@@ -58,6 +61,12 @@ MAX_BLOCK_DRIFT = 30  # Max allowed drift from gateway-observed block
 
 # Build identifier for transparency log
 BUILD_ID = os.environ.get("BUILD_ID", "production-gateway-tee")
+PCR0_ALLOWLIST_URL = os.environ.get(
+    "PCR0_ALLOWLIST_URL",
+    "https://raw.githubusercontent.com/leadpoet/leadpoet/main/pcr0_allowlist.json",
+)
+_COMMIT_HASH_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+_NOTES_COMMIT_RE = re.compile(r"\bcommit\s+([0-9a-fA-F]{7,40})\b")
 
 # PCR0 is the ROOT OF TRUST - code_hash in user_data is INFORMATIONAL only
 # The verify_nitro_attestation_full function checks PCR0 against the allowlist
@@ -85,6 +94,87 @@ def get_subtensor():
         import bittensor as bt
         _subtensor = bt.subtensor()
     return _subtensor
+
+
+def _extract_commit_hash_from_allowlist_entry(entry: dict) -> Optional[str]:
+    """Return commit metadata from a PCR0 allowlist entry, if present."""
+    return (
+        _extract_explicit_commit_hash_from_allowlist_entry(entry)
+        or _extract_notes_commit_hash_from_allowlist_entry(entry)
+    )
+
+
+def _extract_explicit_commit_hash_from_allowlist_entry(entry: dict) -> Optional[str]:
+    """Return structured commit metadata from a PCR0 allowlist entry."""
+    for key in ("commit_hash", "git_commit_sha", "git_commit", "commit"):
+        value = entry.get(key)
+        if isinstance(value, str) and _COMMIT_HASH_RE.fullmatch(value.strip()):
+            return value.strip().lower()
+
+    return None
+
+
+def _extract_notes_commit_hash_from_allowlist_entry(entry: dict) -> Optional[str]:
+    """Return legacy free-text commit metadata from a PCR0 allowlist entry."""
+    notes = entry.get("notes")
+    if isinstance(notes, str):
+        match = _NOTES_COMMIT_RE.search(notes)
+        if match:
+            return match.group(1).lower()
+
+    return None
+
+
+def _lookup_pcr0_commit_hash_from_allowlist(pcr0_hex: str) -> Optional[str]:
+    """
+    Resolve static-allowlist PCR0 approvals back to a commit for audit storage.
+
+    Dynamic GitHub verification already returns pcr0_commit. Static allowlist
+    fallback must also store a non-null commit hash because auditors rely on
+    published_weight_bundles.pcr0_commit_hash.
+    """
+    if not pcr0_hex or pcr0_hex == "N/A":
+        return None
+
+    allowlist_docs = []
+    try:
+        request = urllib.request.Request(
+            PCR0_ALLOWLIST_URL,
+            headers={"User-Agent": "LeadPoet-Gateway/1.0"},
+        )
+        with urllib.request.urlopen(request, timeout=10) as response:
+            allowlist_docs.append(json.loads(response.read().decode("utf-8")))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as e:
+        logger.warning(f"[PCR0] Could not fetch allowlist metadata from GitHub: {e}")
+
+    try:
+        with open("pcr0_allowlist.json", "r", encoding="utf-8") as handle:
+            allowlist_docs.append(json.load(handle))
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug(f"[PCR0] Could not read local allowlist metadata: {e}")
+
+    explicit_matches = []
+    legacy_note_matches = []
+    for doc in allowlist_docs:
+        for entry in doc.get("validator_pcr0", []):
+            if entry.get("pcr0") != pcr0_hex:
+                continue
+
+            explicit = _extract_explicit_commit_hash_from_allowlist_entry(entry)
+            if explicit:
+                explicit_matches.append(explicit)
+                continue
+
+            notes_commit = _extract_notes_commit_hash_from_allowlist_entry(entry)
+            if notes_commit:
+                legacy_note_matches.append(notes_commit)
+
+    if explicit_matches:
+        return explicit_matches[0]
+    if legacy_note_matches:
+        return legacy_note_matches[0]
+
+    return None
 
 
 # ============================================================================
@@ -389,11 +479,18 @@ async def submit_weights(submission: WeightSubmission) -> WeightSubmissionRespon
     verified_pcr0 = attestation_data.get("pcr0", "N/A")
     pcr0_mode = attestation_data.get("pcr0_verification_mode", "allowlist")
     pcr0_commit_hash = attestation_data.get("pcr0_commit")  # Git commit hash for auditability
+    if not pcr0_commit_hash:
+        pcr0_commit_hash = _lookup_pcr0_commit_hash_from_allowlist(verified_pcr0)
     print(f"   ✅ Nitro attestation OK")
     print(f"      PCR0: {verified_pcr0[:32]}...")
     print(f"      Mode: {pcr0_mode} (auditors verify against GitHub)")
     if pcr0_commit_hash:
         print(f"      Commit: {pcr0_commit_hash[:8]}... (auditors can verify this commit exists)")
+    else:
+        raise HTTPException(
+            status_code=500,
+            detail="Verified validator PCR0 but could not resolve pcr0_commit_hash for audit storage",
+        )
     
     # --- Step 5: Hotkey binding verification ---
     print(f"   Step 5: Verifying hotkey binding...")

--- a/gateway/research_lab/capture_health.py
+++ b/gateway/research_lab/capture_health.py
@@ -213,7 +213,7 @@ async def check_projector_tables() -> dict[str, str]:
     out: dict[str, str] = {}
     for table in tables:
         try:
-            await select_many(table, columns="id", limit=1)
+            await select_many(table, columns="*", filters=(), limit=1)
             out[table] = "present"
         except Exception as exc:  # noqa: BLE001 - reporting only
             out[table] = f"error:{str(exc)[:80]}"

--- a/gateway/research_lab/code_loop_engine.py
+++ b/gateway/research_lab/code_loop_engine.py
@@ -3025,27 +3025,60 @@ class CodeEditLoopEngine:
                 )
 
                 remaining_call_seconds = max(1, int(settings.max_seconds - elapsed()))
-                repair_result = _coerce_call_result(
-                    await self.call_openrouter(
-                        build_code_edit_repair_messages(
-                            draft=candidate_draft,
-                            apply_error=str(exc),
-                            source_inspection_context=source_inspection_context,
-                            runtime_source_context=source_context.prompt_context(),
-                            budget_context={
-                                **dict(budget_context),
-                                "loop_iteration": iteration,
-                                "repair_attempt": repair_attempt + 1,
-                                "candidate_kind": "image_build",
-                            },
-                            repair_attempt=repair_attempt + 1,
-                            max_candidates=1,
-                        ),
-                        min(settings.draft_timeout_seconds, remaining_call_seconds),
-                        3000,
-                        "code_edit_repair",
-                    )
+                repair_result, repair_call_error = await self._call_stage_contained(
+                    build_code_edit_repair_messages(
+                        draft=candidate_draft,
+                        apply_error=str(exc),
+                        source_inspection_context=source_inspection_context,
+                        runtime_source_context=source_context.prompt_context(),
+                        budget_context={
+                            **dict(budget_context),
+                            "loop_iteration": iteration,
+                            "repair_attempt": repair_attempt + 1,
+                            "candidate_kind": "image_build",
+                        },
+                        repair_attempt=repair_attempt + 1,
+                        max_candidates=1,
+                    ),
+                    min(settings.draft_timeout_seconds, remaining_call_seconds),
+                    3000,
+                    "code_edit_repair",
                 )
+                if repair_result is None:
+                    failure_usage = (
+                        repair_call_error.failure_usage_entries()
+                        if isinstance(repair_call_error, ContainedStageFailure)
+                        else []
+                    )
+                    if isinstance(repair_call_error, ContainedStageFailure):
+                        actual_cost_microusd += repair_call_error.cost_microusd
+                        provider_usage.extend(failure_usage)
+                    await self.event_sink(
+                        AutoResearchLoopEvent(
+                            event_type="code_edit_repair_failed",
+                            loop_status="running",
+                            elapsed_seconds=elapsed(),
+                            node_id=node_id,
+                            provider_usage=failure_usage,
+                            cost_ledger=_running_cost_ledger(
+                                openrouter_calls,
+                                estimated_cost,
+                                actual_cost_microusd,
+                                "code_edit_repair_call_failed",
+                            ),
+                            event_doc={
+                                "iteration": iteration,
+                                "repair_attempt": repair_attempt + 1,
+                                "stage": "code_edit_repair_call_failed",
+                                "target_files": list(candidate_draft.target_files),
+                                "source_diff_hash": sha256_json({"unified_diff": candidate_draft.unified_diff}),
+                                "error": repair_call_error or "code_edit_repair_call_failed",
+                            },
+                        )
+                    )
+                    if repair_attempt + 1 >= max_repairs:
+                        return None, openrouter_calls, estimated_cost, actual_cost_microusd, False
+                    continue
                 openrouter_calls += 1
                 estimated_cost += settings.estimated_iteration_cost_usd
                 actual_cost_microusd += max(0, int(repair_result.cost_microusd))

--- a/gateway/research_lab/trace_reconciler.py
+++ b/gateway/research_lab/trace_reconciler.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping, Sequence
 
 from gateway.research_lab.trajectory_projector import (
@@ -39,6 +40,8 @@ from gateway.research_lab.trajectory_projector import (
 )
 
 logger = logging.getLogger(__name__)
+
+TRACE_POINTER_QUARANTINE_TABLE = "research_lab_trace_pointer_quarantine"
 
 _POINTER_KEY_PAIRS = (
     ("raw_trace_ref", None),  # nested {s3_ref, sha256}
@@ -105,6 +108,44 @@ async def collect_trace_pointers(
     return list(out.values())
 
 
+def _pointer_key(pointer: Mapping[str, Any]) -> tuple[str, str]:
+    return (str(pointer.get("s3_ref") or ""), str(pointer.get("sha256") or ""))
+
+
+async def collect_quarantined_trace_pointers(
+    *,
+    store: Any | None = None,
+    max_rows: int = 50000,
+) -> dict[tuple[str, str], dict[str, Any]]:
+    """Load operator-marked unrecoverable trace pointers.
+
+    The table is optional during rolling deploys. If scripts/66 is not applied
+    yet, reconciliation stays conservative and reports pointers as missing.
+    """
+    store = store or GatewayProjectorStore()
+    try:
+        rows = await store.select_all(
+            TRACE_POINTER_QUARANTINE_TABLE,
+            columns="s3_ref,sha256,source,status,reason,marked_at,quarantine_doc",
+            filters=(("status", "unrecoverable"),),
+            order_by=(("marked_at", True),),
+            max_rows=max(1, int(max_rows)),
+        )
+    except Exception as exc:  # noqa: BLE001 - optional operator metadata
+        logger.warning(
+            "trace_pointer_quarantine_unavailable table=%s error=%s",
+            TRACE_POINTER_QUARANTINE_TABLE,
+            str(exc)[:160],
+        )
+        return {}
+    out: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in rows:
+        key = _pointer_key(row)
+        if key[0]:
+            out[key] = dict(row)
+    return out
+
+
 def _head_object(s3_client: Any, s3_ref: str) -> str:
     bucket, _sep, key = s3_ref[5:].partition("/")
     if not bucket or not key:
@@ -131,7 +172,9 @@ async def reconcile_trace_pointers(
     store: Any | None = None,
     s3_client: Any | None = None,
     verify_hash: bool = False,
+    include_quarantine: bool = True,
     max_rows: int = 2000,
+    max_problems: int | None = 50,
 ) -> dict[str, Any]:
     """P6: verify pointer→object integrity for recent corpus pointers.
 
@@ -139,6 +182,11 @@ async def reconcile_trace_pointers(
     missing/mismatched refs for operator output; alerts are the caller's job.
     """
     pointers = await collect_trace_pointers(store=store, max_rows=max_rows)
+    quarantined = (
+        await collect_quarantined_trace_pointers(store=store, max_rows=max_rows * 5)
+        if include_quarantine
+        else {}
+    )
     if s3_client is None:
         try:
             import boto3  # type: ignore
@@ -152,9 +200,17 @@ async def reconcile_trace_pointers(
                 "pointer_count": len(pointers),
             }
 
-    counts = {"verified": 0, "missing": 0, "hash_mismatch": 0, "unchecked": 0, "invalid_ref": 0}
+    counts = {
+        "verified": 0,
+        "missing": 0,
+        "unrecoverable": 0,
+        "hash_mismatch": 0,
+        "unchecked": 0,
+        "invalid_ref": 0,
+    }
     by_source: dict[str, dict[str, int]] = {}
     problems: list[dict[str, Any]] = []
+    unrecoverable: list[dict[str, Any]] = []
 
     def _check(pointer: Mapping[str, Any]) -> tuple[dict[str, Any], str]:
         status = _head_object(s3_client, pointer["s3_ref"])
@@ -169,11 +225,22 @@ async def reconcile_trace_pointers(
 
     for pointer in pointers:
         checked, status = await asyncio.to_thread(_check, pointer)
+        if status == "missing" and _pointer_key(checked) in quarantined:
+            status = "unrecoverable"
+            checked["quarantine"] = quarantined[_pointer_key(checked)]
         counts[status] = counts.get(status, 0) + 1
         source_counts = by_source.setdefault(str(checked.get("source")), {})
         source_counts[status] = source_counts.get(status, 0) + 1
-        if status in {"missing", "hash_mismatch"} and len(problems) < 50:
+        if (
+            status in {"missing", "hash_mismatch"}
+            and (max_problems is None or len(problems) < max_problems)
+        ):
             problems.append({**checked, "status": status})
+        if (
+            status == "unrecoverable"
+            and (max_problems is None or len(unrecoverable) < max_problems)
+        ):
+            unrecoverable.append({**checked, "status": status})
     if counts["missing"] or counts["hash_mismatch"]:
         logger.error(
             "research_lab_trace_pointer_reconcile_problems missing=%s hash_mismatch=%s "
@@ -187,9 +254,100 @@ async def reconcile_trace_pointers(
         "status": "completed",
         "pointer_count": len(pointers),
         "verify_hash": bool(verify_hash),
+        "quarantine_enabled": bool(include_quarantine),
+        "quarantined_pointer_count": len(quarantined),
         "counts": counts,
         "by_source": by_source,
         "problems": problems,
+        "unrecoverable": unrecoverable,
+    }
+
+
+async def quarantine_missing_trace_pointers(
+    *,
+    store: Any | None = None,
+    s3_client: Any | None = None,
+    max_rows: int = 2000,
+    reason: str = "historical_beta_optimistic_upload_missing",
+    operator_note: str = "",
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Mark currently missing trace pointers as intentionally unrecoverable.
+
+    This is an operator action for known historical beta gaps. It does not
+    delete or mutate source corpus rows; it writes a separate audit row so
+    future reconciliation can keep new misses loud.
+    """
+    store = store or GatewayProjectorStore()
+    if s3_client is None:
+        try:
+            import boto3  # type: ignore
+
+            s3_client = boto3.client("s3")
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "schema_version": "1.0",
+                "status": "s3_unavailable",
+                "error": str(exc)[:200],
+                "dry_run": bool(dry_run),
+            }
+    pointers = await collect_trace_pointers(store=store, max_rows=max_rows)
+    existing = await collect_quarantined_trace_pointers(store=store, max_rows=max_rows * 5)
+    now = datetime.now(timezone.utc).isoformat()
+    rows: list[dict[str, Any]] = []
+    for pointer in pointers:
+        status = await asyncio.to_thread(_head_object, s3_client, pointer["s3_ref"])
+        if status != "missing":
+            continue
+        key = _pointer_key(pointer)
+        if key in existing:
+            continue
+        rows.append(
+            {
+                "s3_ref": key[0],
+                "sha256": key[1],
+                "source": str(pointer.get("source") or ""),
+                "status": "unrecoverable",
+                "reason": str(reason or "historical_beta_optimistic_upload_missing"),
+                "operator_note": str(operator_note or ""),
+                "marked_at": now,
+                "quarantine_doc": {
+                    "source": str(pointer.get("source") or ""),
+                    "marked_by": "gateway.research_lab.trace_reconciler",
+                    "pointer": dict(pointer),
+                },
+            }
+        )
+    inserted = 0
+    skipped_existing = len([p for p in pointers if _pointer_key(p) in existing])
+    failed = 0
+    if not dry_run:
+        for row in rows:
+            try:
+                await store.insert_row(TRACE_POINTER_QUARANTINE_TABLE, row)
+                inserted += 1
+            except Exception as exc:  # noqa: BLE001 - duplicate races are benign
+                if "duplicate" in str(exc).lower() or "unique" in str(exc).lower():
+                    skipped_existing += 1
+                    continue
+                failed += 1
+                logger.warning(
+                    "trace_pointer_quarantine_insert_failed ref=%s error=%s",
+                    row["s3_ref"],
+                    str(exc)[:160],
+                )
+    return {
+        "schema_version": "1.0",
+        "status": "completed" if not failed else "completed_with_errors",
+        "dry_run": bool(dry_run),
+        "reason": str(reason or ""),
+        "pointers_scanned": len(pointers),
+        "already_quarantined": len(existing),
+        "missing_to_quarantine": len(rows),
+        "quarantined": inserted if not dry_run else 0,
+        "skipped_existing": skipped_existing,
+        "failed": failed,
+        "sample": rows[:50],
     }
 
 

--- a/gateway/research_lab/trajectory_projector.py
+++ b/gateway/research_lab/trajectory_projector.py
@@ -3668,7 +3668,10 @@ async def backfill_corpus_trace_rows(
             RUN_QUEUE_TABLE,
             columns="run_id,ticket_id,current_queue_status,current_status_at",
             filters=(("current_queue_status", "in", list(_QUEUE_TERMINAL_STATUSES)),),
-            order_by=(("current_status_at", False),),
+            # Late scorer/in-container traces usually arrive after run
+            # completion, so the maintenance pass should prioritize recent
+            # terminal runs. Historical deep repairs remain the CLI's job.
+            order_by=(("current_status_at", True),),
             max_rows=max_candidates,
         )
     except Exception as exc:

--- a/gateway/research_lab/trajectory_projector.py
+++ b/gateway/research_lab/trajectory_projector.py
@@ -2977,8 +2977,150 @@ def _merge_trace_calls(
     return changed, merged
 
 
+def _merge_doc_values(
+    existing: Mapping[str, Any], proposed: Mapping[str, Any]
+) -> tuple[bool, dict[str, Any]]:
+    """Merge projector metadata docs, preferring newly derived safe values."""
+    merged = dict(existing)
+    changed = False
+    for key, value in proposed.items():
+        if value is None:
+            continue
+        current = merged.get(key)
+        if isinstance(current, Mapping) and isinstance(value, Mapping):
+            nested_changed, nested = _merge_doc_values(current, value)
+            if nested_changed:
+                merged[key] = nested
+                changed = True
+            continue
+        if current != value:
+            merged[key] = value
+            changed = True
+    return changed, merged
+
+
+def _judge_verdict_key(verdict: Mapping[str, Any]) -> tuple[str, str, str, str, str, str]:
+    s3_ref = str(verdict.get("s3_ref") or "")
+    sha256 = str(verdict.get("sha256") or "")
+    if s3_ref or sha256:
+        return ("raw", s3_ref, sha256, "", "", "")
+    return (
+        "metadata",
+        str(verdict.get("verdict_kind") or ""),
+        str(verdict.get("icp_ref") or ""),
+        str(verdict.get("score_bundle_ref") or ""),
+        str(verdict.get("candidate_ref") or ""),
+        str(verdict.get("source") or ""),
+    )
+
+
+def _merge_judge_verdicts(
+    existing_verdicts: Any,
+    proposed_verdicts: Any,
+) -> tuple[bool, list[dict[str, Any]]]:
+    merged: list[dict[str, Any]] = [
+        dict(item)
+        for item in (existing_verdicts if isinstance(existing_verdicts, list) else [])
+        if isinstance(item, Mapping)
+    ]
+    by_key = {_judge_verdict_key(item): index for index, item in enumerate(merged)}
+    changed = False
+    for item in proposed_verdicts if isinstance(proposed_verdicts, list) else []:
+        if not isinstance(item, Mapping):
+            continue
+        key = _judge_verdict_key(item)
+        if key in by_key:
+            index = by_key[key]
+            item_changed, merged_item = _merge_doc_values(merged[index], item)
+            if item_changed:
+                merged[index] = merged_item
+                changed = True
+            continue
+        by_key[key] = len(merged)
+        merged.append(dict(item))
+        changed = True
+    if len(merged) > _EXECUTION_TRACE_CALL_CAP:
+        merged = _cap_pointer_entries(
+            merged,
+            _EXECUTION_TRACE_CALL_CAP,
+            "judge_verdict_truncation_marker",
+        )
+        changed = True
+    return changed, merged
+
+
+def _merge_string_refs(existing_refs: Any, proposed_refs: Any) -> tuple[bool, list[str]]:
+    merged: list[str] = [
+        str(item)
+        for item in (existing_refs if isinstance(existing_refs, list) else [])
+        if str(item or "")
+    ]
+    seen = set(merged)
+    changed = False
+    for item in proposed_refs if isinstance(proposed_refs, list) else []:
+        ref = str(item or "")
+        if not ref or ref in seen:
+            continue
+        seen.add(ref)
+        merged.append(ref)
+        changed = True
+    return changed, merged
+
+
+def _snapshot_key(snapshot: Mapping[str, Any]) -> tuple[str, str, str]:
+    kind = str(snapshot.get("snapshot_kind") or "")
+    icp_ref = str(snapshot.get("icp_ref") or "")
+    if kind == "per_icp_score_evidence" and icp_ref:
+        return (kind, "icp", icp_ref)
+    score_bundle_ref = str(snapshot.get("score_bundle_ref") or "")
+    if score_bundle_ref:
+        return (kind, "score_bundle", score_bundle_ref)
+    scorer_ref = str(snapshot.get("scorer_trace_ref") or "")
+    if scorer_ref:
+        return (kind, "scorer_trace", scorer_ref)
+    incontainer_ref = str(snapshot.get("incontainer_trace_ref") or "")
+    if incontainer_ref:
+        return (kind, "incontainer_trace", incontainer_ref)
+    return (kind, "fallback", sha256_json(snapshot))
+
+
+def _merge_evidence_snapshots(
+    existing_snapshots: Any,
+    proposed_snapshots: Any,
+) -> tuple[bool, list[dict[str, Any]]]:
+    merged: list[dict[str, Any]] = [
+        dict(item)
+        for item in (existing_snapshots if isinstance(existing_snapshots, list) else [])
+        if isinstance(item, Mapping)
+    ]
+    by_key = {_snapshot_key(item): index for index, item in enumerate(merged)}
+    changed = False
+    for item in proposed_snapshots if isinstance(proposed_snapshots, list) else []:
+        if not isinstance(item, Mapping):
+            continue
+        key = _snapshot_key(item)
+        if key in by_key:
+            index = by_key[key]
+            item_changed, merged_item = _merge_doc_values(merged[index], item)
+            if item_changed:
+                merged[index] = merged_item
+                changed = True
+            continue
+        by_key[key] = len(merged)
+        merged.append(dict(item))
+        changed = True
+    if len(merged) > _EVIDENCE_SNAPSHOT_CAP:
+        merged = _cap_pointer_entries(
+            merged,
+            _EVIDENCE_SNAPSHOT_CAP,
+            "per_icp_truncation_marker",
+        )
+        changed = True
+    return changed, merged
+
+
 async def _upsert_execution_trace_row(store: Any, row: Mapping[str, Any]) -> str:
-    """Insert a trace row, or merge newly discovered calls into an existing row."""
+    """Insert a trace row, or merge newly discovered pointer metadata."""
     existing = await store.select_one(
         EXECUTION_TRACES_TABLE, filters=(("run_id", row["run_id"]),)
     )
@@ -2991,11 +3133,45 @@ async def _upsert_execution_trace_row(store: Any, row: Mapping[str, Any]) -> str
     if not existing:
         return "unchanged"
     changed, calls = _merge_trace_calls(existing.get("calls"), row.get("calls"))
-    if not changed:
+    verdicts_changed, judge_verdicts = _merge_judge_verdicts(
+        existing.get("judge_verdicts"), row.get("judge_verdicts")
+    )
+    evidence_changed, evidence_refs = _merge_string_refs(
+        existing.get("evidence_bundles"), row.get("evidence_bundles")
+    )
+    trace_doc_changed = False
+    trace_doc: dict[str, Any] | None = None
+    if isinstance(row.get("trace_doc"), Mapping):
+        trace_doc_changed, trace_doc = _merge_doc_values(
+            existing.get("trace_doc")
+            if isinstance(existing.get("trace_doc"), Mapping)
+            else {},
+            row["trace_doc"],
+        )
+    trajectory_id = row.get("trajectory_id")
+    trajectory_changed = bool(trajectory_id and not existing.get("trajectory_id"))
+    if not (
+        changed
+        or verdicts_changed
+        or evidence_changed
+        or trace_doc_changed
+        or trajectory_changed
+    ):
         return "unchanged"
+    values: dict[str, Any] = {}
+    if changed:
+        values["calls"] = calls
+    if verdicts_changed:
+        values["judge_verdicts"] = judge_verdicts
+    if evidence_changed:
+        values["evidence_bundles"] = evidence_refs
+    if trace_doc_changed and trace_doc is not None:
+        values["trace_doc"] = trace_doc
+    if trajectory_changed:
+        values["trajectory_id"] = trajectory_id
     await store.update_row(
         EXECUTION_TRACES_TABLE,
-        {"calls": calls},
+        values,
         filters=(("run_id", row["run_id"]),),
     )
     return "updated"
@@ -3008,7 +3184,105 @@ async def _execution_trace_row_needs_write(store: Any, row: Mapping[str, Any]) -
     if not existing:
         return True
     changed, _calls = _merge_trace_calls(existing.get("calls"), row.get("calls"))
-    return changed
+    verdicts_changed, _verdicts = _merge_judge_verdicts(
+        existing.get("judge_verdicts"), row.get("judge_verdicts")
+    )
+    evidence_changed, _refs = _merge_string_refs(
+        existing.get("evidence_bundles"), row.get("evidence_bundles")
+    )
+    trace_doc_changed = False
+    if isinstance(row.get("trace_doc"), Mapping):
+        trace_doc_changed, _trace_doc = _merge_doc_values(
+            existing.get("trace_doc")
+            if isinstance(existing.get("trace_doc"), Mapping)
+            else {},
+            row["trace_doc"],
+        )
+    trajectory_changed = bool(
+        row.get("trajectory_id") and not existing.get("trajectory_id")
+    )
+    return (
+        changed
+        or verdicts_changed
+        or evidence_changed
+        or trace_doc_changed
+        or trajectory_changed
+    )
+
+
+async def _upsert_evidence_bundle_row(store: Any, row: Mapping[str, Any]) -> str:
+    """Insert evidence row, or merge newly discovered safe snapshots/docs."""
+    existing = await store.select_one(
+        EVIDENCE_BUNDLES_TABLE, filters=(("bundle_id", row["bundle_id"]),)
+    )
+    if not existing:
+        if await _insert_missing(store, EVIDENCE_BUNDLES_TABLE, "bundle_id", row):
+            return "inserted"
+        existing = await store.select_one(
+            EVIDENCE_BUNDLES_TABLE, filters=(("bundle_id", row["bundle_id"]),)
+        )
+    if not existing or existing.get("verification_state") == "content_deleted":
+        return "unchanged"
+    snapshots_changed, snapshots = _merge_evidence_snapshots(
+        existing.get("snapshots"), row.get("snapshots")
+    )
+    bundle_doc_changed = False
+    bundle_doc: dict[str, Any] | None = None
+    if isinstance(row.get("bundle_doc"), Mapping):
+        bundle_doc_changed, bundle_doc = _merge_doc_values(
+            existing.get("bundle_doc")
+            if isinstance(existing.get("bundle_doc"), Mapping)
+            else {},
+            row["bundle_doc"],
+        )
+    if not snapshots_changed and not bundle_doc_changed:
+        return "unchanged"
+    values: dict[str, Any] = {}
+    final_snapshots = snapshots if snapshots_changed else existing.get("snapshots")
+    final_doc = (
+        bundle_doc
+        if bundle_doc_changed and bundle_doc is not None
+        else existing.get("bundle_doc")
+    )
+    if snapshots_changed:
+        values["snapshots"] = snapshots
+    if bundle_doc_changed and bundle_doc is not None:
+        values["bundle_doc"] = bundle_doc
+    values["bundle_hash"] = sha256_json(
+        {
+            "evidence_bundle_id": row["bundle_id"],
+            "snapshots": final_snapshots,
+            "bundle_doc": final_doc,
+        }
+    )
+    await store.update_row(
+        EVIDENCE_BUNDLES_TABLE,
+        values,
+        filters=(("bundle_id", row["bundle_id"]),),
+    )
+    return "updated"
+
+
+async def _evidence_bundle_row_needs_write(store: Any, row: Mapping[str, Any]) -> bool:
+    existing = await store.select_one(
+        EVIDENCE_BUNDLES_TABLE, filters=(("bundle_id", row["bundle_id"]),)
+    )
+    if not existing:
+        return True
+    if existing.get("verification_state") == "content_deleted":
+        return False
+    snapshots_changed, _snapshots = _merge_evidence_snapshots(
+        existing.get("snapshots"), row.get("snapshots")
+    )
+    bundle_doc_changed = False
+    if isinstance(row.get("bundle_doc"), Mapping):
+        bundle_doc_changed, _bundle_doc = _merge_doc_values(
+            existing.get("bundle_doc")
+            if isinstance(existing.get("bundle_doc"), Mapping)
+            else {},
+            row["bundle_doc"],
+        )
+    return snapshots_changed or bundle_doc_changed
 
 
 async def _write_missing_corpus_trace_rows(
@@ -3022,7 +3296,8 @@ async def _write_missing_corpus_trace_rows(
             trace_changed += 1
     evidence_written = 0
     for row in projection.evidence_bundle_rows:
-        if await _insert_missing(store, EVIDENCE_BUNDLES_TABLE, "bundle_id", row):
+        evidence_status = await _upsert_evidence_bundle_row(store, row)
+        if evidence_status in {"inserted", "updated"}:
             evidence_written += 1
     return trace_changed, evidence_written
 
@@ -3316,9 +3591,7 @@ async def backfill_run_corpus_trace_rows(
         missing_evidence = [
             row
             for row in projection.evidence_bundle_rows
-            if not await store.select_one(
-                EVIDENCE_BUNDLES_TABLE, filters=(("bundle_id", row["bundle_id"]),)
-            )
+            if await _evidence_bundle_row_needs_write(store, row)
         ]
         if not missing_traces and not missing_evidence:
             return ProjectionResult(
@@ -3339,7 +3612,8 @@ async def backfill_run_corpus_trace_rows(
                 trace_written += 1
         evidence_written = 0
         for row in missing_evidence:
-            if await _insert_missing(store, EVIDENCE_BUNDLES_TABLE, "bundle_id", row):
+            evidence_status = await _upsert_evidence_bundle_row(store, row)
+            if evidence_status in {"inserted", "updated"}:
                 evidence_written += 1
         logger.info(
             "research_lab_corpus_traces_backfilled run_id=%s trajectory_id=%s "

--- a/gateway/research_lab/trajectory_projector.py
+++ b/gateway/research_lab/trajectory_projector.py
@@ -3866,6 +3866,24 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="P6: HEAD every recent S3 trace pointer and report verified/missing/hash_mismatch",
     )
     parser.add_argument(
+        "--quarantine-missing-pointers",
+        action="store_true",
+        help=(
+            "operator action: mark currently missing S3 trace pointers as "
+            "unrecoverable in the private quarantine table (dry-run by default)"
+        ),
+    )
+    parser.add_argument(
+        "--quarantine-reason",
+        default="historical_beta_optimistic_upload_missing",
+        help="reason stored when --quarantine-missing-pointers writes rows",
+    )
+    parser.add_argument(
+        "--operator-note",
+        default="",
+        help="operator note stored when --quarantine-missing-pointers writes rows",
+    )
+    parser.add_argument(
         "--verify-hash",
         action="store_true",
         help="with --reconcile-pointers: fetch objects and verify sha256 (slow)",
@@ -3915,14 +3933,21 @@ async def _cli_main(argv: Sequence[str] | None = None) -> int:
         and not args.reasoning_coverage
         and not args.capture_coverage
         and not args.reconcile_pointers
+        and not args.quarantine_missing_pointers
         and not args.import_shadow_windows
     ):
         _build_arg_parser().print_help()
         return 2
     store = GatewayProjectorStore()
-    if args.capture_coverage or args.reconcile_pointers or args.import_shadow_windows:
+    if (
+        args.capture_coverage
+        or args.reconcile_pointers
+        or args.quarantine_missing_pointers
+        or args.import_shadow_windows
+    ):
         from gateway.research_lab.trace_reconciler import (
             import_shadow_windows,
+            quarantine_missing_trace_pointers,
             reconcile_trace_pointers,
             summarize_capture_coverage,
         )
@@ -3935,6 +3960,14 @@ async def _cli_main(argv: Sequence[str] | None = None) -> int:
         if args.reconcile_pointers:
             report["pointer_reconciliation"] = await reconcile_trace_pointers(
                 store=store, verify_hash=args.verify_hash, max_rows=args.max_events
+            )
+        if args.quarantine_missing_pointers:
+            report["trace_pointer_quarantine"] = await quarantine_missing_trace_pointers(
+                store=store,
+                max_rows=args.max_events,
+                reason=args.quarantine_reason,
+                operator_note=args.operator_note,
+                dry_run=args.dry_run,
             )
         if args.import_shadow_windows:
             report["dry_run"] = False

--- a/gateway/research_lab/worker.py
+++ b/gateway/research_lab/worker.py
@@ -50,11 +50,13 @@ from gateway.research_lab.public_activity import (
     safe_project_public_loop_activity,
 )
 from gateway.research_lab.reimbursement_awards import (
+    cost_evidence_actual_microusd,
     cost_evidence_cost_ledger,
     cost_evidence_from_loop_result,
     cost_evidence_provider_usage,
     create_reimbursement_decision,
     latest_reimbursable_loop_cost_evidence,
+    normalize_cost_evidence,
 )
 from gateway.research_lab.store import (
     canonical_hash,
@@ -975,6 +977,9 @@ class HostedRunContext:
     # (see _resolve_loop_start_credit_id).
     resolved_loop_start_credit_id: str | None = None
     loop_start_credit_id_resolved: bool = False
+    # Latest cumulative loop cost evidence observed in-process before writing
+    # the loop event. Used if the store write itself fails after miner spend.
+    latest_loop_cost_evidence: dict[str, Any] = field(default_factory=dict)
 
     @property
     def run_id(self) -> str:
@@ -1261,7 +1266,7 @@ class ResearchLabHostedWorker:
                     ),
                 )
             )
-            return await self._mark_failed(context, str(exc))
+            return await self._mark_failed(context, str(exc), failure_exception=exc)
 
     def _require_enabled(self) -> None:
         if not self.config.hosted_worker_enabled:
@@ -1688,6 +1693,16 @@ class ResearchLabHostedWorker:
                     checkpoint_doc = event.event_doc.get("checkpoint") if isinstance(event.event_doc, Mapping) else None
                     if isinstance(checkpoint_doc, dict):
                         latest_checkpoint = dict(checkpoint_doc)
+                event_provider_usage = event.provider_usage or self._provider_usage(context)
+                context.latest_loop_cost_evidence = normalize_cost_evidence(
+                    {
+                        "source": "loop_event_in_memory",
+                        "source_event_type": event.event_type,
+                        "provider_usage": event_provider_usage,
+                        "cost_ledger": event.cost_ledger,
+                        "elapsed_seconds": event.elapsed_seconds,
+                    }
+                )
                 loop_event_row = await create_auto_research_loop_event(
                     run_id=context.run_id,
                     ticket_id=context.ticket_id,
@@ -1699,7 +1714,7 @@ class ResearchLabHostedWorker:
                     elapsed_seconds=event.elapsed_seconds,
                     candidate_artifact_hash=event.candidate_artifact_hash,
                     candidate_patch_hash=event.candidate_patch_hash,
-                    provider_usage=event.provider_usage or self._provider_usage(context),
+                    provider_usage=event_provider_usage,
                     cost_ledger=event.cost_ledger,
                     event_doc=event.event_doc,
                 )
@@ -2267,6 +2282,15 @@ class ResearchLabHostedWorker:
             provider_usage = self._provider_usage(context)
         except HostedResearchLabWorkerError:
             provider_usage = []
+        projection_cost_ledger: Mapping[str, Any] | None = None
+        projection_provider_usage: list[dict[str, Any]] | None = None
+        if isinstance(event_doc, Mapping):
+            maybe_ledger = event_doc.get("final_cost_ledger") or event_doc.get("cost_ledger")
+            if isinstance(maybe_ledger, Mapping):
+                projection_cost_ledger = maybe_ledger
+            maybe_usage = event_doc.get("provider_usage")
+            if isinstance(maybe_usage, Sequence) and not isinstance(maybe_usage, (str, bytes, bytearray)):
+                projection_provider_usage = [dict(item) for item in maybe_usage if isinstance(item, Mapping)]
         projection_event_doc = {
             "schema_version": "1.0",
             "reason": reason,
@@ -2289,7 +2313,8 @@ class ResearchLabHostedWorker:
                     event_type=event_type,
                     loop_status=loop_status,
                     worker_ref=self.worker_ref,
-                    provider_usage=provider_usage,
+                    provider_usage=projection_provider_usage or provider_usage,
+                    cost_ledger=dict(projection_cost_ledger or {}),
                     event_doc=projection_event_doc,
                 ),
             )
@@ -3053,10 +3078,13 @@ class ResearchLabHostedWorker:
         error: str,
         *,
         loop_result: Any | None = None,
+        failure_exception: BaseException | None = None,
         reason: str = "hosted_research_lab_run_failed",
     ) -> HostedWorkerOutcome:
         if loop_result is not None:
             cost_evidence = cost_evidence_from_loop_result(loop_result)
+        elif context.latest_loop_cost_evidence:
+            cost_evidence = dict(context.latest_loop_cost_evidence)
         else:
             try:
                 cost_evidence = await latest_reimbursable_loop_cost_evidence(context.run_id)
@@ -3067,6 +3095,7 @@ class ResearchLabHostedWorker:
                     str(exc)[:240],
                 )
                 cost_evidence = {}
+        cost_evidence = _merge_failure_exception_cost_evidence(cost_evidence, failure_exception)
         cost_ledger = cost_evidence_cost_ledger(cost_evidence)
         provider_usage = cost_evidence_provider_usage(cost_evidence)
         receipt_id = context.receipt_id
@@ -4053,6 +4082,70 @@ def _sum_award_usd(rows: Iterable[Mapping[str, Any]]) -> float:
         except Exception:
             continue
     return float(total.quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP))
+
+
+def _merge_failure_exception_cost_evidence(
+    cost_evidence: Mapping[str, Any] | None,
+    failure_exception: BaseException | None,
+) -> dict[str, Any]:
+    evidence = normalize_cost_evidence(cost_evidence)
+    if failure_exception is None:
+        return evidence
+    exception_cost_microusd = max(0, int(getattr(failure_exception, "cost_microusd", 0) or 0))
+    exception_usage = _failure_exception_provider_usage(failure_exception)
+    if exception_cost_microusd <= 0 and not exception_usage:
+        return evidence
+
+    prior_cost_microusd = cost_evidence_actual_microusd(evidence)
+    merged_cost_microusd = prior_cost_microusd + exception_cost_microusd
+    prior_ledger = cost_evidence_cost_ledger(evidence)
+    merged_ledger = {
+        **prior_ledger,
+        "schema_version": "1.0",
+        "status": "failed",
+        "stage": "failure_exception_after_latest_loop_evidence",
+        "total_usd": round(merged_cost_microusd / 1_000_000, 6),
+        "actual_openrouter_cost_usd": round(merged_cost_microusd / 1_000_000, 6),
+        "actual_openrouter_cost_microusd": merged_cost_microusd,
+        "previous_actual_openrouter_cost_microusd": prior_cost_microusd,
+        "failure_exception_cost_microusd": exception_cost_microusd,
+    }
+    if "openrouter_call_count" not in merged_ledger:
+        merged_ledger["openrouter_call_count"] = int(evidence.get("openrouter_call_count") or 0)
+    if "estimated_cost_usd" not in merged_ledger:
+        merged_ledger["estimated_cost_usd"] = float(evidence.get("estimated_cost_usd") or 0.0)
+
+    return normalize_cost_evidence(
+        {
+            "source": (
+                "loop_event_plus_failure_exception"
+                if prior_cost_microusd > 0 or prior_ledger
+                else "failure_exception"
+            ),
+            "trusted_cost_ledger": bool(prior_ledger) or exception_cost_microusd > 0,
+            "provider_usage": cost_evidence_provider_usage(evidence) + exception_usage,
+            "cost_ledger": merged_ledger,
+            "actual_openrouter_cost_microusd": merged_cost_microusd,
+            "estimated_cost_usd": evidence.get("estimated_cost_usd"),
+            "openrouter_call_count": evidence.get("openrouter_call_count"),
+            "iterations_completed": evidence.get("iterations_completed"),
+            "stop_reason": str(evidence.get("stop_reason") or "") or str(failure_exception)[:160],
+            "elapsed_seconds": evidence.get("elapsed_seconds"),
+        }
+    )
+
+
+def _failure_exception_provider_usage(exc: BaseException) -> list[dict[str, Any]]:
+    usage = getattr(exc, "provider_usage", None)
+    if isinstance(usage, Mapping):
+        return [{**dict(usage), "call_outcome": "failure_exception"}]
+    if isinstance(usage, Sequence) and not isinstance(usage, (str, bytes, bytearray)):
+        return [
+            {**dict(item), "call_outcome": str(dict(item).get("call_outcome") or "failure_exception")}
+            for item in usage
+            if isinstance(item, Mapping)
+        ]
+    return []
 
 
 def _redacted_reimbursement_run_cost(value: Mapping[str, Any]) -> dict[str, Any]:

--- a/gateway/research_lab/worker.py
+++ b/gateway/research_lab/worker.py
@@ -1388,11 +1388,17 @@ class ResearchLabHostedWorker:
             # RESEARCH_LAB_TRAJECTORY_PROJECTOR_ENABLED=true.
             if projector_enabled():
                 await project_completed_runs(dry_run=False)
+                trace_backfill_max_candidates = _env_int(
+                    "RESEARCH_LAB_TRAJECTORY_BACKFILL_MAX_CANDIDATES", 50
+                )
                 await backfill_corpus_trace_rows(
                     batch_size=_env_int("RESEARCH_LAB_TRAJECTORY_BACKFILL_BATCH_SIZE", 2),
                     dry_run=False,
-                    max_candidates=_env_int("RESEARCH_LAB_TRAJECTORY_BACKFILL_MAX_CANDIDATES", 50),
-                    max_attempts=_env_int("RESEARCH_LAB_TRAJECTORY_BACKFILL_MAX_ATTEMPTS", 10),
+                    max_candidates=trace_backfill_max_candidates,
+                    max_attempts=_env_int(
+                        "RESEARCH_LAB_TRAJECTORY_BACKFILL_MAX_ATTEMPTS",
+                        trace_backfill_max_candidates,
+                    ),
                 )
         except Exception as exc:
             logger.warning(

--- a/pcr0_allowlist.json
+++ b/pcr0_allowlist.json
@@ -1,6 +1,6 @@
 {
   "_comment": "PCR0 allowlist for LeadPoet TEE verification. Updated by CI/CD on each enclave build.",
-  "_updated": "2026-06-23",
+  "_updated": "2026-07-05",
   "_repo": "https://github.com/leadpoet/leadpoet",
   "gateway_pcr0": [
     {
@@ -34,6 +34,13 @@
       "version": "v1.1.0",
       "deployed": "2026-02-06",
       "notes": "IMMEDIATE REVEAL MODE - validator with weight calculation and reveal removal changes"
+    },
+    {
+      "pcr0": "01877a6d4fd0f4b6f335e7816af36072c63e141ed40e9b100703f467a1feca740cdbca2fd29196e0808d80d50fee5104",
+      "version": "2026-07-05",
+      "deployed": "2026-07-05",
+      "commit_hash": "9e2f22846d8a0fb4a3ff1c73f821fed8f127b40e",
+      "notes": "validator enclave: current production build on commit 9e2f228"
     }
   ]
 }

--- a/research_lab/openrouter_telemetry.py
+++ b/research_lab/openrouter_telemetry.py
@@ -52,9 +52,8 @@ OPENROUTER_CHAT_COMPLETIONS_URL = "https://openrouter.ai/api/v1/chat/completions
 OPENROUTER_EMBEDDINGS_URL = "https://openrouter.ai/api/v1/embeddings"
 
 RAW_TRACE_S3_PREFIX_ENV = "RESEARCH_LAB_RAW_TRACE_S3_PREFIX"
-RAW_TRACE_KMS_KEY_ENV = "RESEARCH_LAB_RAW_TRACE_KMS_KEY_ID"
+RAW_TRACE_KMS_KEY_ENV = "RESEARCH_LAB_TRACE_KMS_KEY_ID"
 INCLUDE_REASONING_ENV = "RESEARCH_LAB_LLM_INCLUDE_REASONING"
-_DEFAULT_KMS_KEY = "alias/leadpoet-research-lab-artifact-signing"
 
 _SECRET_PATTERNS = (
     re.compile(r"sk-or-[A-Za-z0-9\-_]+"),
@@ -166,6 +165,13 @@ class _TelemetryTraceUploader:
             bucket, _sep, key_prefix = prefix[5:].partition("/")
             if not bucket:
                 return None
+            kms_key_id = str(os.getenv(RAW_TRACE_KMS_KEY_ENV, "")).strip()
+            if not kms_key_id:
+                self._warn_once(
+                    f"set {RAW_TRACE_KMS_KEY_ENV}=alias/leadpoet-research-lab-trace-encryption "
+                    "to capture legacy-channel OpenRouter traces"
+                )
+                return None
             safe_channel = _path_segment(channel, "channel")
             safe_purpose = _path_segment(purpose, "call")
             date_segment = datetime.now(timezone.utc).strftime("%Y%m%d")
@@ -188,7 +194,7 @@ class _TelemetryTraceUploader:
                 default=str,
             ).encode("utf-8")
             digest = "sha256:" + hashlib.sha256(body).hexdigest()
-            self._submit(bucket=bucket, object_key=object_key, body=body)
+            self._submit(bucket=bucket, object_key=object_key, body=body, kms_key_id=kms_key_id)
             return {"s3_ref": f"s3://{bucket}/{object_key}", "sha256": digest}
         except Exception as exc:  # noqa: BLE001 - capture never fails the call
             logger.warning(
@@ -223,19 +229,19 @@ class _TelemetryTraceUploader:
             self._warned = True
         logger.warning("openrouter_telemetry_capture_unavailable hint=%s", hint)
 
-    def _submit(self, *, bucket: str, object_key: str, body: bytes) -> None:
+    def _submit(self, *, bucket: str, object_key: str, body: bytes, kms_key_id: str) -> None:
         with self._lock:
             if self._executor is None:
                 self._executor = ThreadPoolExecutor(
                     max_workers=2, thread_name_prefix="openrouter-telemetry-trace"
                 )
             executor = self._executor
-        future = executor.submit(self._put_object, bucket, object_key, body)
+        future = executor.submit(self._put_object, bucket, object_key, body, kms_key_id)
         with self._lock:
             self._pending.add(future)
         future.add_done_callback(self._consume)
 
-    def _put_object(self, bucket: str, object_key: str, body: bytes) -> None:
+    def _put_object(self, bucket: str, object_key: str, body: bytes, kms_key_id: str) -> None:
         import boto3  # type: ignore
 
         put_kwargs: dict[str, Any] = {
@@ -244,10 +250,8 @@ class _TelemetryTraceUploader:
             "Body": body,
             "ContentType": "application/json",
             "ServerSideEncryption": "aws:kms",
+            "SSEKMSKeyId": kms_key_id,
         }
-        kms_key_id = str(os.getenv(RAW_TRACE_KMS_KEY_ENV, "") or _DEFAULT_KMS_KEY).strip()
-        if kms_key_id:
-            put_kwargs["SSEKMSKeyId"] = kms_key_id
         boto3.client("s3").put_object(**put_kwargs)
 
     def _consume(self, future: "Future[None]") -> None:

--- a/scripts/66-research-lab-trace-pointer-quarantine.sql
+++ b/scripts/66-research-lab-trace-pointer-quarantine.sql
@@ -1,0 +1,63 @@
+-- Research Lab trace pointer quarantine.
+--
+-- Historical beta raw trace uploads were optimistic: the corpus row could
+-- receive a pointer before the async S3 upload completed. If that upload later
+-- failed, the pointer is dangling. This table records operator decisions that
+-- a missing pointer is intentionally unrecoverable, without mutating the source
+-- corpus rows or pretending an object exists.
+--
+-- Access model:
+--   * private service_role-only table
+--   * no anon/authenticated grants
+--   * RLS enabled for exposed-schema defense in depth
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.research_lab_trace_pointer_quarantine (
+    s3_ref          TEXT        NOT NULL,
+    sha256          TEXT        NOT NULL DEFAULT '',
+    source          TEXT        NOT NULL,
+    status          TEXT        NOT NULL CHECK (status IN ('unrecoverable')),
+    reason          TEXT        NOT NULL,
+    operator_note   TEXT        NOT NULL DEFAULT '',
+    marked_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    quarantine_doc  JSONB       NOT NULL DEFAULT '{}'::JSONB
+                                CHECK (jsonb_typeof(quarantine_doc) = 'object'),
+    PRIMARY KEY (s3_ref, sha256),
+    CHECK (s3_ref LIKE 's3://%'),
+    CHECK (sha256 = '' OR sha256 LIKE 'sha256:%')
+);
+
+CREATE INDEX IF NOT EXISTS idx_trace_pointer_quarantine_status_marked
+    ON public.research_lab_trace_pointer_quarantine(status, marked_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_trace_pointer_quarantine_source
+    ON public.research_lab_trace_pointer_quarantine(source, marked_at DESC);
+
+REVOKE ALL ON TABLE public.research_lab_trace_pointer_quarantine
+    FROM anon, authenticated;
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+    ON TABLE public.research_lab_trace_pointer_quarantine
+    TO service_role;
+
+ALTER TABLE public.research_lab_trace_pointer_quarantine
+    ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS service_role_all
+    ON public.research_lab_trace_pointer_quarantine;
+
+CREATE POLICY service_role_all
+    ON public.research_lab_trace_pointer_quarantine
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+COMMENT ON TABLE public.research_lab_trace_pointer_quarantine IS
+    'Operator audit table for missing trace S3 pointers that are intentionally marked unrecoverable; reconciliation classifies these separately from active capture failures.';
+
+COMMENT ON COLUMN public.research_lab_trace_pointer_quarantine.reason IS
+    'Machine-readable reason, e.g. historical_beta_optimistic_upload_missing.';
+
+COMMIT;

--- a/tests/test_capture_health.py
+++ b/tests/test_capture_health.py
@@ -174,3 +174,20 @@ def test_healthy_production_start_passes(monkeypatch):
     config = _config(production_writes_enabled=True)
     health = ch.enforce_capture_health(config, worker_kind="hosted_worker")
     assert health["violations"] == []
+
+
+@pytest.mark.asyncio
+async def test_check_projector_tables_uses_current_store_contract(monkeypatch):
+    calls = []
+
+    async def fake_select_many(table, **kwargs):
+        calls.append((table, kwargs))
+        return []
+
+    monkeypatch.setattr("gateway.research_lab.store.select_many", fake_select_many)
+    statuses = await ch.check_projector_tables()
+
+    assert set(statuses.values()) == {"present"}
+    assert calls
+    assert all(kwargs["columns"] == "*" for _table, kwargs in calls)
+    assert all(kwargs["filters"] == () for _table, kwargs in calls)

--- a/tests/test_capture_health.py
+++ b/tests/test_capture_health.py
@@ -61,6 +61,7 @@ def test_env_names_match_recorder_modules():
     from gateway.research_lab import worker as w
     from gateway.research_lab import scoring_worker as sw
     from gateway.research_lab import trajectory_projector as tp
+    from research_lab import openrouter_telemetry as ot
     from research_lab.eval import evaluator as ev
 
     assert ch.RAW_TRACE_CAPTURE_ENABLED_ENV == w._RAW_TRACE_CAPTURE_ENABLED_ENV
@@ -69,6 +70,7 @@ def test_env_names_match_recorder_modules():
     assert ch.SCORER_TRACE_S3_PREFIX_ENV == sw._SCORER_TRACE_S3_PREFIX_ENV
     assert ch.TRACE_KMS_KEY_ENV == w._TRACE_KMS_KEY_ENV
     assert ch.TRACE_KMS_KEY_ENV == sw._TRACE_KMS_KEY_ENV
+    assert ch.TRACE_KMS_KEY_ENV == ot.RAW_TRACE_KMS_KEY_ENV
     assert ch.INCONTAINER_TRACE_S3_PREFIX_ENV == ev.INCONTAINER_TRACE_S3_PREFIX_ENV
     assert ch.INCONTAINER_TRACE_KMS_KEY_ENV == ev.INCONTAINER_TRACE_KMS_KEY_ENV
     assert ch.PROJECTOR_ENABLED_ENV == tp.PROJECTOR_ENABLED_ENV

--- a/tests/test_code_loop_engine_fixes.py
+++ b/tests/test_code_loop_engine_fixes.py
@@ -15,7 +15,12 @@ import types
 import pytest
 
 from gateway.research_lab import code_loop_engine as engine
-from gateway.research_lab.code_build import CodeEditBuildResult
+from gateway.research_lab.code_build import (
+    CodeEditBuildResult,
+    CodeEditPatchApplyError,
+    ParentImageSourceContext,
+)
+from gateway.research_lab.loop_engine import AutoResearchLoopSettings, OpenRouterCallResult
 from research_lab.code_editing import CodeEditDraft
 from research_lab.eval import PrivateModelArtifactManifest
 
@@ -61,6 +66,21 @@ def _build_result():
         code_edit_manifest={"target_files": ["sourcing_model.py"], "kind": "code_edit"},
         source_diff_hash="sha256:" + "f" * 64,
         build_doc={"build_doc_hash": "sha256:" + "1" * 64, "source_diff_artifact_uri": "s3://test-bucket/diff.json"},
+    )
+
+
+def _source_context(tmp_path):
+    source_root = tmp_path / "source"
+    source_root.mkdir(exist_ok=True)
+    (source_root / "sourcing_model.py").write_text("x = 1\n", encoding="utf-8")
+    return ParentImageSourceContext(
+        source_root=source_root,
+        source_mode="extracted",
+        parent_image_digest_hash="sha256:" + "9" * 64,
+        source_tree_hash="sha256:" + "8" * 64,
+        top_level_paths=("sourcing_model.py",),
+        editable_files=("sourcing_model.py",),
+        file_previews=(),
     )
 
 
@@ -292,3 +312,175 @@ def test_node_id_unique_per_candidate_index():
     second = engine._node_id("run-1", 1, 1, draft)
     assert first != second
     assert first == engine._node_id("run-1", 1, 0, draft)
+
+
+# --- reimbursement cost evidence: failed/no-candidate exits keep miner spend ---
+
+
+class _NoCandidateBuilder:
+    def __init__(self, source_context):
+        self._source_context = source_context
+        self.config = types.SimpleNamespace(
+            loop_planner_enabled=False,
+            loop_planner_max_tokens=2000,
+            loop_alignment_judge_enabled=False,
+            loop_alignment_judge_max_tokens=800,
+            loop_novelty_strict=False,
+            code_edit_source_inspection_rounds=1,
+            code_edit_source_inspection_max_files=4,
+            code_edit_source_inspection_file_bytes=4000,
+            code_edit_source_inspection_total_bytes=16000,
+            code_edit_source_inspection_search_matches=5,
+            code_edit_patch_repair_attempts=0,
+        )
+
+    def prepare_parent_source_context(self, *, parent_artifact, workspace_dir):
+        return self._source_context
+
+    def validate_draft_against_source_context(self, draft, source_context, *, read_paths, require_read):
+        return []
+
+    def check_patch_applies(self, *, draft, parent_artifact, source_context):
+        return None
+
+    def build(self, *, draft, parent_artifact, run_id, candidate_index, source_context):
+        raise AssertionError("no-candidate test should not build")
+
+
+async def test_no_candidate_loop_failed_carries_final_cost_ledger(tmp_path):
+    events = []
+
+    async def call_model(messages, timeout_seconds, max_tokens, stage):
+        if stage == "source_inspection":
+            return OpenRouterCallResult(
+                content='{"requests":[{"operation":"read_file","path":"sourcing_model.py"}]}',
+                provider_usage={"provider": "openrouter", "response_id": "inspect", "cost_microusd": 1000},
+                cost_microusd=1000,
+            )
+        if stage == "code_edit_draft":
+            return OpenRouterCallResult(
+                content='{"no_viable_patch":true,"reason":"loop found no safe candidate"}',
+                provider_usage={"provider": "openrouter", "response_id": "draft", "cost_microusd": 2000},
+                cost_microusd=2000,
+            )
+        raise AssertionError(f"unexpected stage: {stage}")
+
+    async def event_sink(event):
+        events.append(event)
+
+    result = await engine.CodeEditLoopEngine(
+        settings=AutoResearchLoopSettings(
+            min_seconds=0,
+            max_seconds=30,
+            min_iterations=1,
+            max_iterations=1,
+            draft_timeout_seconds=10,
+            reflection_timeout_seconds=10,
+            estimated_iteration_cost_usd=0.01,
+            max_candidates=1,
+        ),
+        call_openrouter=call_model,
+        event_sink=event_sink,
+        builder=_NoCandidateBuilder(_source_context(tmp_path)),
+    ).run(
+        run_id="run-no-candidate",
+        ticket={
+            "ticket_id": "ticket-no-candidate",
+            "miner_hotkey": "hotkey",
+            "island": "generalist",
+            "brief_sanitized_ref": "brief",
+            "ticket_doc": {"brief_public_summary": "test"},
+            "requested_loop_count": 1,
+        },
+        artifact=_manifest(),
+        component_registry={},
+        benchmark_public_summary={"item_count": 1},
+        model_id="test/model",
+        budget_context={"requested_compute_budget_usd": 5.0, "research_model_tier": "default"},
+        requested_loop_count=1,
+    )
+
+    assert result.status == "failed"
+    assert result.selected_candidates == ()
+    assert result.actual_openrouter_cost_microusd == 3000
+    terminal = events[-1]
+    assert terminal.event_type == "loop_failed"
+    assert terminal.cost_ledger["actual_openrouter_cost_microusd"] == 3000
+    assert terminal.event_doc["run_summary"]["cost_ledger"]["actual_openrouter_cost_microusd"] == 3000
+
+
+class _RepairFailureBuilder(_NoCandidateBuilder):
+    def __init__(self, source_context):
+        super().__init__(source_context)
+        self.config.code_edit_patch_repair_attempts = 1
+
+    def check_patch_applies(self, *, draft, parent_artifact, source_context):
+        raise CodeEditPatchApplyError("patch does not apply")
+
+
+class _CostedRepairError(RuntimeError):
+    provider_usage = {
+        "provider": "openrouter",
+        "response_id": "repair-failed",
+        "raw_trace_ref": {"s3_ref": "s3://bucket/repair.json", "sha256": "sha256:" + "1" * 64},
+    }
+    cost_microusd = 4321
+
+
+async def test_repair_call_failure_records_exception_cost_in_running_ledger(tmp_path):
+    events = []
+
+    async def call_model(messages, timeout_seconds, max_tokens, stage):
+        assert stage == "code_edit_repair"
+        raise _CostedRepairError("repair model failed after provider spend")
+
+    async def event_sink(event):
+        events.append(event)
+
+    loop = engine.CodeEditLoopEngine(
+        settings=AutoResearchLoopSettings(
+            min_seconds=0,
+            max_seconds=30,
+            min_iterations=1,
+            max_iterations=1,
+            draft_timeout_seconds=10,
+            reflection_timeout_seconds=10,
+            estimated_iteration_cost_usd=0.01,
+            max_candidates=1,
+        ),
+        call_openrouter=call_model,
+        event_sink=event_sink,
+        builder=_RepairFailureBuilder(_source_context(tmp_path)),
+    )
+
+    repaired, openrouter_calls, estimated_cost, actual_cost_microusd, budget_exhausted = (
+        await loop._ensure_patch_applies_or_repair(
+            draft=_draft(),
+            run_id="run-repair-failed",
+            node_id="node-repair-failed",
+            iteration=1,
+            settings=loop.settings,
+            artifact=_manifest(),
+            source_context=_source_context(tmp_path),
+            source_inspection_context={},
+            read_paths=("sourcing_model.py",),
+            budget_context={"requested_compute_budget_usd": 5.0},
+            budget_limit_microusd=5_000_000,
+            elapsed=lambda: 0.0,
+            openrouter_calls=0,
+            estimated_cost=0.0,
+            actual_cost_microusd=0,
+            provider_usage=[],
+        )
+    )
+
+    assert repaired is None
+    assert openrouter_calls == 0
+    assert estimated_cost == 0.0
+    assert actual_cost_microusd == 4321
+    assert budget_exhausted is False
+    repair_failure = [event for event in events if event.event_doc.get("stage") == "code_edit_repair_call_failed"][-1]
+    assert repair_failure.event_type == "code_edit_repair_failed"
+    assert repair_failure.cost_ledger["actual_openrouter_cost_microusd"] == 4321
+    assert repair_failure.provider_usage[0]["call_outcome"] == "contained_failure"
+    assert repair_failure.provider_usage[0]["raw_trace_ref"]["s3_ref"] == "s3://bucket/repair.json"

--- a/tests/test_corpus_trace_population.py
+++ b/tests/test_corpus_trace_population.py
@@ -85,6 +85,7 @@ class FakeStore:
             name: [dict(row) for row in rows] for name, rows in tables.items()
         }
         self.inserted: dict[str, list[dict[str, Any]]] = {}
+        self.updated: dict[str, list[dict[str, Any]]] = {}
 
     @staticmethod
     def _matches(row: Mapping[str, Any], filters: Any) -> bool:
@@ -166,10 +167,31 @@ class FakeStore:
         self.inserted.setdefault(table, []).append(dict(row))
         return dict(row)
 
+    async def update_row(self, table: str, values: dict[str, Any], *, filters: Any):
+        rows = self._select(table, filters)
+        if not rows:
+            raise RuntimeError(f"{table}: update returned no rows")
+        target = rows[0]
+        stored = self.tables.setdefault(table, [])
+        for index, row in enumerate(stored):
+            if row is target or all(
+                str(row.get(spec[0])) == str(spec[1])
+                for spec in filters
+                if len(spec) == 2
+            ):
+                updated = dict(row)
+                updated.update(copy.deepcopy(values))
+                stored[index] = updated
+                self.updated.setdefault(table, []).append(updated)
+                return dict(updated)
+        raise RuntimeError(f"{table}: update returned no rows")
+
     def write_count(self, table: str | None = None) -> int:
         if table is not None:
-            return len(self.inserted.get(table, []))
-        return sum(len(rows) for rows in self.inserted.values())
+            return len(self.inserted.get(table, [])) + len(self.updated.get(table, []))
+        return sum(len(rows) for rows in self.inserted.values()) + sum(
+            len(rows) for rows in self.updated.values()
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -982,6 +1004,88 @@ async def test_traces_backfill_adds_rows_without_touching_events(tables, enabled
     # forward-only: append-only tables untouched
     assert store.write_count(TRAJECTORY_EVENTS_TABLE) == event_writes
     assert store.write_count(TRAJECTORIES_TABLE) == envelope_writes
+
+
+async def test_traces_backfill_repairs_existing_stale_pointer_rows(tables, enabled):
+    store = FakeStore(tables)
+    await project_run(RUN_ID, store=store, dry_run=False)
+
+    for index, row in enumerate(store.tables[EXECUTION_TRACES_TABLE]):
+        if row["run_id"] != NODE1_TRACE_ID:
+            continue
+        stale = dict(row)
+        stale["calls"] = [
+            call for call in row["calls"] if call.get("call_kind") == "engine_raw_trace"
+        ]
+        stale["judge_verdicts"] = []
+        stale["evidence_bundles"] = []
+        stale["trace_doc"] = {
+            **dict(row["trace_doc"]),
+            "incontainer_trace_count": 0,
+            "judge_verdict_count": 0,
+        }
+        store.tables[EXECUTION_TRACES_TABLE][index] = stale
+        break
+
+    for index, row in enumerate(store.tables[EVIDENCE_BUNDLES_TABLE]):
+        if row["bundle_id"] != EVIDENCE_ID:
+            continue
+        stale_snapshots = []
+        for snapshot in row["snapshots"]:
+            stale = {
+                key: value
+                for key, value in snapshot.items()
+                if key
+                not in {
+                    "scorer_trace_ref",
+                    "scorer_trace_sha256",
+                    "incontainer_trace_ref",
+                    "incontainer_trace_sha256",
+                    "incontainer_trace_call_count",
+                }
+            }
+            stale_snapshots.append(stale)
+        stale_row = dict(row)
+        stale_row["snapshots"] = stale_snapshots
+        stale_row["bundle_doc"] = {
+            **dict(row["bundle_doc"]),
+            "incontainer_trace_count": 0,
+            "incontainer_call_count_total": 0,
+        }
+        store.tables[EVIDENCE_BUNDLES_TABLE][index] = stale_row
+        break
+
+    result = await backfill_run_corpus_trace_rows(RUN_ID, store=store, dry_run=False)
+    assert result.status == "traces_backfilled"
+    assert result.execution_trace_count == 1
+    assert result.evidence_bundle_count == 1
+
+    repaired_trace = {
+        row["run_id"]: row for row in store.tables[EXECUTION_TRACES_TABLE]
+    }[NODE1_TRACE_ID]
+    assert repaired_trace["evidence_bundles"] == [f"evidence_bundle:{EVIDENCE_ID}"]
+    assert len(
+        [call for call in repaired_trace["calls"] if call["call_kind"] == "incontainer_trace"]
+    ) == 2
+    assert len(repaired_trace["judge_verdicts"]) == 2
+    assert repaired_trace["trace_doc"]["incontainer_trace_count"] == 2
+    assert repaired_trace["trace_doc"]["judge_verdict_count"] == 2
+
+    repaired_evidence = {
+        row["bundle_id"]: row for row in store.tables[EVIDENCE_BUNDLES_TABLE]
+    }[EVIDENCE_ID]
+    assert any(snapshot.get("scorer_trace_ref") for snapshot in repaired_evidence["snapshots"])
+    assert any(
+        snapshot.get("incontainer_trace_ref") for snapshot in repaired_evidence["snapshots"]
+    )
+    assert repaired_evidence["bundle_doc"]["incontainer_trace_count"] == 2
+    assert repaired_evidence["bundle_hash"] == sha256_json(
+        {
+            "evidence_bundle_id": EVIDENCE_ID,
+            "snapshots": repaired_evidence["snapshots"],
+            "bundle_doc": repaired_evidence["bundle_doc"],
+        }
+    )
 
 
 async def test_traces_backfill_dry_run_writes_nothing(tables, disabled):

--- a/tests/test_openrouter_telemetry.py
+++ b/tests/test_openrouter_telemetry.py
@@ -175,6 +175,17 @@ def test_no_s3_prefix_is_inert_but_call_succeeds(fake_boto3, monkeypatch):
     assert fake_boto3 == []
 
 
+def test_s3_prefix_without_kms_does_not_create_dangling_pointer(fake_boto3, monkeypatch):
+    monkeypatch.setenv(ot.RAW_TRACE_S3_PREFIX_ENV, TRACE_PREFIX)
+    monkeypatch.delenv(ot.RAW_TRACE_KMS_KEY_ENV, raising=False)
+    result = _call(opener=_opener([_chat_response()]))
+    ot.flush_telemetry_traces()
+    assert result.content == '{"ok": true}'
+    assert result.raw_trace_ref is None
+    assert result.provider_usage["reasoning_capture"]["storage_state"] == "metadata_only"
+    assert fake_boto3 == []
+
+
 def test_record_openrouter_trace_hook(fake_boto3, trace_env):
     usage = ot.record_openrouter_trace(
         channel="qualification",

--- a/tests/test_trace_reconciler.py
+++ b/tests/test_trace_reconciler.py
@@ -13,9 +13,34 @@ from research_lab.canonical import sha256_json
 class FakeStore:
     def __init__(self, tables: Mapping[str, Sequence[Mapping[str, Any]]]) -> None:
         self.tables = {name: [dict(row) for row in rows] for name, rows in tables.items()}
+        self.inserted: dict[str, list[dict[str, Any]]] = {}
 
     async def select_all(self, table, *, columns="*", filters=(), order_by=(), max_rows=1000):
-        return [dict(row) for row in self.tables.get(table, [])][:max_rows]
+        rows = []
+        for row in self.tables.get(table, []):
+            keep = True
+            for spec in filters:
+                if len(spec) == 2 and row.get(spec[0]) != spec[1]:
+                    keep = False
+                elif len(spec) == 3:
+                    field, operator, value = spec
+                    if operator == "eq" and row.get(field) != value:
+                        keep = False
+            if keep:
+                rows.append(dict(row))
+        return rows[:max_rows]
+
+    async def insert_row(self, table, row):
+        stored = self.tables.setdefault(table, [])
+        if any(
+            existing.get("s3_ref") == row.get("s3_ref")
+            and existing.get("sha256") == row.get("sha256")
+            for existing in stored
+        ):
+            raise RuntimeError("duplicate key value violates unique constraint")
+        stored.append(dict(row))
+        self.inserted.setdefault(table, []).append(dict(row))
+        return dict(row)
 
 
 class FakeS3:
@@ -178,6 +203,38 @@ async def test_reconcile_classifies_verified_and_missing():
     assert "s3://bucket/incontainer/cand-1/icp-1.json" in missing_refs
 
 
+async def test_reconcile_classifies_quarantined_missing_as_unrecoverable():
+    tables = _tables()
+    tables[tr.TRACE_POINTER_QUARANTINE_TABLE] = [
+        {
+            "s3_ref": "s3://bucket/incontainer/cand-1/icp-1.json",
+            "sha256": "sha256:iiii",
+            "source": "score_bundle",
+            "status": "unrecoverable",
+            "reason": "historical_beta_optimistic_upload_missing",
+            "marked_at": "2026-07-04T00:00:00Z",
+            "quarantine_doc": {},
+        }
+    ]
+    s3 = FakeS3(
+        {
+            "s3://bucket/traces/0001.json.enc": b"x",
+            "s3://bucket/scorer-traces/cand-1/icp-1.json": b"y",
+            # diagnostics + incontainer objects deliberately missing
+        }
+    )
+
+    report = await tr.reconcile_trace_pointers(store=FakeStore(tables), s3_client=s3)
+
+    assert report["counts"]["verified"] == 2
+    assert report["counts"]["missing"] == 1
+    assert report["counts"]["unrecoverable"] == 1
+    problem_refs = {problem["s3_ref"] for problem in report["problems"]}
+    assert "s3://bucket/incontainer/cand-1/icp-1.json" not in problem_refs
+    unrecoverable_refs = {item["s3_ref"] for item in report["unrecoverable"]}
+    assert "s3://bucket/incontainer/cand-1/icp-1.json" in unrecoverable_refs
+
+
 async def test_reconcile_hash_mismatch_detected():
     body = b'{"doc": 1}'
     good_hash = "sha256:" + __import__("hashlib").sha256(body).hexdigest()
@@ -210,6 +267,46 @@ async def test_reconcile_hash_mismatch_detected():
     )
     assert report["counts"]["verified"] == 1
     assert report["counts"]["hash_mismatch"] == 1
+
+
+async def test_quarantine_missing_trace_pointers_inserts_only_missing():
+    s3 = FakeS3(
+        {
+            "s3://bucket/traces/0001.json.enc": b"x",
+            "s3://bucket/scorer-traces/cand-1/icp-1.json": b"y",
+            # diagnostics + incontainer objects deliberately missing
+        }
+    )
+    store = FakeStore(_tables())
+
+    report = await tr.quarantine_missing_trace_pointers(
+        store=store,
+        s3_client=s3,
+        dry_run=False,
+        reason="historical_beta_optimistic_upload_missing",
+        operator_note="beta cleanup",
+    )
+
+    assert report["status"] == "completed"
+    assert report["missing_to_quarantine"] == 2
+    assert report["quarantined"] == 2
+    rows = store.inserted[tr.TRACE_POINTER_QUARANTINE_TABLE]
+    assert {row["status"] for row in rows} == {"unrecoverable"}
+    assert {row["reason"] for row in rows} == {"historical_beta_optimistic_upload_missing"}
+    assert {row["operator_note"] for row in rows} == {"beta cleanup"}
+
+
+async def test_quarantine_missing_trace_pointers_dry_run_does_not_insert():
+    store = FakeStore(_tables())
+    report = await tr.quarantine_missing_trace_pointers(
+        store=store,
+        s3_client=FakeS3({}),
+        dry_run=True,
+    )
+
+    assert report["dry_run"] is True
+    assert report["missing_to_quarantine"] == 4
+    assert tr.TRACE_POINTER_QUARANTINE_TABLE not in store.inserted
 
 
 async def test_capture_coverage_counts_all_channels():

--- a/tests/test_trajectory_backfill.py
+++ b/tests/test_trajectory_backfill.py
@@ -13,9 +13,12 @@ from __future__ import annotations
 import uuid
 from typing import Any
 
+import gateway.research_lab.trajectory_projector as trajectory_projector
 from gateway.research_lab.scoring_worker import ResearchLabGatewayScoringWorker
 from gateway.research_lab.trajectory_projector import (
     PROJECTOR_ENABLED_ENV,
+    ProjectionResult,
+    backfill_corpus_trace_rows,
     backfill_run_corpus_trace_rows,
     evidence_bundle_id_for_node,
     execution_trace_id_for_node,
@@ -161,3 +164,66 @@ async def test_backfill_is_best_effort_on_store_errors() -> None:
         RUN_ID, store=BrokenStore(), dry_run=True
     )
     assert result.status == "failed"
+
+
+async def test_periodic_trace_backfill_discovers_recent_terminal_runs_first(
+    monkeypatch,
+) -> None:
+    run_ids = (
+        "11111111-1111-4111-8111-111111111111",
+        "22222222-2222-4222-8222-222222222222",
+        "33333333-3333-4333-8333-333333333333",
+    )
+
+    class DiscoveryStore:
+        calls: list[dict[str, Any]]
+
+        def __init__(self) -> None:
+            self.calls = []
+
+        async def select_all(self, table: str, **kwargs: Any) -> list[dict[str, Any]]:
+            self.calls.append({"table": table, **kwargs})
+            return [{"run_id": run_id} for run_id in run_ids]
+
+    seen: list[str] = []
+
+    async def fake_backfill_run(
+        run_id: str,
+        *,
+        store: Any | None = None,
+        dry_run: bool = True,
+    ) -> ProjectionResult:
+        seen.append(run_id)
+        status = (
+            "traces_backfilled"
+            if run_id == run_ids[-1]
+            else "skipped_traces_existing"
+        )
+        return ProjectionResult(
+            run_id=run_id,
+            status=status,
+            trajectory_id=trajectory_id_for_run(run_id),
+        )
+
+    monkeypatch.setattr(
+        trajectory_projector,
+        "backfill_run_corpus_trace_rows",
+        fake_backfill_run,
+    )
+    monkeypatch.setenv(PROJECTOR_ENABLED_ENV, "true")
+
+    store = DiscoveryStore()
+    results = await backfill_corpus_trace_rows(
+        batch_size=1,
+        dry_run=False,
+        store=store,
+        max_candidates=3,
+    )
+
+    assert store.calls[0]["order_by"] == (("current_status_at", True),)
+    assert seen == list(run_ids)
+    assert [result.status for result in results] == [
+        "skipped_traces_existing",
+        "skipped_traces_existing",
+        "traces_backfilled",
+    ]

--- a/tests/test_weight_pcr0_commit_fallback.py
+++ b/tests/test_weight_pcr0_commit_fallback.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+
+from gateway.api import weights
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+def test_extract_commit_hash_from_explicit_allowlist_field():
+    entry = {
+        "pcr0": "0" * 96,
+        "commit_hash": "9e2f22846d8a0fb4a3ff1c73f821fed8f127b40e",
+        "notes": "validator enclave: current production build on commit badcafe",
+    }
+
+    assert (
+        weights._extract_commit_hash_from_allowlist_entry(entry)
+        == "9e2f22846d8a0fb4a3ff1c73f821fed8f127b40e"
+    )
+
+
+def test_extract_commit_hash_from_notes_fallback():
+    entry = {
+        "pcr0": "0" * 96,
+        "notes": "validator enclave: current production build on commit 9e2f228",
+    }
+
+    assert weights._extract_commit_hash_from_allowlist_entry(entry) == "9e2f228"
+
+
+def test_lookup_pcr0_commit_hash_from_remote_allowlist(monkeypatch):
+    pcr0 = "01877a6d4fd0f4b6f335e7816af36072c63e141ed40e9b100703f467a1feca740cdbca2fd29196e0808d80d50fee5104"
+    payload = {
+        "validator_pcr0": [
+            {
+                "pcr0": pcr0,
+                "commit_hash": "9e2f22846d8a0fb4a3ff1c73f821fed8f127b40e",
+            }
+        ]
+    }
+
+    def fake_urlopen(request, timeout):
+        assert timeout == 10
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr(weights.urllib.request, "urlopen", fake_urlopen)
+
+    assert (
+        weights._lookup_pcr0_commit_hash_from_allowlist(pcr0)
+        == "9e2f22846d8a0fb4a3ff1c73f821fed8f127b40e"
+    )
+
+
+def test_lookup_pcr0_commit_prefers_structured_local_commit_over_remote_notes(
+    monkeypatch, tmp_path
+):
+    pcr0 = "01877a6d4fd0f4b6f335e7816af36072c63e141ed40e9b100703f467a1feca740cdbca2fd29196e0808d80d50fee5104"
+    remote_payload = {
+        "validator_pcr0": [
+            {
+                "pcr0": pcr0,
+                "notes": "validator enclave: current production build on commit 9e2f228",
+            }
+        ]
+    }
+    local_payload = {
+        "validator_pcr0": [
+            {
+                "pcr0": pcr0,
+                "commit_hash": "9e2f22846d8a0fb4a3ff1c73f821fed8f127b40e",
+            }
+        ]
+    }
+    (tmp_path / "pcr0_allowlist.json").write_text(json.dumps(local_payload), encoding="utf-8")
+
+    def fake_urlopen(request, timeout):
+        return _FakeResponse(remote_payload)
+
+    monkeypatch.setattr(weights.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.chdir(tmp_path)
+
+    assert (
+        weights._lookup_pcr0_commit_hash_from_allowlist(pcr0)
+        == "9e2f22846d8a0fb4a3ff1c73f821fed8f127b40e"
+    )

--- a/tests/test_worker_fixes.py
+++ b/tests/test_worker_fixes.py
@@ -318,6 +318,71 @@ async def test_heartbeat_non_conflict_insert_error_still_warns_and_skips(hosted_
     assert context.claim_lost is False
 
 
+async def test_terminal_loop_projection_carries_failed_run_cost_ledger(hosted_worker, monkeypatch):
+    context = _make_context(receipt_id="55555555-5555-4555-8555-555555555555")
+    captured = []
+
+    async def fake_select_one(table, **kwargs):
+        assert table == "research_lab_auto_research_loop_current"
+        return None
+
+    async def fake_create_auto_research_loop_event(**kwargs):
+        captured.append(kwargs)
+        return {"seq": 7, "anchored_hash": "sha256:" + "e" * 64}
+
+    monkeypatch.setattr(worker_mod, "select_one", fake_select_one)
+    monkeypatch.setattr(worker_mod, "create_auto_research_loop_event", fake_create_auto_research_loop_event)
+
+    await hosted_worker._ensure_terminal_loop_projection(
+        context,
+        event_type="loop_failed",
+        loop_status="failed",
+        reason="system_error_after_spend",
+        event_doc={
+            "final_cost_ledger": {
+                "schema_version": "1.0",
+                "status": "failed",
+                "actual_openrouter_cost_microusd": 123456,
+                "actual_openrouter_cost_usd": 0.123456,
+                "total_usd": 0.123456,
+            },
+            "provider_usage": [{"provider": "openrouter", "response_id": "spent-before-error"}],
+        },
+    )
+
+    assert len(captured) == 1
+    assert captured[0]["event_type"] == "loop_failed"
+    assert captured[0]["cost_ledger"]["actual_openrouter_cost_microusd"] == 123456
+    assert captured[0]["provider_usage"][0]["response_id"] == "spent-before-error"
+
+
+def test_failure_exception_cost_evidence_merges_unpersisted_spend():
+    class CostedFailure(RuntimeError):
+        cost_microusd = 2500
+        provider_usage = {"provider": "openrouter", "response_id": "failed-generation"}
+
+    evidence = worker_mod._merge_failure_exception_cost_evidence(
+        {
+            "source": "loop_event",
+            "trusted_cost_ledger": True,
+            "cost_ledger": {
+                "schema_version": "1.0",
+                "actual_openrouter_cost_microusd": 1000,
+                "actual_openrouter_cost_usd": 0.001,
+                "total_usd": 0.001,
+                "openrouter_call_count": 1,
+            },
+            "provider_usage": [{"provider": "openrouter", "response_id": "persisted-generation"}],
+        },
+        CostedFailure("provider charged before failure"),
+    )
+
+    assert evidence["actual_openrouter_cost_microusd"] == 3500
+    assert evidence["cost_ledger"]["failure_exception_cost_microusd"] == 2500
+    assert evidence["provider_usage"][0]["response_id"] == "persisted-generation"
+    assert evidence["provider_usage"][1]["response_id"] == "failed-generation"
+
+
 async def test_to_thread_heartbeat_claim_lost_aborts_before_running_phase(hosted_worker, monkeypatch):
     context = _make_context()
 


### PR DESCRIPTION
## Summary

- Preserve miner OpenRouter spend evidence when code-edit repair calls fail after provider spend.
- Keep latest in-memory loop cost evidence before loop-event persistence, so system/store errors after spend can still produce failed-run reimbursement decisions.
- Carry failed-run cost ledgers into terminal loop projections for recovery/backfill visibility.

## Validation

- pytest tests/test_code_loop_engine_fixes.py tests/test_worker_fixes.py -q
- python3 -m py_compile gateway/research_lab/code_loop_engine.py gateway/research_lab/worker.py
- python3 scripts/verify_research_lab_reimbursements.py
