### PR TITLE
Mirror the live epoch from staged publication-first authority

### DIFF
--- a/gateway/api/weights.py
+++ b/gateway/api/weights.py
@@ -1468,6 +1468,49 @@ async def get_attested_weights_v2(netuid: int, epoch_id: int) -> Dict[str, Any]:
     return authority
 
 
+@router.get("/v2/published/{netuid}/{epoch_id}")
+async def get_published_weights_v2(netuid: int, epoch_id: int) -> Dict[str, Any]:
+    """Return the strongest staged V2 authority: published or finalized.
+
+    The primary's chain finalization completes shortly after the epoch
+    boundary, so during the live epoch the strongest existing authority is
+    the enclave-signed bundle plus the durable gateway publication. Auditors
+    mirror from this staged view within the same epoch; the finalized-chain
+    proof is attached as soon as it exists, and the finalized-only
+    /v2/latest contract is unchanged for existing consumers.
+    """
+
+    try:
+        from gateway.research_lab.attested_v2_store import load_weight_authority_v2
+
+        if len(PRIMARY_VALIDATOR_HOTKEYS) != 1:
+            raise RuntimeError("authoritative primary validator hotkey is ambiguous")
+        authority = await load_weight_authority_v2(
+            netuid=int(netuid),
+            epoch_id=int(epoch_id),
+            validator_hotkey=next(iter(PRIMARY_VALIDATOR_HOTKEYS)),
+            require_finalization=False,
+        )
+    except Exception as exc:
+        logger.error(
+            "weight_published_v2_load_failed netuid=%s epoch=%s "
+            "error_type=%s error=%s",
+            netuid,
+            epoch_id,
+            type(exc).__name__,
+            str(exc)[:240],
+        )
+        raise HTTPException(
+            status_code=500, detail="v2 staged weight authority load failed"
+        ) from exc
+    if authority is None:
+        raise HTTPException(
+            status_code=404,
+            detail="published v2 weight authority not found",
+        )
+    return authority
+
+
 @router.get("/v2/release-evidence/{commit_sha}")
 async def get_auditor_release_evidence_v2(commit_sha: str) -> Dict[str, Any]:
     """Return short-lived links to one immutable six-build release channel."""

--- a/gateway/research_lab/attested_v2_store.py
+++ b/gateway/research_lab/attested_v2_store.py
@@ -1830,9 +1830,23 @@ async def persist_weight_finalization_v2(
 
 
 async def load_weight_authority_v2(
-    *, netuid: int, epoch_id: int, validator_hotkey: str
+    *,
+    netuid: int,
+    epoch_id: int,
+    validator_hotkey: str,
+    require_finalization: bool = True,
 ) -> dict[str, Any] | None:
-    """Load the bundle, gateway publication, and finalized-chain proof."""
+    """Load the bundle, gateway publication, and finalized-chain proof.
+
+    With ``require_finalization=True`` (the default) the historical payload
+    shape is returned unchanged and only fully finalized authority exists.
+    With ``require_finalization=False`` a staged payload is returned as soon
+    as the durable gateway publication exists: ``authority_stage`` is
+    ``"published"`` until the finalized-chain proof lands, after which the
+    same request returns ``"finalized"`` with the full proof attached. The
+    staged shape lets auditors mirror the enclave-signed publication within
+    the live epoch instead of one epoch behind.
+    """
 
     bundle = await load_weight_bundle_v2(
         netuid=int(netuid),
@@ -1853,7 +1867,29 @@ async def load_weight_authority_v2(
         filters=(("bundle_hash", bundle_verified["bundle_hash"]),),
     )
     if not isinstance(finalization, Mapping):
-        return None
+        if require_finalization:
+            return None
+        staged_publication_graph = await load_receipt_graph_v2(
+            str(publication.get("publication_receipt_hash") or "")
+        )
+        return {
+            "schema_version": (
+                "leadpoet.published_weight_authority_stage.v2"
+            ),
+            "authority_stage": "published",
+            "bundle": bundle,
+            "publication": {
+                "weight_submission_event_hash": publication[
+                    "weight_submission_event_hash"
+                ],
+                "publication_receipt_hash": publication[
+                    "publication_receipt_hash"
+                ],
+                "publication_doc": dict(publication["publication_doc"]),
+                "receipt_graph": staged_publication_graph,
+            },
+            "finalization": None,
+        }
     publication_graph = await load_receipt_graph_v2(
         str(publication.get("publication_receipt_hash") or "")
     )
@@ -1869,23 +1905,35 @@ async def load_weight_authority_v2(
         "finalization": dict(finalization.get("finalization_doc") or {}),
         "receipt_graph": finalization_graph,
     }
+    publication_section = {
+        "weight_submission_event_hash": publication[
+            "weight_submission_event_hash"
+        ],
+        "publication_receipt_hash": publication[
+            "publication_receipt_hash"
+        ],
+        "publication_doc": dict(publication["publication_doc"]),
+        "receipt_graph": publication_graph,
+    }
+    finalization_section = {
+        "weight_finalization_event_hash": finalization[
+            "weight_finalization_event_hash"
+        ],
+        "submission": finalization_submission,
+    }
+    if not require_finalization:
+        return {
+            "schema_version": (
+                "leadpoet.published_weight_authority_stage.v2"
+            ),
+            "authority_stage": "finalized",
+            "bundle": bundle,
+            "publication": publication_section,
+            "finalization": finalization_section,
+        }
     return {
         "schema_version": "leadpoet.published_weight_authority.v2",
         "bundle": bundle,
-        "publication": {
-            "weight_submission_event_hash": publication[
-                "weight_submission_event_hash"
-            ],
-            "publication_receipt_hash": publication[
-                "publication_receipt_hash"
-            ],
-            "publication_doc": dict(publication["publication_doc"]),
-            "receipt_graph": publication_graph,
-        },
-        "finalization": {
-            "weight_finalization_event_hash": finalization[
-                "weight_finalization_event_hash"
-            ],
-            "submission": finalization_submission,
-        },
+        "publication": publication_section,
+        "finalization": finalization_section,
     }

--- a/leadpoet_canonical/auditor_v2.py
+++ b/leadpoet_canonical/auditor_v2.py
@@ -343,6 +343,89 @@ def verify_attested_weight_authority_v2(
         identity_cache=identity_cache,
         boot_verifier=boot_verifier,
     )
+    return _verify_publication_and_finalization(
+        verified_bundle=verified_bundle,
+        publication=publication,
+        finalization=finalization,
+        identity_cache=identity_cache,
+        chain_signing_profile=chain_signing_profile,
+        boot_verifier=boot_verifier,
+    )
+
+
+def verify_published_weight_authority_stage_v2(
+    authority: Mapping[str, Any],
+    *,
+    identity_cache: Mapping[str, Any],
+    chain_signing_profile: Mapping[str, Any],
+    boot_verifier: Optional[Callable[..., Any]] = None,
+) -> Dict[str, Any]:
+    """Verify a staged authority: publication always, finalization if present.
+
+    The primary's chain finalization completes shortly after the epoch
+    boundary, so during the live epoch the strongest existing authority is
+    often bundle + durable gateway publication. Every cryptographic check on
+    the bundle and publication (enclave signatures, boot identities against
+    independent release evidence, receipt graphs, event hashes) is identical
+    to the finalized path; only the finalized-chain proof is stage-dependent.
+    Mirroring before chain inclusion is covered retrospectively by the
+    auditors' soft equivocation check against on-chain weights.
+    """
+
+    if not isinstance(authority, Mapping) or set(authority) != {
+        "schema_version",
+        "authority_stage",
+        "bundle",
+        "publication",
+        "finalization",
+    }:
+        raise AuditorV2Error("staged V2 weight authority fields are invalid")
+    if (
+        authority.get("schema_version")
+        != "leadpoet.published_weight_authority_stage.v2"
+    ):
+        raise AuditorV2Error("staged V2 weight authority schema is invalid")
+    stage = authority.get("authority_stage")
+    bundle = authority.get("bundle")
+    publication = authority.get("publication")
+    finalization = authority.get("finalization")
+    if not isinstance(bundle, Mapping) or not isinstance(publication, Mapping):
+        raise AuditorV2Error("staged V2 weight authority components are invalid")
+    if stage == "finalized":
+        if not isinstance(finalization, Mapping):
+            raise AuditorV2Error("finalized V2 authority is missing its proof")
+    elif stage == "published":
+        if finalization is not None:
+            raise AuditorV2Error(
+                "published-stage V2 authority must not carry a finalization"
+            )
+    else:
+        raise AuditorV2Error("staged V2 weight authority stage is invalid")
+    verified_bundle = verify_attested_weight_bundle_v2(
+        bundle,
+        identity_cache=identity_cache,
+        boot_verifier=boot_verifier,
+    )
+    verified = _verify_publication_and_finalization(
+        verified_bundle=verified_bundle,
+        publication=publication,
+        finalization=finalization if stage == "finalized" else None,
+        identity_cache=identity_cache,
+        chain_signing_profile=chain_signing_profile,
+        boot_verifier=boot_verifier,
+    )
+    return {**verified, "authority_stage": stage}
+
+
+def _verify_publication_and_finalization(
+    *,
+    verified_bundle: Mapping[str, Any],
+    publication: Mapping[str, Any],
+    finalization: Optional[Mapping[str, Any]],
+    identity_cache: Mapping[str, Any],
+    chain_signing_profile: Mapping[str, Any],
+    boot_verifier: Optional[Callable[..., Any]] = None,
+) -> Dict[str, Any]:
 
     # Boot identities are issued once at enclave boot and verified for days
     # afterwards; the Nitro leaf certificate is only valid for hours, so the
@@ -418,6 +501,13 @@ def verify_attested_weight_authority_v2(
     )
     if publication.get("weight_submission_event_hash") != expected_submission_event:
         raise AuditorV2Error("V2 publication event hash differs")
+
+    if finalization is None:
+        return {
+            **verified_bundle,
+            "weight_submission_event_hash": expected_submission_event,
+            "additional_verified_boots": sorted(set(observed)),
+        }
 
     if set(finalization) != {
         "weight_finalization_event_hash",

--- a/neurons/auditor_validator.py
+++ b/neurons/auditor_validator.py
@@ -197,6 +197,7 @@ from leadpoet_canonical.events import verify_log_entry
 from leadpoet_canonical.auditor_v2 import (
     fetch_locked_release_identity_cache,
     verify_attested_weight_authority_v2,
+    verify_published_weight_authority_stage_v2,
 )
 
 # Constants from canonical module
@@ -881,44 +882,69 @@ class AuditorValidator:
         return candidates
 
     async def fetch_attested_weights_v2(self, epoch_id: int) -> Optional[Dict]:
-        """Fetch the sole authoritative V2 bundle."""
+        """Fetch the strongest authoritative V2 authority for one epoch.
+
+        Prefers the staged view (published or finalized), which exists as
+        soon as the primary's durable gateway publication lands, so the
+        live epoch can be mirrored in-window. Falls back to the
+        finalized-only legacy route when the gateway predates the staged
+        view.
+        """
 
         self._last_v2_authority_was_absent = False
+        netuid = int(self.config.netuid)
+        staged_url = (
+            f"{self.gateway_url}/weights/v2/published/{netuid}/{int(epoch_id)}"
+        )
+        legacy_url = (
+            f"{self.gateway_url}/weights/v2/latest/{netuid}/{int(epoch_id)}"
+        )
+        absent_details = {
+            "v2 weight bundle not found",
+            "finalized v2 weight authority not found",
+            "published v2 weight authority not found",
+        }
         try:
             async with aiohttp.ClientSession(trust_env=False) as session:
-                url = f"{self.gateway_url}/weights/v2/latest/{self.config.netuid}/{int(epoch_id)}"
-                async with session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as response:
-                    if response.status == 404:
-                        try:
-                            not_found = await response.json()
-                        except Exception:
-                            not_found = None
-                        detail = (
-                            str(not_found.get("detail") or "").strip()
-                            if isinstance(not_found, dict)
-                            else ""
-                        )
-                        self._last_v2_authority_was_absent = detail in {
-                            "Not Found",
-                            "v2 weight bundle not found",
-                            "finalized v2 weight authority not found",
-                        }
-                        if not self._last_v2_authority_was_absent:
-                            logger.warning(
-                                "auditor_v2_fetch_failed epoch=%s status=404 detail=%s",
-                                epoch_id,
-                                detail[:160],
+                for url in (staged_url, legacy_url):
+                    async with session.get(
+                        url, timeout=aiohttp.ClientTimeout(total=30)
+                    ) as response:
+                        if response.status == 404:
+                            try:
+                                not_found = await response.json()
+                            except Exception:
+                                not_found = None
+                            detail = (
+                                str(not_found.get("detail") or "").strip()
+                                if isinstance(not_found, dict)
+                                else ""
                             )
-                        return None
-                    if response.status != 200:
-                        logger.warning(
-                            "auditor_v2_fetch_failed epoch=%s status=%s",
-                            epoch_id,
-                            response.status,
-                        )
-                        return None
-                    value = await response.json()
-                    return value if isinstance(value, dict) else None
+                            if url is staged_url and detail == "Not Found":
+                                # The gateway predates the staged route;
+                                # fall through to the legacy view.
+                                continue
+                            self._last_v2_authority_was_absent = detail in (
+                                absent_details | {"Not Found"}
+                            )
+                            if not self._last_v2_authority_was_absent:
+                                logger.warning(
+                                    "auditor_v2_fetch_failed epoch=%s "
+                                    "status=404 detail=%s",
+                                    epoch_id,
+                                    detail[:160],
+                                )
+                            return None
+                        if response.status != 200:
+                            logger.warning(
+                                "auditor_v2_fetch_failed epoch=%s status=%s",
+                                epoch_id,
+                                response.status,
+                            )
+                            return None
+                        value = await response.json()
+                        return value if isinstance(value, dict) else None
+            return None
         except Exception as exc:
             logger.warning(
                 "auditor_v2_fetch_failed epoch=%s error_type=%s error=%s",
@@ -1071,11 +1097,26 @@ class AuditorValidator:
                 )
             ).expanduser()
             profile = json.loads(profile_file.read_text(encoding="utf-8"))
-            verified = verify_attested_weight_authority_v2(
-                authority,
-                identity_cache=identity_cache,
-                chain_signing_profile=profile,
-            )
+            if (
+                isinstance(authority, dict)
+                and "authority_stage" in authority
+            ):
+                # Staged view: publication-stage authority is fully
+                # enclave-signed and release-evidence verified; the
+                # finalized-chain proof is verified whenever present. The
+                # soft equivocation check covers chain divergence
+                # retrospectively.
+                verified = verify_published_weight_authority_stage_v2(
+                    authority,
+                    identity_cache=identity_cache,
+                    chain_signing_profile=profile,
+                )
+            else:
+                verified = verify_attested_weight_authority_v2(
+                    authority,
+                    identity_cache=identity_cache,
+                    chain_signing_profile=profile,
+                )
             self._verify_stateful_bundle_epoch(verified)
             return verified
         except Exception as exc:

--- a/tests/test_auditor_same_epoch_mirroring.py
+++ b/tests/test_auditor_same_epoch_mirroring.py
@@ -1,0 +1,335 @@
+"""Auditors mirror the live epoch from staged (publication-first) authority.
+
+The primary's chain finalization completes shortly after the epoch boundary,
+so a finalized-only view is typically one epoch behind the auditor's
+submission window. The staged view serves the enclave-signed bundle plus the
+durable gateway publication as soon as they exist, attaches the
+finalized-chain proof once it lands, and leaves the finalized-only
+/v2/latest contract untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import leadpoet_canonical.auditor_v2 as auditor_v2
+
+
+# ---------------------------------------------------------------------------
+# Canonical staged verifier: stage gating and routing
+# ---------------------------------------------------------------------------
+
+
+def _staged_authority(stage, finalization):
+    return {
+        "schema_version": "leadpoet.published_weight_authority_stage.v2",
+        "authority_stage": stage,
+        "bundle": {"kind": "bundle"},
+        "publication": {"kind": "publication"},
+        "finalization": finalization,
+    }
+
+
+@pytest.fixture()
+def routed(monkeypatch):
+    calls = {}
+
+    def fake_bundle_verify(bundle, *, identity_cache, boot_verifier=None):
+        calls["bundle"] = bundle
+        return {"bundle_hash": "sha256:" + "a" * 64}
+
+    def fake_tail(**kwargs):
+        calls["finalization_arg"] = kwargs["finalization"]
+        return {"epoch_id": 24084, "netuid": 71}
+
+    monkeypatch.setattr(
+        auditor_v2, "verify_attested_weight_bundle_v2", fake_bundle_verify
+    )
+    monkeypatch.setattr(
+        auditor_v2, "_verify_publication_and_finalization", fake_tail
+    )
+    return calls
+
+
+def test_published_stage_verifies_without_finalization(routed):
+    verified = auditor_v2.verify_published_weight_authority_stage_v2(
+        _staged_authority("published", None),
+        identity_cache={},
+        chain_signing_profile={},
+    )
+    assert routed["finalization_arg"] is None
+    assert verified["authority_stage"] == "published"
+
+
+def test_finalized_stage_passes_proof_through(routed):
+    proof = {"kind": "finalization"}
+    verified = auditor_v2.verify_published_weight_authority_stage_v2(
+        _staged_authority("finalized", proof),
+        identity_cache={},
+        chain_signing_profile={},
+    )
+    assert routed["finalization_arg"] == proof
+    assert verified["authority_stage"] == "finalized"
+
+
+def test_published_stage_must_not_carry_finalization(routed):
+    with pytest.raises(auditor_v2.AuditorV2Error):
+        auditor_v2.verify_published_weight_authority_stage_v2(
+            _staged_authority("published", {"kind": "finalization"}),
+            identity_cache={},
+            chain_signing_profile={},
+        )
+
+
+def test_finalized_stage_requires_its_proof(routed):
+    with pytest.raises(auditor_v2.AuditorV2Error):
+        auditor_v2.verify_published_weight_authority_stage_v2(
+            _staged_authority("finalized", None),
+            identity_cache={},
+            chain_signing_profile={},
+        )
+
+
+def test_unknown_stage_fails_closed(routed):
+    with pytest.raises(auditor_v2.AuditorV2Error):
+        auditor_v2.verify_published_weight_authority_stage_v2(
+            _staged_authority("committed", None),
+            identity_cache={},
+            chain_signing_profile={},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Store loader: staged payload shapes, legacy shape untouched
+# ---------------------------------------------------------------------------
+
+
+def _store(monkeypatch, *, finalization_row):
+    from gateway.research_lab import attested_v2_store as store
+
+    async def fake_bundle(**_kwargs):
+        return {"kind": "bundle"}
+
+    def fake_validate(bundle):
+        return {"bundle_hash": "sha256:" + "b" * 64}
+
+    async def fake_select_one(table, filters):
+        if table == store.PUBLICATION_TABLE:
+            return {
+                "weight_submission_event_hash": "sha256:" + "c" * 64,
+                "publication_receipt_hash": "sha256:" + "d" * 64,
+                "publication_doc": {"kind": "publication-doc"},
+            }
+        if table == store.FINALIZATION_TABLE:
+            return finalization_row
+        raise AssertionError(table)
+
+    async def fake_graph(_receipt_hash):
+        return {"kind": "graph"}
+
+    monkeypatch.setattr(store, "load_weight_bundle_v2", fake_bundle)
+    monkeypatch.setattr(
+        store, "validate_published_weight_bundle_v2", fake_validate
+    )
+    monkeypatch.setattr(store, "select_one", fake_select_one)
+    monkeypatch.setattr(store, "load_receipt_graph_v2", fake_graph)
+    return store
+
+
+def test_store_returns_published_stage_before_finalization(monkeypatch):
+    store = _store(monkeypatch, finalization_row=None)
+    authority = asyncio.run(
+        store.load_weight_authority_v2(
+            netuid=71,
+            epoch_id=24084,
+            validator_hotkey="hk",
+            require_finalization=False,
+        )
+    )
+    assert authority["authority_stage"] == "published"
+    assert authority["finalization"] is None
+    assert authority["publication"]["receipt_graph"] == {"kind": "graph"}
+
+
+def test_store_keeps_finalized_only_contract_by_default(monkeypatch):
+    store = _store(monkeypatch, finalization_row=None)
+    authority = asyncio.run(
+        store.load_weight_authority_v2(
+            netuid=71,
+            epoch_id=24084,
+            validator_hotkey="hk",
+        )
+    )
+    assert authority is None
+
+
+def test_store_upgrades_staged_payload_once_finalized(monkeypatch):
+    finalization_row = {
+        "weight_finalization_event_hash": "sha256:" + "e" * 64,
+        "finalization_receipt_hash": "sha256:" + "f" * 64,
+        "finalization_doc": {"kind": "finalization-doc"},
+    }
+    store = _store(monkeypatch, finalization_row=finalization_row)
+    staged = asyncio.run(
+        store.load_weight_authority_v2(
+            netuid=71,
+            epoch_id=24084,
+            validator_hotkey="hk",
+            require_finalization=False,
+        )
+    )
+    assert staged["authority_stage"] == "finalized"
+    assert staged["finalization"]["submission"]["finalization"] == {
+        "kind": "finalization-doc"
+    }
+    legacy = asyncio.run(
+        store.load_weight_authority_v2(
+            netuid=71,
+            epoch_id=24084,
+            validator_hotkey="hk",
+        )
+    )
+    assert set(legacy) == {
+        "schema_version",
+        "bundle",
+        "publication",
+        "finalization",
+    }
+    assert legacy["schema_version"] == "leadpoet.published_weight_authority.v2"
+
+
+# ---------------------------------------------------------------------------
+# Auditor fetch: staged route preferred, legacy fallback, dispatch by stage
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status, payload):
+        self.status = status
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, responses):
+        self._responses = responses
+        self.urls = []
+
+    def get(self, url, timeout=None):
+        self.urls.append(url)
+        return self._responses.pop(0)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+def _fetch_auditor(monkeypatch, responses):
+    import neurons.auditor_validator as auditor_module
+
+    session = _FakeSession(responses)
+    monkeypatch.setattr(
+        auditor_module.aiohttp,
+        "ClientSession",
+        lambda trust_env=False: session,
+    )
+    auditor = SimpleNamespace(
+        gateway_url="http://gw",
+        config=SimpleNamespace(netuid=71),
+    )
+    fetch = auditor_module.AuditorValidator.fetch_attested_weights_v2
+    return auditor_module, auditor, session, fetch
+
+
+def test_fetch_prefers_staged_route(monkeypatch):
+    _, auditor, session, fetch = _fetch_auditor(
+        monkeypatch,
+        [_FakeResponse(200, {"authority_stage": "published"})],
+    )
+    value = asyncio.run(fetch(auditor, 24084))
+    assert value == {"authority_stage": "published"}
+    assert session.urls == ["http://gw/weights/v2/published/71/24084"]
+
+
+def test_fetch_falls_back_when_gateway_predates_staged_route(monkeypatch):
+    _, auditor, session, fetch = _fetch_auditor(
+        monkeypatch,
+        [
+            _FakeResponse(404, {"detail": "Not Found"}),
+            _FakeResponse(200, {"schema_version": "legacy"}),
+        ],
+    )
+    value = asyncio.run(fetch(auditor, 24084))
+    assert value == {"schema_version": "legacy"}
+    assert session.urls == [
+        "http://gw/weights/v2/published/71/24084",
+        "http://gw/weights/v2/latest/71/24084",
+    ]
+    assert auditor._last_v2_authority_was_absent is False
+
+
+def test_fetch_marks_absent_authority(monkeypatch):
+    _, auditor, session, fetch = _fetch_auditor(
+        monkeypatch,
+        [
+            _FakeResponse(
+                404, {"detail": "published v2 weight authority not found"}
+            )
+        ],
+    )
+    value = asyncio.run(fetch(auditor, 24084))
+    assert value is None
+    assert auditor._last_v2_authority_was_absent is True
+    assert session.urls == ["http://gw/weights/v2/published/71/24084"]
+
+
+def test_verify_dispatches_staged_authority(monkeypatch, tmp_path):
+    import neurons.auditor_validator as auditor_module
+
+    profile_path = tmp_path / "profile.json"
+    profile_path.write_text(json.dumps({"version_key": 1}), encoding="utf-8")
+    monkeypatch.setenv("AUDITOR_CHAIN_SIGNING_PROFILE_FILE", str(profile_path))
+    calls = {}
+
+    def staged_verify(authority, *, identity_cache, chain_signing_profile):
+        calls["staged"] = authority
+        return {"epoch_id": 24084, "netuid": 71}
+
+    def finalized_verify(authority, *, identity_cache, chain_signing_profile):
+        calls["finalized"] = authority
+        return {"epoch_id": 24084, "netuid": 71}
+
+    monkeypatch.setattr(
+        auditor_module,
+        "verify_published_weight_authority_stage_v2",
+        staged_verify,
+    )
+    monkeypatch.setattr(
+        auditor_module,
+        "verify_attested_weight_authority_v2",
+        finalized_verify,
+    )
+    auditor = SimpleNamespace(_verify_stateful_bundle_epoch=lambda _v: None)
+    verify = auditor_module.AuditorValidator.verify_attested_weights_v2
+
+    staged = {"authority_stage": "published"}
+    assert verify(auditor, staged, identity_cache={}) is not None
+    assert calls["staged"] is staged
+
+    legacy = {"schema_version": "leadpoet.published_weight_authority.v2"}
+    assert verify(auditor, legacy, identity_cache={}) is not None
+    assert calls["finalized"] is legacy

--- a/tests/test_auditor_v2_hardening.py
+++ b/tests/test_auditor_v2_hardening.py
@@ -28,15 +28,23 @@ def _auditor(netuid=71):
 
 
 def test_default_boot_verifier_checks_certificates_at_attestation_time():
-    # Both verify entrypoints must bind the real Nitro verifier with
+    # Every verify path must bind the real Nitro verifier with
     # attestation-time certificate validity; an injected test verifier keeps
-    # its own signature untouched.
+    # its own signature untouched. The publication/finalization checks are
+    # shared, so both authority entrypoints must provably route through the
+    # helper that binds the verifier.
     for fn in (
         auditor_v2.verify_attested_weight_bundle_v2,
-        auditor_v2.verify_attested_weight_authority_v2,
+        auditor_v2._verify_publication_and_finalization,
     ):
         source = inspect.getsource(fn)
         assert "certificate_validity_at_attestation_time=True" in source, fn.__name__
+    for fn in (
+        auditor_v2.verify_attested_weight_authority_v2,
+        auditor_v2.verify_published_weight_authority_stage_v2,
+    ):
+        source = inspect.getsource(fn)
+        assert "_verify_publication_and_finalization" in source, fn.__name__
 
 
 def test_verified_authority_must_match_requested_epoch_and_netuid(monkeypatch):

--- a/validator_tee/enclave/protected_workflows_v2.json
+++ b/validator_tee/enclave/protected_workflows_v2.json
@@ -12,7 +12,12 @@
       "symbol": "validate_allocation_handoff_v2"
     },
     {
-      "ast_sha256": "sha256:0a35072ef1934ea93434e80d8ccbd1388756fab768f64d231c516c79ce54a717",
+      "ast_sha256": "sha256:71afd8999033d3b42707c02011400b3f819577ca3b887760840d58808c39bc7e",
+      "path": "leadpoet_canonical/auditor_v2.py",
+      "symbol": "_verify_publication_and_finalization"
+    },
+    {
+      "ast_sha256": "sha256:b2005511fc81f53aa29094b863122862017cf2830d79157febd1ab9b251ad6a0",
       "path": "leadpoet_canonical/auditor_v2.py",
       "symbol": "verify_attested_weight_authority_v2"
     },
@@ -20,6 +25,11 @@
       "ast_sha256": "sha256:65086de05473064b17e241d01e0b6f9253f42875e08f8c833bc4c4012a378e6c",
       "path": "leadpoet_canonical/auditor_v2.py",
       "symbol": "verify_attested_weight_bundle_v2"
+    },
+    {
+      "ast_sha256": "sha256:f6166e866766675d119d0e2dbc0e629ed7c77e371c541d9ed97ec4ad0b05d8ec",
+      "path": "leadpoet_canonical/auditor_v2.py",
+      "symbol": "verify_published_weight_authority_stage_v2"
     },
     {
       "ast_sha256": "sha256:4e9d832cf6e7c722c578ce1dff953194f292df3ec6e0b56cbc3901869ef6e410",
@@ -117,7 +127,7 @@
       "symbol": "weight_config_document"
     },
     {
-      "ast_sha256": "sha256:cc519cc8440b27219b2eb75eab2d5cabf49c6ac87aa7fcb5c4bae7241136c5ba",
+      "ast_sha256": "sha256:0a313a76743fe3ffbd525d6831231b5e23668ce4e3578eafd6882e751b7332d7",
       "path": "neurons/auditor_validator.py",
       "symbol": "AuditorValidator.fetch_attested_weights_v2"
     },
@@ -137,7 +147,7 @@
       "symbol": "AuditorValidator.submit_weights_to_chain"
     },
     {
-      "ast_sha256": "sha256:888035344f1bbe5f4357534d80721d69048da37cfe61a06ae323abb165a9cb96",
+      "ast_sha256": "sha256:c36fbdab83769a05ded4f60c3a17868a88697d6ea49cdb1e5b105efa3cdc3be7",
       "path": "neurons/auditor_validator.py",
       "symbol": "AuditorValidator.verify_attested_weights_v2"
     },
@@ -272,7 +282,7 @@
       "symbol": "normalize_weight_protocol"
     }
   ],
-  "manifest_hash": "sha256:be6cf7b5bbf1988817f614be087178146f843728f95e77a384c96f605ee86af7",
-  "protected_source_commit": "a3145773666a15276871102fe513e80f8bd5543a",
+  "manifest_hash": "sha256:933941da39bb7903a184b00f2323728981702b6385f34fb6556d0dfb0ec3a4ca",
+  "protected_source_commit": "e49dfbef1b3bd84d6208044a87aa2ce0abc72954",
   "schema_version": "leadpoet.validator_protected_workflows.v2"
 }

--- a/validator_tee/host/protected_workflows_v2.py
+++ b/validator_tee/host/protected_workflows_v2.py
@@ -62,6 +62,8 @@ PROTECTED_SYMBOLS = {
     "leadpoet_canonical/auditor_v2.py": (
         "verify_attested_weight_bundle_v2",
         "verify_attested_weight_authority_v2",
+        "verify_published_weight_authority_stage_v2",
+        "_verify_publication_and_finalization",
     ),
     "validator_tee/enclave/weight_authority_v2.py": (
         "ValidatorWeightAuthorityV2.compute",


### PR DESCRIPTION
## Why

Auditors act only on fully **finalized** authority, and the primary's finalization completes shortly after each epoch boundary — so auditors run one epoch behind by construction (+1 lag). This PR makes auditors submit **within the same epoch** as the primary, one to two minutes after its publication.

## Trust-model decision (explicit)

Endorse-at-publication vs endorse-at-inclusion. The staged view exposes the enclave-signed bundle plus the durable gateway publication — everything the auditor verifies cryptographically (enclave signatures, boot identities against independent COMPLIANCE-locked release evidence, receipt graphs, event hashes) exists at publication time. The only stage-dependent element is the finalized-chain proof, which is attached the moment it exists and verified whenever present. Divergence between what the primary published and what it lands on-chain remains covered by the existing soft equivocation check two epochs back, now with indelible signed evidence on both sides.

## What

- **Store** (`attested_v2_store.load_weight_authority_v2`): new `require_finalization` flag. Default `True` returns the historical payload byte-identically (existing consumers untouched). `False` returns a staged payload: `authority_stage: "published"` (bundle + publication, `finalization: null`) upgrading to `"finalized"` with the full proof.
- **Gateway**: new route `GET /weights/v2/published/{netuid}/{epoch_id}` serving the staged view. `/v2/latest` contract unchanged.
- **Canonical** (`auditor_v2`): verification refactored into shared bundle+publication checks and a finalization tail. `verify_attested_weight_authority_v2` is composed of both — behavior unchanged. New `verify_published_weight_authority_stage_v2` verifies staged authority with strict stage gating (published must not carry a proof; finalized must). Both entrypoints and the shared tail are protected workflow symbols; the attestation-time certificate guarantee test now asserts the setting in the shared tail and that both entrypoints route through it (strengthened, not weakened).
- **Auditor**: fetches the staged route first, falls back to `/v2/latest` when the gateway predates it (both rollout orders safe), and dispatches verification on the stage. Epoch/netuid binding, candidate selection, live-epoch staleness guard, and equivocation records are unchanged.
- **Protected workflow manifest** regenerated in a separate commit pinned to the code commit, per convention.

## Verification

- 60/60 across `test_auditor_same_epoch_mirroring.py` (new: stage gating ×5, store shapes ×3, fetch preference/fallback/absent ×3, verify dispatch), `test_auditor_v2_hardening.py`, `test_auditor_validator_v2_runtime.py`, `test_validator_protected_workflows_v2.py`.
- `py_compile` clean across all four touched modules.

## Rollout

Gateway redeploy (route + store) and auditor operator restarts; order-independent thanks to the fallback. Canonical changes alter validator EIF content — normal PCR0/release automation applies. Expected behavior after both sides update: primary publishes at ~epoch block 345–355, auditors verify and submit the same epoch ~1–2 minutes later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)