### PR TITLE
Retry transient edge failures on weight-critical Supabase reads

### DIFF
--- a/gateway/research_lab/store.py
+++ b/gateway/research_lab/store.py
@@ -17,6 +17,96 @@ from research_lab.canonical import sha256_json
 
 logger = logging.getLogger(__name__)
 
+# A read on the weight-critical path (allocation graph, publication,
+# finalization) that hits a transient edge/proxy failure — a Cloudflare or
+# gateway 5xx/timeout in front of Supabase, or a dropped connection — must
+# not burn a whole 72-minute epoch. These are idempotent reads, so a bounded
+# retry is safe. The classifier is an allowlist: anything that is not a
+# recognized transient propagates immediately, exactly as before, so genuine
+# query-logic errors still fail closed.
+_TRANSIENT_READ_ATTEMPTS = 4
+_TRANSIENT_READ_BACKOFF_SECONDS = (0.25, 0.75, 1.5)
+_TRANSIENT_ERROR_SIGNATURES = (
+    "cloudflare",
+    "<html",
+    "json could not be generated",
+    "bad gateway",
+    "gateway time-out",
+    "gateway timeout",
+    "service temporarily unavailable",
+    "temporarily unavailable",
+    "connection reset",
+    "connection aborted",
+    "connection refused",
+    "server disconnected",
+    "timed out",
+    "timeout",
+)
+_TRANSIENT_ERROR_TYPE_SIGNATURES = (
+    "timeout",
+    "connection",
+    "connecterror",
+    "readerror",
+    "remoteprotocol",
+    "serverdisconnected",
+)
+
+
+def _is_transient_read_error(exc: BaseException) -> bool:
+    """Return whether a read failure is a retryable edge/network transient.
+
+    Fail-safe: only a recognized transient returns True. An unknown error —
+    including a genuine PostgREST/Postgres query error — returns False and
+    propagates unchanged.
+    """
+
+    type_name = type(exc).__name__.lower()
+    if any(token in type_name for token in _TRANSIENT_ERROR_TYPE_SIGNATURES):
+        return True
+    message = str(getattr(exc, "message", "") or "").lower()
+    detail = str(exc).lower()
+    haystack = message + "\n" + detail
+    # A genuine PostgREST logic error carries a SQLSTATE or PGRST code; never
+    # retry those even if some transient token also appears in the payload.
+    code = str(getattr(exc, "code", "") or "").strip().lower()
+    edge_codes = {"408", "429", "500", "502", "503", "504", "520", "521", "522", "523", "524"}
+    if code in edge_codes:
+        return True
+    if code and code not in edge_codes and (code.startswith("pgrst") or len(code) == 5):
+        return False
+    return any(token in haystack for token in _TRANSIENT_ERROR_SIGNATURES)
+
+
+async def _execute_read_with_retry(call, *, label: str):
+    """Run an idempotent PostgREST read, retrying only transient failures."""
+
+    last_exc: BaseException | None = None
+    for attempt in range(_TRANSIENT_READ_ATTEMPTS):
+        try:
+            return await asyncio.to_thread(call)
+        except Exception as exc:  # noqa: BLE001 - reclassified below
+            if not _is_transient_read_error(exc) or attempt == (
+                _TRANSIENT_READ_ATTEMPTS - 1
+            ):
+                raise
+            last_exc = exc
+            backoff = _TRANSIENT_READ_BACKOFF_SECONDS[
+                min(attempt, len(_TRANSIENT_READ_BACKOFF_SECONDS) - 1)
+            ]
+            logger.warning(
+                "transient_read_retry label=%s attempt=%s/%s type=%s error=%s",
+                label,
+                attempt + 1,
+                _TRANSIENT_READ_ATTEMPTS,
+                type(exc).__name__,
+                str(exc)[:160],
+            )
+            await asyncio.sleep(backoff)
+    # Unreachable: the loop either returns or raises, but keep mypy honest.
+    assert last_exc is not None
+    raise last_exc
+
+
 
 RESEARCH_LAB_UUID_NAMESPACE = uuid5(NAMESPACE_URL, "leadpoet:research_lab:gateway")
 
@@ -163,7 +253,9 @@ async def select_one(
         query = _apply_filters(query, filters)
         return query.limit(1).execute()
 
-    response = await asyncio.to_thread(_call)
+    response = await _execute_read_with_retry(
+        _call, label="select_one:%s" % table
+    )
     data = getattr(response, "data", None) or []
     return dict(data[0]) if data else None
 
@@ -183,7 +275,9 @@ async def select_many(
             query = query.order(field, desc=desc)
         return query.limit(limit).execute()
 
-    response = await asyncio.to_thread(_call)
+    response = await _execute_read_with_retry(
+        _call, label="select_many:%s" % table
+    )
     return [dict(row) for row in (getattr(response, "data", None) or [])]
 
 
@@ -214,7 +308,9 @@ async def select_all(
                 query = query.order(field, desc=desc)
             return query.range(offset, end).execute()
 
-        response = await asyncio.to_thread(_call)
+        response = await _execute_read_with_retry(
+            _call, label="select_all:%s" % table
+        )
         batch = [dict(row) for row in (getattr(response, "data", None) or [])]
         rows.extend(batch)
         if len(batch) < batch_size:

--- a/tests/test_store_transient_read_retry.py
+++ b/tests/test_store_transient_read_retry.py
@@ -1,0 +1,141 @@
+"""Weight-critical reads retry transient edge failures, not logic errors.
+
+A single Cloudflare/Supabase-edge 5xx or a dropped connection during the
+3-minute weight-submission window previously burned the whole 72-minute
+epoch (observed at epoch 24085: PostgREST returned a Cloudflare 400
+"JSON could not be generated" mid-window). These reads are idempotent, so a
+bounded retry is safe. The classifier is an allowlist: genuine query errors
+still fail closed with no extra attempts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from gateway.research_lab import store
+
+
+class _CloudflareEdgeError(Exception):
+    """Shaped like postgrest APIError for a Cloudflare edge rejection."""
+
+    def __init__(self):
+        super().__init__(
+            "{'message': 'JSON could not be generated', 'code': 400, "
+            "'details': '<html><center>cloudflare</center></html>'}"
+        )
+        self.message = "JSON could not be generated"
+        self.code = 400
+
+
+class _PostgrestLogicError(Exception):
+    """A genuine PostgREST/Postgres query error (SQLSTATE)."""
+
+    def __init__(self):
+        super().__init__("column foo does not exist")
+        self.message = "column foo does not exist"
+        self.code = "42703"
+
+
+class _ConnectionResetError(Exception):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch):
+    async def _no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(store.asyncio, "sleep", _no_sleep)
+
+
+def test_transient_classifier_allowlist():
+    assert store._is_transient_read_error(_CloudflareEdgeError()) is True
+    assert store._is_transient_read_error(_ConnectionResetError()) is True
+    assert store._is_transient_read_error(TimeoutError("timed out")) is True
+    # Genuine logic errors and unknown errors must not be retried.
+    assert store._is_transient_read_error(_PostgrestLogicError()) is False
+    assert store._is_transient_read_error(ValueError("bad input")) is False
+
+
+def test_retry_recovers_from_transient_then_succeeds(monkeypatch):
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _CloudflareEdgeError()
+        return "ok"
+
+    result = asyncio.run(
+        store._execute_read_with_retry(flaky, label="test")
+    )
+    assert result == "ok"
+    assert calls["n"] == 3
+
+
+def test_retry_exhausts_and_raises_last_transient(monkeypatch):
+    calls = {"n": 0}
+
+    def always_transient():
+        calls["n"] += 1
+        raise _ConnectionResetError()
+
+    with pytest.raises(_ConnectionResetError):
+        asyncio.run(
+            store._execute_read_with_retry(always_transient, label="test")
+        )
+    assert calls["n"] == store._TRANSIENT_READ_ATTEMPTS
+
+
+def test_logic_error_is_not_retried(monkeypatch):
+    calls = {"n": 0}
+
+    def logic_error():
+        calls["n"] += 1
+        raise _PostgrestLogicError()
+
+    with pytest.raises(_PostgrestLogicError):
+        asyncio.run(
+            store._execute_read_with_retry(logic_error, label="test")
+        )
+    assert calls["n"] == 1
+
+
+def test_select_one_retries_through_helper(monkeypatch):
+    attempts = {"n": 0}
+
+    class _Resp:
+        data = [{"id": 7}]
+
+    def fake_call():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise _CloudflareEdgeError()
+        return _Resp()
+
+    # Patch the write client so the inner _call raises/returns deterministically.
+    class _Query:
+        def select(self, *_a, **_k):
+            return self
+
+        def eq(self, *_a, **_k):
+            return self
+
+        def limit(self, *_a, **_k):
+            return self
+
+        def execute(self):
+            return fake_call()
+
+    class _Client:
+        def table(self, *_a, **_k):
+            return _Query()
+
+    monkeypatch.setattr(store, "get_write_client", lambda: _Client())
+    monkeypatch.setattr(store, "_apply_filters", lambda q, _f: q)
+
+    row = asyncio.run(store.select_one("t", filters=(("id", 7),)))
+    assert row == {"id": 7}
+    assert attempts["n"] == 2


### PR DESCRIPTION
## Why

Epoch 24085's weight submission was lost to infrastructure, not a code gate. The primary's input-assembly read (`load_business_artifact_graph_v2` → `store.select_all`) hit a Cloudflare `400 'JSON could not be generated'` in front of Supabase during the 3-minute submission window:

```
authoritative_weight_inputs_v2_failed epoch=24085 type=APIError
error={'message': 'JSON could not be generated', 'code': 400, ...cloudflare...}
```

Both in-window retries caught the same brief edge blip, so no bundle was built and auditors correctly had nothing to mirror. The underlying row read back cleanly seconds later — pure transient. Under the current no-retry read helpers, a single edge hiccup anywhere in input assembly costs a full 72-minute epoch.

## What

Wrap the three idempotent read helpers (`select_one`, `select_all`, `select_many`) in a bounded transient retry: 4 attempts, 0.25/0.75/1.5s backoff. The classifier is a strict **allowlist** — it retries only recognized transients (Cloudflare/gateway 5xx, edge 4xx 408/429, `JSON could not be generated`, HTML error bodies, dropped connections, timeouts). Anything carrying a PostgREST/SQLSTATE code, or any unrecognized error, returns `False` and propagates immediately with no extra attempts — so genuine query-logic failures (missing column, RLS denial, ambiguous lineage) still fail closed exactly as today. Writes are untouched.

## Verification

- `tests/test_store_transient_read_retry.py` (5): classifier allowlist (transient vs logic vs unknown), recover-then-succeed, exhaust-and-raise, logic-error-not-retried (single attempt), and `select_one` retrying end-to-end through the helper. Green locally.
- `py_compile` clean.

## Scope note

This does not change any verification, signing, or write path — only makes weight-critical **reads** resilient to edge transients. It is complementary to the epoch-survival and same-epoch-mirroring work already merged; none of those addressed a read-time infra transient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)