### PR TITLE
Allowlist validator PCR0 for 90a7d9e6

### DIFF
--- a/pcr0_allowlist.json
+++ b/pcr0_allowlist.json
@@ -1,6 +1,6 @@
 {
   "_comment": "PCR0 allowlist for LeadPoet TEE verification. Updated by CI/CD on each enclave build.",
-  "_updated": "2026-07-06T19:12:18Z",
+  "_updated": "2026-07-06T23:08:00Z",
   "_repo": "https://github.com/leadpoet/leadpoet",
   "gateway_pcr0": [
     {
@@ -18,6 +18,13 @@
     }
   ],
   "validator_pcr0": [
+    {
+      "pcr0": "67da49d008d22c120eaafcbc17580364c340aa1f02f83547f19d1ff64b086ede9be2a44762d3ff30aad06ddcd0855788",
+      "version": "2026-07-06",
+      "deployed": "2026-07-06",
+      "commit_hash": "90a7d9e679c4f5be785588b0cab45ffa60b23d94",
+      "notes": "validator enclave: observed production build on commit 90a7d9e6 after stale private-source rebase restart (.eif built 2026-07-06T20:41Z)"
+    },
     {
       "pcr0": "86c579cc13003b16692f35a80391c7ea3a975ea52860b02aeed73da6f1dff21fbf1e686756f2c73c262be7ff5571b098",
       "version": "2026-07-06",


### PR DESCRIPTION
## Problem

The validator enclave was rebuilt during the **2026-07-06T20:41Z restart** (commit \`90a7d9e6\`, Docker cache wiped), producing enclave measurement:

\`\`\`
PCR0 = 67da49d008d22c120eaafcbc17580364c340aa1f02f83547f19d1ff64b086ede9be2a44762d3ff30aad06ddcd0855788
\`\`\`

This measurement was **not** in \`pcr0_allowlist.json\` (newest \`validator_pcr0\` was \`8f36ef9f…\` / commit \`6d75fd91\`), and not yet in the gateway's dynamic GitHub cache. As a result the gateway 403-rejects the validator's TEE weight submissions:

\`\`\`
❌ Gateway rejected submission: 403
   Invalid validator attestation: PCR0 not recognized
   (not in dynamic GitHub cache or static allowlist)!
     Got: 67da49d008d22c12...
\`\`\`

The raw on-chain \`set_weights\` still lands ("proceeding to chain anyway"), but the **TEE-attested / audited weight path is broken** — the gateway won't co-sign this validator's weights.

## Verification (step 1)

- Restart log \`vali_restart_20260706T204102Z\` pulled \`origin/main\` ("Already up to date") **before** rebuilding, then wiped the Docker base image + build cache.
- \`.eif\` built at 20:41:58Z; repo HEAD \`90a7d9e6\` committed 20:35:41Z; working tree had only untracked \`.env.backup*\` files (not in build context).
- Gateway enclave PCR0 \`af54faab…\` is already allowlisted — gateway→validator direction is fine; only the validator→gateway direction was failing.

## Change

Add \`67da49d0…\` to \`validator_pcr0\` (commit \`90a7d9e6\`). Once merged to \`main\`, the gateway's dynamic GitHub cache picks it up on its next refresh — no gateway rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)