### PR TITLE
Point protected workflow provenance at the rebased mirroring commit

### DIFF
--- a/validator_tee/enclave/protected_workflows_v2.json
+++ b/validator_tee/enclave/protected_workflows_v2.json
@@ -282,7 +282,7 @@
       "symbol": "normalize_weight_protocol"
     }
   ],
-  "manifest_hash": "sha256:933941da39bb7903a184b00f2323728981702b6385f34fb6556d0dfb0ec3a4ca",
-  "protected_source_commit": "e49dfbef1b3bd84d6208044a87aa2ce0abc72954",
+  "manifest_hash": "sha256:7e47ca3daa9e84d7155fe135832893ff939bfa4bfbfcde5d3e8061d6d641b6f0",
+  "protected_source_commit": "cd3edcb504fba140b0159155f77df882d583ee96",
   "schema_version": "leadpoet.validator_protected_workflows.v2"
 }


### PR DESCRIPTION
Post-rebase housekeeping for the staged-mirroring merge: the committed manifest's `protected_source_commit` references the pre-rebase branch commit, which fresh CI clones cannot resolve (`git cat-file -e` in `test_committed_validator_protected_manifest_matches_source` fails). AST entries are byte-identical — file content did not change in the rebase — so this only moves provenance to `cd3edcb5`, the commit that landed on main. Manifest regenerated with the standard tooling; suite green locally (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)