### PR TITLE
Originate missed epoch initializations before the submission window

### DIFF
--- a/gateway/tasks/epoch_monitor.py
+++ b/gateway/tasks/epoch_monitor.py
@@ -29,6 +29,7 @@ from Leadpoet.utils.subnet_epoch import (
     load_subnet_epoch_cutover,
     read_subnet_epoch_snapshot,
 )
+from leadpoet_canonical.constants import WEIGHT_SUBMISSION_BLOCK
 from gateway.utils.subnet_epoch_archive import (
     read_exact_subnet_epoch_snapshot_from_archive,
     validate_cutover_anchor_from_archive,
@@ -81,6 +82,10 @@ class EpochMonitor:
         # They receive no lifecycle events and settle nonfinalized; the
         # monitor resumes at the first boundary it fully observes.
         self.skipped_epochs = set()
+        # Exact boundary snapshots for epochs being originated after their
+        # boundary but before the weight-submission block. The initialization
+        # must anchor the true boundary authority, not the live poll state.
+        self._late_origination_snapshots = {}
         self.validation_ending_epochs = set()
         self.pending_validation_ends = {}
         self.closed_epochs = set()  # Epochs that completed consensus successfully
@@ -307,24 +312,40 @@ class EpochMonitor:
                 f"{current_epoch}; validating it before reuse"
             )
         else:
-            # A restart cannot recreate the queue/assignment snapshot after
-            # the transition has passed. Only a process observing the exact
-            # official boundary may originate a missing initialization.
+            # The epoch authority is the exact boundary snapshot, which the
+            # archive can reproduce byte-for-byte at any later block. A
+            # missing initialization may therefore be originated after the
+            # boundary, as long as it lands before the weight-submission
+            # window opens; the initialization stays anchored to the true
+            # boundary snapshot, never to mid-epoch chain state.
             current_boundary = await self._find_stateful_transition_snapshot(
                 snapshot.subnet_epoch_index,
                 snapshot,
             )
             if current_boundary.current_block != snapshot.current_block:
-                # The boundary passed while no lifecycle process was
-                # observing it, so this epoch can never be initialized.
-                # Skip it (it settles nonfinalized) instead of wedging the
-                # monitor; the next observed transition resumes normally.
-                print(
-                    f"⏭️  Epoch {current_epoch} passed its official boundary "
-                    "without a durable initialization; skipping it and "
-                    "arming for the next boundary"
-                )
-                self.skipped_epochs.add(current_epoch)
+                if snapshot.epoch_block < WEIGHT_SUBMISSION_BLOCK:
+                    print(
+                        f"⏪ Epoch {current_epoch} boundary passed at block "
+                        f"{current_boundary.current_block}; originating its "
+                        f"initialization late at epoch block "
+                        f"{snapshot.epoch_block} (before the submission "
+                        f"window at {WEIGHT_SUBMISSION_BLOCK})"
+                    )
+                    self._late_origination_snapshots[current_epoch] = (
+                        current_boundary
+                    )
+                else:
+                    # Too late: weights were already due for this epoch, so
+                    # a fresh initialization could never lead to a valid
+                    # submission. Skip it (it settles nonfinalized) instead
+                    # of wedging the monitor.
+                    print(
+                        f"⏭️  Epoch {current_epoch} passed its official "
+                        "boundary without a durable initialization and its "
+                        "submission window already opened; skipping it and "
+                        "arming for the next boundary"
+                    )
+                    self.skipped_epochs.add(current_epoch)
 
         if snapshot.subnet_epoch_index == cutover.first_subnet_epoch_index:
             return
@@ -423,12 +444,25 @@ class EpochMonitor:
                     initialization is None
                     and boundary.current_block != snapshot.current_block
                 ):
-                    print(
-                        f"⏭️  Epoch {target_epoch} passed its official "
-                        "boundary without a durable initialization; "
-                        "skipping it and arming for the next boundary"
-                    )
-                    self.skipped_epochs.add(target_epoch)
+                    if snapshot.epoch_block < WEIGHT_SUBMISSION_BLOCK:
+                        print(
+                            f"⏪ Epoch {target_epoch} boundary passed at "
+                            f"block {boundary.current_block}; originating "
+                            f"its initialization late at epoch block "
+                            f"{snapshot.epoch_block} (before the submission "
+                            f"window at {WEIGHT_SUBMISSION_BLOCK})"
+                        )
+                        self._late_origination_snapshots[target_epoch] = (
+                            boundary
+                        )
+                    else:
+                        print(
+                            f"⏭️  Epoch {target_epoch} passed its official "
+                            "boundary without a durable initialization and "
+                            "its submission window already opened; skipping "
+                            "it and arming for the next boundary"
+                        )
+                        self.skipped_epochs.add(target_epoch)
             cursor = boundary
         return cursor
 
@@ -554,7 +588,12 @@ class EpochMonitor:
             asyncio.create_task(
                 self._on_epoch_start(
                     current_epoch,
-                    epoch_snapshot=initialization_snapshot,
+                    # A late origination must anchor the exact boundary
+                    # snapshot, never the mid-epoch poll state.
+                    epoch_snapshot=self._late_origination_snapshots.pop(
+                        current_epoch,
+                        initialization_snapshot,
+                    ),
                 )
             )
 

--- a/tests/test_epoch_monitor_reconciliation.py
+++ b/tests/test_epoch_monitor_reconciliation.py
@@ -212,17 +212,50 @@ async def test_restart_hydration_closes_previous_epoch_from_durable_init(
 
 
 @pytest.mark.asyncio
-async def test_restart_skips_missing_initialization_after_boundary(
+async def test_restart_originates_late_before_submission_window(
     monkeypatch,
 ):
-    # A boundary that passed while no lifecycle process observed it can
-    # never be initialized. The monitor must record the epoch as skipped
-    # (it settles nonfinalized) instead of wedging the polling loop; the
-    # invariant that initializations are never originated late holds.
+    # The epoch authority is the exact boundary snapshot, reproducible from
+    # the archive at any later block. A restart that lands before the
+    # weight-submission window must originate the missing initialization,
+    # anchored to the boundary snapshot rather than mid-epoch chain state.
     from gateway.tasks import epoch_lifecycle, epoch_monitor
 
     cutover = _cutover()
     late = _snapshot(block=110)
+    boundary_snapshot = _snapshot(block=100)
+
+    async def missing(*_args, **_kwargs):
+        return None
+
+    async def boundary(*_args, **_kwargs):
+        return boundary_snapshot
+
+    monkeypatch.setattr(epoch_monitor, "load_subnet_epoch_cutover", lambda: cutover)
+    monkeypatch.setattr(epoch_lifecycle, "get_durable_epoch_event", missing)
+    monitor = epoch_monitor.EpochMonitor()
+    monkeypatch.setattr(monitor, "_find_stateful_transition_snapshot", boundary)
+
+    await monitor._hydrate_stateful_state(late)
+
+    assert 101 not in monitor.skipped_epochs
+    assert monitor._late_origination_snapshots[101] is boundary_snapshot
+    assert 101 not in monitor.initialized_epochs
+    assert 101 not in monitor.initializing_epochs
+
+
+@pytest.mark.asyncio
+async def test_restart_skips_missing_initialization_after_submission_window(
+    monkeypatch,
+):
+    # Once the submission window has opened, a fresh initialization could
+    # never lead to a valid weight submission for the epoch. The monitor
+    # must record it as skipped (it settles nonfinalized) instead of
+    # wedging the polling loop.
+    from gateway.tasks import epoch_lifecycle, epoch_monitor
+
+    cutover = _cutover()
+    late = _snapshot(block=100 + 350)
 
     async def missing(*_args, **_kwargs):
         return None
@@ -238,6 +271,7 @@ async def test_restart_skips_missing_initialization_after_boundary(
     await monitor._hydrate_stateful_state(late)
 
     assert 101 in monitor.skipped_epochs
+    assert 101 not in monitor._late_origination_snapshots
     assert 101 not in monitor.initialized_epochs
     assert 101 not in monitor.initializing_epochs
 
@@ -264,7 +298,11 @@ async def test_restart_skips_uninitialized_previous_epoch(monkeypatch):
 
     await monitor._hydrate_stateful_state(late)
 
-    assert {101, 102} <= monitor.skipped_epochs
+    # The fully missed previous epoch stays skipped; the current epoch is
+    # still before its submission window, so it is originated late instead.
+    assert 101 in monitor.skipped_epochs
+    assert 102 not in monitor.skipped_epochs
+    assert 102 in monitor._late_origination_snapshots
 
 
 @pytest.mark.asyncio
@@ -530,3 +568,36 @@ async def test_validation_end_marks_memory_only_after_both_durable_events(
     assert end_payloads[-1]["epoch_key_semantics"] == "settlement_ordinal"
     assert end_payloads[-1]["epoch_authority"] == authority
     assert inputs_kwargs["epoch_authority"] == authority
+
+
+@pytest.mark.asyncio
+async def test_dispatch_anchors_late_origination_to_boundary_snapshot(
+    monkeypatch,
+):
+    # When an epoch is originated after its boundary, the initialization
+    # dispatch must receive the exact boundary snapshot, not the live
+    # mid-epoch poll snapshot the loop happened to observe.
+    from gateway.tasks import epoch_monitor
+
+    cutover = _cutover()
+    monkeypatch.setattr(epoch_monitor, "load_subnet_epoch_cutover", lambda: cutover)
+    monitor = epoch_monitor.EpochMonitor()
+    boundary_snapshot = _snapshot(block=100)
+    live = _snapshot(block=130)
+    monitor._late_origination_snapshots[101] = boundary_snapshot
+    captured = {}
+
+    async def capture(epoch_id, epoch_snapshot):
+        captured["epoch_id"] = epoch_id
+        captured["snapshot"] = epoch_snapshot
+
+    monkeypatch.setattr(monitor, "_on_epoch_start", capture)
+    await monitor._process_stateful_snapshot(live)
+    for _ in range(10):
+        if captured:
+            break
+        await asyncio.sleep(0)
+
+    assert captured["epoch_id"] == 101
+    assert captured["snapshot"] is boundary_snapshot
+    assert 101 not in monitor._late_origination_snapshots


### PR DESCRIPTION
## Why

Every gateway restart or hang that crossed an epoch boundary permanently cost that epoch's weights: origination required a poll observing the **exact boundary block**, which a process that was down at the boundary can never satisfy. Tonight alone this consumed epochs 24074, 24082, and 24083.

## What

The epoch authority is the exact boundary snapshot, and `_find_stateful_transition_snapshot` already reproduces it byte-for-byte from the archive at any later block. This PR lets the monitor originate a missing current-epoch initialization **until the weight-submission window opens** (`WEIGHT_SUBMISSION_BLOCK = 345`):

- `_hydrate_stateful_state` and `_reconcile_stateful_gap`: when the current epoch's initialization is missing and the boundary has passed, stash the exact boundary snapshot and originate late if `epoch_block < 345`; skip (nonfinalized) as before once the window has opened, since a fresh initialization could never yield a valid submission.
- The initialization dispatch anchors to the stashed **boundary snapshot**, never the mid-epoch poll state, so the durable initialization is identical to one originated at the boundary (same authority document, same boundaries).
- Skipped-epoch semantics, transition handling, and the never-originate-after-weights-due invariant are unchanged.

Net behavior: a restart that finishes before weights are due submits weights for the epoch it lands in — restarts stop costing whole epochs.

## Verification

- `tests/test_epoch_monitor_reconciliation.py`: 13/13 green — new tests for late origination within the window, skip after the window opens, boundary-snapshot anchoring of the dispatch, and updated expectations for the previously always-skip cases.
- `py_compile` clean. Gateway parent-process change only (no enclave/PCR0 impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)