### PR TITLE
feat: add OpenTelemetry instrumentation to the gateway

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,43 @@
+# Telemetry — leadpoet-gateway
+
+## Service
+
+- `service.name`: `leadpoet-gateway`
+- Runtime: Python / FastAPI + uvicorn (`gateway/main.py`)
+- Instrumentation: `opentelemetry-sdk` 1.27.0, `opentelemetry-exporter-otlp-proto-http` 1.27.0, `opentelemetry-instrumentation-{fastapi,aiohttp-client,httpx,requests,urllib,urllib3}` 0.48b0 (the contrib release paired with SDK 1.27.0 — kept at these pins because Langfuse 2.x requires OTel <1.33 and the validator Firestore stack requires protobuf <5)
+- Bootstrap: `gateway/telemetry.py` — `init_telemetry()` runs at the top of `gateway/main.py` (after `gateway/config.py` loads `.env`); `instrument_app(app)` attaches request spans after the app is created. Both are no-ops unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+- Scope: **gateway only.** The validator (`neurons/validator.py`), miner, and auditor neurons are not instrumented.
+- Backend: OTLP/HTTP via standard `OTEL_EXPORTER_OTLP_*` env vars (see `env.example`). The ingest token is write-only — it can push telemetry and cannot read anything back.
+- Last regenerated: 2026-07-06
+
+## Spans (auto-instrumented)
+
+No hand-written spans yet — everything below comes from auto-instrumentation.
+
+| Span name | Kind | When it fires | Key attributes |
+|---|---|---|---|
+| `GET /`, `POST /presign`, `GET /epoch/*`, `POST /validate/*`, `GET /manifest/*`, `POST /attest`, `GET /attestation/*`, and every other registered FastAPI route | SERVER | One span per inbound HTTP request, named `{METHOD} {route}` (parameterized route, not the raw URL). `GET /health` is excluded to keep k8s probes out of traces. | `http.method`, `http.route`, `http.status_code` |
+| `GET` / `POST` (aiohttp, httpx, requests, urllib, urllib3) | CLIENT | Outbound calls — Supabase (PostgREST via httpx), S3 presign/boto3 HTTP layer (urllib3), provider APIs | `http.method`, `http.url`, `http.status_code` |
+
+Client spans nest under the SERVER span of the request that triggered them; W3C `traceparent` is injected on outbound HTTP automatically.
+
+## Metrics
+
+Metrics pipeline (OTLP/HTTP, periodic reader) is configured, but no custom meters are registered yet. (Prometheus metrics via `prometheus_client` are unchanged and separate.)
+
+## Logs
+
+Root-logger records at INFO+ ship as OTLP log records with `trace_id`/`span_id` correlation. Note: much of the gateway logs via bare `print()`, which does **not** flow to OTLP — only `logging` module records do.
+
+## Configuration
+
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=https://<tenant>.logger.onepatch.dev   # unset = telemetry fully off
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20<write-only-token>
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_SERVICE_NAME=leadpoet-gateway
+```
+
+- Local: `.env` (gitignored, file mode 400). Production: the gateway env comes from AWS Secrets Manager (`leadpoet/prod/gateway/env`) — add the same four vars there to enable telemetry in prod.
+- Header value is URL-encoded (`Bearer%20…`); the SDK decodes `%20` to a space.
+- Never commit the endpoint/token to source — env vars only.

--- a/env.example
+++ b/env.example
@@ -97,3 +97,14 @@ RESEARCH_LAB_TRAJECTORY_PROJECTOR_ENABLED=true
 RESEARCH_LAB_EXECUTION_TRACE_TRAJECTORY_ID_ENABLED=true
 # Escape hatch: start a production worker with degraded capture (loud error)
 # RESEARCH_LAB_CAPTURE_HEALTH_ALLOW_DEGRADED=true
+
+# =============================================================================
+# OpenTelemetry export (GATEWAY — optional; telemetry is OFF when unset)
+# =============================================================================
+# OTLP/HTTP backend root URL (SDK appends /v1/traces etc.). The token is a
+# write-only ingest credential (can push telemetry, cannot read anything back).
+# Header value is URL-encoded: "Bearer%20<token>" (the SDK decodes %20).
+# OTEL_EXPORTER_OTLP_ENDPOINT=https://your-tenant.logger.onepatch.dev
+# OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer%20your_write_only_token
+# OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+# OTEL_SERVICE_NAME=leadpoet-gateway

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -35,6 +35,12 @@ from gateway.build_info import get_build_info
 from gateway.config import BUILD_ID, GITHUB_COMMIT, TIMESTAMP_TOLERANCE_SECONDS
 from gateway.config import SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
 
+# Telemetry: no-op unless OTEL_EXPORTER_OTLP_ENDPOINT is set (see TELEMETRY.md).
+# Must init before HTTP-client modules are used so auto-instrumentation patches apply.
+from gateway.telemetry import init_telemetry, instrument_app
+
+init_telemetry()
+
 # Import models
 from gateway.models.events import SubmissionRequestEvent, EventType
 from gateway.models.responses import PresignedURLResponse, ErrorResponse, HealthResponse
@@ -469,6 +475,8 @@ app = FastAPI(
     lifespan=lifespan,  # Use lifespan context manager
     redirect_slashes=False,  # Prevent 307 redirects from consuming semaphore slots
 )
+
+instrument_app(app)  # OTel SERVER spans per request; no-op when telemetry is off
 
 # ============================================================
 # CORS Middleware

--- a/gateway/telemetry.py
+++ b/gateway/telemetry.py
@@ -1,0 +1,83 @@
+"""OpenTelemetry bootstrap for the gateway — traces, metrics, logs over OTLP/HTTP.
+
+Activates only when ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set (gateway/config.py
+loads .env before this module is initialized). Degrades to a no-op when the
+endpoint is unset or the OTel packages are missing, so the gateway never gains
+a hard runtime dependency on telemetry.
+
+Config (standard OTel env vars — see env.example):
+  OTEL_EXPORTER_OTLP_ENDPOINT   OTLP HTTP root URL (SDK appends /v1/<signal>)
+  OTEL_EXPORTER_OTLP_HEADERS    e.g. Authorization=Bearer%20<token>
+  OTEL_SERVICE_NAME             defaults to leadpoet-gateway
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+_initialized = False
+
+
+def init_telemetry() -> None:
+    """Idempotent SDK init + auto-instrumentation of outbound HTTP clients."""
+    global _initialized
+    if _initialized or not os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        return
+    try:
+        from opentelemetry import metrics, trace
+        from opentelemetry._logs import set_logger_provider
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        return
+
+    os.environ.setdefault("OTEL_SERVICE_NAME", "leadpoet-gateway")
+    resource = Resource.create()  # reads OTEL_SERVICE_NAME + OTEL_RESOURCE_ATTRIBUTES
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(tracer_provider)
+
+    metrics.set_meter_provider(MeterProvider(
+        resource=resource,
+        metric_readers=[PeriodicExportingMetricReader(OTLPMetricExporter())],
+    ))
+
+    logger_provider = LoggerProvider(resource=resource)
+    logger_provider.add_log_record_processor(BatchLogRecordProcessor(OTLPLogExporter()))
+    set_logger_provider(logger_provider)
+    logging.getLogger().addHandler(LoggingHandler(level=logging.INFO, logger_provider=logger_provider))
+
+    for path, cls in (
+        ("opentelemetry.instrumentation.aiohttp_client", "AioHttpClientInstrumentor"),
+        ("opentelemetry.instrumentation.httpx", "HTTPXClientInstrumentor"),
+        ("opentelemetry.instrumentation.requests", "RequestsInstrumentor"),
+        ("opentelemetry.instrumentation.urllib", "URLLibInstrumentor"),
+        ("opentelemetry.instrumentation.urllib3", "URLLib3Instrumentor"),
+    ):
+        try:
+            module = __import__(path, fromlist=[cls])
+            getattr(module, cls)().instrument()
+        except Exception:
+            pass  # a missing/incompatible instrumentation must never block the gateway
+
+    _initialized = True
+
+
+def instrument_app(app) -> None:
+    """Attach SERVER-span instrumentation to the FastAPI app (no-op when off)."""
+    if not _initialized:
+        return
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+        FastAPIInstrumentor.instrument_app(app, excluded_urls="health")
+    except Exception:
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,15 @@ langfuse==2.60.10
 opentelemetry-api==1.27.0
 opentelemetry-sdk==1.27.0
 opentelemetry-exporter-otlp-proto-http==1.27.0
+# Gateway OTel auto-instrumentation (0.48b0 is the contrib release paired with
+# SDK 1.27.0). Export activates only when OTEL_EXPORTER_OTLP_ENDPOINT is set —
+# see TELEMETRY.md.
+opentelemetry-instrumentation-fastapi==0.48b0
+opentelemetry-instrumentation-aiohttp-client==0.48b0
+opentelemetry-instrumentation-httpx==0.48b0
+opentelemetry-instrumentation-requests==0.48b0
+opentelemetry-instrumentation-urllib==0.48b0
+opentelemetry-instrumentation-urllib3==0.48b0
 
 # Retry and resilience
 tenacity>=8.2.0


### PR DESCRIPTION
## Summary

- Adds an env-gated OpenTelemetry bootstrap (`gateway/telemetry.py`): traces, metrics, and logs over OTLP/HTTP. Completely off unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set — no behavior change for existing deployments.
- `gateway/main.py`: `init_telemetry()` runs after `gateway/config.py` loads `.env`; `instrument_app(app)` emits one SERVER span per request (`GET /health` excluded so k8s probes stay out of traces).
- Auto-instruments outbound HTTP clients (aiohttp, httpx, requests, urllib, urllib3) so Supabase/S3/provider calls appear as CLIENT spans nested under the request span.
- Scope: **gateway only** — validator / miner / auditor neurons untouched.

## Version pins

Instrumentation packages pinned to `0.48b0`, the contrib release paired with the existing `opentelemetry-sdk==1.27.0` pin. The Langfuse (<1.33) and validator Firestore (protobuf <5) constraints are unchanged; `firestore`, `bittensor`, `fastapi`, and `supabase` all import cleanly with the new packages.

## Docs & config

- `TELEMETRY.md` (new, repo root) documents the emitted telemetry surface — spans, logs, config.
- `env.example` documents the four `OTEL_*` vars (commented out by default). The ingest token is **write-only** — it can push telemetry, never read data back.
- Prod: add the same four vars to the gateway secret (`leadpoet/prod/gateway/env`) to enable telemetry there.

## Verification

- A request through the instrumented app exported a SERVER span to the OTLP backend successfully (flush confirmed, no exporter warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)