### PR TITLE
Derive the PCR0 cache key from exact validator build inputs

### DIFF
--- a/gateway/utils/pcr0_builder.py
+++ b/gateway/utils/pcr0_builder.py
@@ -1096,9 +1096,25 @@ def compute_files_content_hash(repo_dir: str) -> Optional[str]:
     Only rebuilds when the content of monitored files changes.
     """
     hasher = hashlib.sha256()
-    
+
+    # The cache key must cover every byte that Dockerfile.enclave copies into
+    # the validator image. Hashing a hand-maintained subset let two builds
+    # with different enclave code (for example a protected workflow manifest
+    # change) collide on one cache key, so the gateway kept serving a stale
+    # PCR0 as HEAD's and rejected the actually deployed validator. Derive the
+    # key from the exact build inputs, with no filename-suffix filter.
+    file_inputs: Set[str] = set()
+    dir_inputs: Set[str] = set()
+    for entry in set(MONITORED_FILES) | {
+        d.rstrip("/") for d in MONITORED_DIRS
+    } | {p.rstrip("/") for p in PCR0_COPY_PATHS}:
+        if os.path.isdir(os.path.join(repo_dir, entry)):
+            dir_inputs.add(entry)
+        else:
+            file_inputs.add(entry)
+
     files_found = 0
-    for filepath in sorted(MONITORED_FILES):
+    for filepath in sorted(file_inputs):
         full_path = os.path.join(repo_dir, filepath)
         if os.path.exists(full_path):
             try:
@@ -1108,24 +1124,24 @@ def compute_files_content_hash(repo_dir: str) -> Optional[str]:
                 files_found += 1
             except Exception as e:
                 logger.warning(f"[PCR0] Could not read {filepath}: {e}")
-    
-    # Also hash files in monitored directories
-    for dirpath in sorted(MONITORED_DIRS):
+
+    for dirpath in sorted(dir_inputs):
         full_dir = os.path.join(repo_dir, dirpath)
-        if os.path.isdir(full_dir):
-            for root, dirs, files in os.walk(full_dir):
-                for filename in sorted(files):
-                    if any(filename.endswith(suffix) for suffix in MONITORED_DIR_SUFFIXES):
-                        filepath = os.path.join(root, filename)
-                        rel_path = os.path.relpath(filepath, repo_dir)
-                        try:
-                            with open(filepath, 'rb') as f:
-                                hasher.update(f.read())
-                            hasher.update(rel_path.encode())
-                            files_found += 1
-                        except Exception as e:
-                            logger.warning(f"[PCR0] Could not read {rel_path}: {e}")
-    
+        for root, dirs, files in os.walk(full_dir):
+            dirs[:] = sorted(d for d in dirs if d != "__pycache__")
+            for filename in sorted(files):
+                if filename.endswith(".pyc"):
+                    continue
+                filepath = os.path.join(root, filename)
+                rel_path = os.path.relpath(filepath, repo_dir)
+                try:
+                    with open(filepath, 'rb') as f:
+                        hasher.update(f.read())
+                    hasher.update(rel_path.encode())
+                    files_found += 1
+                except Exception as e:
+                    logger.warning(f"[PCR0] Could not read {rel_path}: {e}")
+
     if files_found == 0:
         logger.error("[PCR0] No monitored files found!")
         return None

--- a/tests/test_pcr0_content_hash_covers_build_inputs.py
+++ b/tests/test_pcr0_content_hash_covers_build_inputs.py
@@ -1,0 +1,79 @@
+"""The PCR0 cache key must cover every validator EIF build input.
+
+A cache key derived from a hand-maintained subset of files let two builds
+with different enclave code collide on one key: the gateway skipped the
+rebuild, kept serving a stale PCR0 as HEAD's, and rejected the actually
+deployed validator with "validator PCR0 is absent from the dynamic Git
+build cache". Every path in PCR0_COPY_PATHS — including protected workflow
+manifests and non .py/.json/.txt artifacts such as the drand lock and
+sha256 pins — must change the computed content hash.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from gateway.utils.pcr0_builder import (
+    PCR0_COPY_PATHS,
+    compute_files_content_hash,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SENSITIVE_BUILD_INPUTS = (
+    "validator_tee/enclave/protected_workflows_v2.json",
+    "validator_tee/enclave/weight_authority_v2.py",
+    "validator_tee/enclave/chain_source_v2.py",
+    "validator_tee/enclave/Cargo.drand-cabi-v2.lock",
+    "validator_tee/enclave/libbittensor_drand_v2.sha256",
+)
+
+
+@pytest.fixture()
+def repo_copy(tmp_path):
+    """Copy only the PCR0 build inputs into a scratch repo directory."""
+
+    destination = tmp_path / "repo"
+    for entry in PCR0_COPY_PATHS:
+        source = REPO_ROOT / entry
+        target = destination / entry
+        if source.is_dir():
+            shutil.copytree(
+                source,
+                target,
+                ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+            )
+        elif source.is_file():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+    return destination
+
+
+def test_every_sensitive_build_input_exists_and_is_copied(repo_copy):
+    for entry in SENSITIVE_BUILD_INPUTS:
+        assert (repo_copy / entry).is_file(), entry
+
+
+def test_content_hash_changes_when_any_build_input_changes(repo_copy):
+    baseline = compute_files_content_hash(str(repo_copy))
+    assert baseline is not None
+
+    for entry in SENSITIVE_BUILD_INPUTS:
+        target = repo_copy / entry
+        original = target.read_bytes()
+        target.write_bytes(original + b"\n# pcr0-key-coverage-probe\n")
+        try:
+            mutated = compute_files_content_hash(str(repo_copy))
+        finally:
+            target.write_bytes(original)
+        assert mutated is not None
+        assert mutated != baseline, (
+            f"{entry} does not affect the PCR0 cache key; a stale PCR0 "
+            "would be served for builds that change it"
+        )
+
+    assert compute_files_content_hash(str(repo_copy)) == baseline


### PR DESCRIPTION
## Why

Epoch 24080's weight submission was rejected with:

```
HTTP 400: validator PCR0 is absent from the dynamic Git build cache
```

The running validator enclave's PCR0 (`7bf24875…`) is not among the gateway's 11 warmed PCR0s, even though the validator repo is clean at current main. Root cause is a two-part defect; 82c0d73b fixed part one (the warm queue's git history selector). This PR completes part two:

`compute_files_content_hash` — the function that produces the cache key and decides "already cached, skipping build" — still hashed the hand-maintained `MONITORED_FILES`/`MONITORED_DIRS` subset. That subset omits most of `validator_tee/enclave/` (protected workflow manifests, `chain_source_v2.py`, `weight_authority_v2.py`) and every non `.py/.json/.txt` artifact (the drand `.lock` and `.sha256` pins). Builds whose enclave code differs therefore collide onto one cache key: the warmer skips the rebuild, the gateway serves a stale PCR0 as HEAD's, and the actually deployed validator can never verify dynamically.

## What

- Derive the hashed file set from the union of the monitored set and `PCR0_COPY_PATHS` (the exact Dockerfile.enclave inputs), with no filename-suffix filter; only `__pycache__`/`*.pyc` are excluded, matching the normalized build context.
- Test copies the real build inputs into a scratch repo, then mutates each previously invisible input (workflow manifest, chain source, weight authority, drand lock, sha256 pin) and requires the cache key to change, so monitored ⊂ build-inputs regressions fail CI.

## Verification

- `python3 -m pytest tests/test_pcr0_content_hash_covers_build_inputs.py -q` → 2 passed.
- Live evidence chain in production: warm log shows `Cache key …:bfada797… already cached, skipping build` while the deployed enclave (clean checkout of main) measures `7bf24875…`, absent from all 11 cached PCR0s.

## Deploy note

After merge and gateway restart, the warmer computes a new HEAD key, rebuilds, and the deployed validator verifies dynamically at the next epoch-close attempt. No validator-side change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)