### PR TITLE
Route validator boots to dynamic PCR0 in the release-lineage verifier

### DIFF
--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -542,7 +542,7 @@
       "symbol": "ProviderSemanticsAuthorityV2"
     },
     {
-      "ast_sha256": "sha256:593dc0abb3879bf347c5d1d93835d78056f377ea05364659c074b9f1ce02ad04",
+      "ast_sha256": "sha256:c15b3ef889b600bbc91f936000f9a70d436ccccfa78649ddd6c7eeeb5aef118d",
       "path": "gateway/tee/release_lineage_v2.py",
       "symbol": "build_release_lineage_boot_verifier_v2"
     },
@@ -1082,7 +1082,7 @@
       "symbol": "validate_source_add_reward_record"
     }
   ],
-  "manifest_hash": "sha256:7b12a0e33012ff8d8f1ee1bc3a41813844248d949af90f2883e81863054f3884",
+  "manifest_hash": "sha256:847676eb9faa38d37778e74c87e251eb8228533290c9f9ee414331521099999d",
   "protected_source_commit": "691ae345faad920031f0e9ea2c6d37520259f412",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/release_lineage_v2.py
+++ b/gateway/tee/release_lineage_v2.py
@@ -24,14 +24,56 @@ class ReleaseLineageV2Error(RuntimeError):
     """A receipt ancestor is not bound to an approved V2 release."""
 
 
+# Validator enclaves are built dynamically from Git and verified against the
+# gateway's reproducible PCR0 build cache, not against a six-build gateway
+# release channel. Receipt ancestry legitimately mixes gateway and validator
+# boots (an allocation graph now embeds the finalized weight receipt ancestry,
+# which carries the validator boot), so validator boots must be routed to
+# dynamic PCR0 verification instead of a gateway release-role expectation.
+_VALIDATOR_PHYSICAL_ROLE = "validator_weights"
+
+
+def _is_gateway_release_boot(identity: Mapping[str, Any]) -> bool:
+    return str(identity.get("physical_role") or "") != _VALIDATOR_PHYSICAL_ROLE
+
+
+def _verify_validator_dynamic_boot(identity: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Verify a validator boot via the gateway's dynamic PCR0 build cache.
+
+    Mirrors the authoritative weight-submission boot check so scoring and
+    submission apply identical trust to the same validator boot identity.
+    """
+
+    from gateway.utils.pcr0_builder import verify_pcr0
+
+    rebuilt = verify_pcr0(str(identity.get("pcr0") or ""))
+    if not rebuilt.get("valid"):
+        raise ReleaseLineageV2Error(
+            "validator PCR0 is absent from the dynamic Git build cache"
+        )
+    if str(rebuilt.get("commit_hash") or "").lower() != str(
+        identity.get("commit_sha") or ""
+    ).lower():
+        raise ReleaseLineageV2Error(
+            "validator PCR0 commit differs from boot identity"
+        )
+    return verify_boot_identity_nitro(
+        identity,
+        expected_pcr0=str(identity.get("pcr0") or ""),
+        certificate_validity_at_attestation_time=True,
+    )
+
+
 def _required_commits(
     parent_graphs: Sequence[Mapping[str, Any]],
 ) -> set[str]:
+    # Only gateway boots require an approved gateway release channel; validator
+    # boots are verified out of band via dynamic PCR0.
     commits = {
         str(identity.get("commit_sha") or "").lower()
         for graph in parent_graphs
         for identity in graph.get("boot_identities") or ()
-        if isinstance(identity, Mapping)
+        if isinstance(identity, Mapping) and _is_gateway_release_boot(identity)
     }
     if "" in commits:
         raise ReleaseLineageV2Error(
@@ -125,6 +167,10 @@ def build_release_lineage_boot_verifier_v2(
     }
 
     def verify(identity: Mapping[str, Any]) -> Mapping[str, Any]:
+        if not _is_gateway_release_boot(identity):
+            # Validator boots in mixed receipt ancestry verify via the
+            # gateway's dynamic PCR0 build cache, not a gateway release role.
+            return _verify_validator_dynamic_boot(identity)
         commit = str(identity.get("commit_sha") or "").lower()
         release = approved.get(commit)
         if release is None:

--- a/tests/test_release_lineage_v2.py
+++ b/tests/test_release_lineage_v2.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import subprocess
+import types
 import sys
 
 import pytest
@@ -153,3 +154,113 @@ def test_lineage_verifier_accepts_historical_release_and_rejects_drift(
 
     with pytest.raises(ReleaseLineageV2Error, match="dependency_lock_hash"):
         verifier({**identity, "dependency_lock_hash": _hash("9")})
+
+
+def _validator_identity(commit_char="a"):
+    # Validator boots are dynamically built from Git; they carry no gateway
+    # release role and are verified via the gateway's PCR0 build cache.
+    return {
+        "physical_role": "validator_weights",
+        "commit_sha": commit_char * 40,
+        "pcr0": "9" * 96,
+        "boot_identity_hash": "sha256:" + "7" * 64,
+        "build_manifest_hash": "sha256:" + "b" * 64,
+        "dependency_lock_hash": "sha256:" + "c" * 64,
+    }
+
+
+def test_required_commits_excludes_validator_boots():
+    # Regression: an allocation graph embeds finalized weight receipt
+    # ancestry, which carries a validator boot. That validator commit must
+    # not require a gateway release channel (it has none), or the whole
+    # gateway wedges at startup with "unknown release role".
+    gateway = _release("1")
+    graphs = (
+        {
+            "boot_identities": [
+                _identity(gateway, role="gateway_scoring"),
+                _validator_identity(),
+            ]
+        },
+    )
+    commits = release_lineage_v2._required_commits(graphs)
+    assert gateway["roles"]["gateway_scoring"]["commit_sha"] in commits
+    assert _validator_identity()["commit_sha"] not in commits
+
+
+def test_load_lineage_ignores_validator_commit(monkeypatch):
+    gateway = _release("1")
+    calls = []
+
+    def load(commit):
+        calls.append(commit)
+        raise AssertionError("validator commit must never hit the channel loader")
+
+    releases = load_approved_release_lineage_v2(
+        current_release=gateway,
+        parent_graphs=({"boot_identities": [_validator_identity()]},),
+        release_channel_loader=load,
+    )
+    assert set(releases) == {"1" * 40}
+    assert calls == []
+
+
+def test_verifier_routes_validator_boot_to_dynamic_pcr0(monkeypatch):
+    gateway = _release("1")
+    validator = _validator_identity()
+    seen = {}
+
+    def _verify_pcr0(pcr0):
+        seen["pcr0"] = pcr0
+        return {"valid": True, "commit_hash": validator["commit_sha"]}
+
+    fake_pcr0 = types.ModuleType("gateway.utils.pcr0_builder")
+    fake_pcr0.verify_pcr0 = _verify_pcr0
+    monkeypatch.setitem(sys.modules, "gateway.utils.pcr0_builder", fake_pcr0)
+
+    nitro = []
+    monkeypatch.setattr(
+        release_lineage_v2,
+        "verify_boot_identity_nitro",
+        lambda identity, *, expected_pcr0, certificate_validity_at_attestation_time: nitro.append(
+            (expected_pcr0, certificate_validity_at_attestation_time)
+        )
+        or {"verified": True},
+    )
+
+    verifier = build_release_lineage_boot_verifier_v2(
+        {gateway["commit_sha"]: gateway}
+    )
+    assert verifier(validator) == {"verified": True}
+    assert seen["pcr0"] == validator["pcr0"]
+    assert nitro == [(validator["pcr0"], True)]
+
+
+def test_verifier_validator_boot_fails_closed_when_pcr0_absent(monkeypatch):
+    gateway = _release("1")
+    fake_pcr0 = types.ModuleType("gateway.utils.pcr0_builder")
+    fake_pcr0.verify_pcr0 = lambda _pcr0: {"valid": False}
+    monkeypatch.setitem(sys.modules, "gateway.utils.pcr0_builder", fake_pcr0)
+
+    verifier = build_release_lineage_boot_verifier_v2(
+        {gateway["commit_sha"]: gateway}
+    )
+    with pytest.raises(ReleaseLineageV2Error, match="dynamic Git build cache"):
+        verifier(_validator_identity())
+
+
+def test_verifier_validator_boot_rejects_commit_mismatch(monkeypatch):
+    gateway = _release("1")
+    validator = _validator_identity()
+    fake_pcr0 = types.ModuleType("gateway.utils.pcr0_builder")
+    fake_pcr0.verify_pcr0 = lambda _pcr0: {
+        "valid": True,
+        "commit_hash": "f" * 40,
+    }
+    monkeypatch.setitem(sys.modules, "gateway.utils.pcr0_builder", fake_pcr0)
+
+    verifier = build_release_lineage_boot_verifier_v2(
+        {gateway["commit_sha"]: gateway}
+    )
+    with pytest.raises(ReleaseLineageV2Error, match="commit differs"):
+        verifier(validator)


### PR DESCRIPTION
## Production impact

The gateway is **down** — `gw_restart` loops and never binds `:8000`. Its pre-launch gate `verify_weight_submission_ready_v2` calls the attested-allocation endpoint, which now fails with:

```
gateway.tee.release_manifest_v2.ReleaseManifestV2Error: unknown release role
```

## Root cause

This is the next fail-closed gate exposed by the allocation-ambiguity fix (`02abc8b2`). With ambiguity resolved, the endpoint proceeds far enough to verify the **full receipt ancestry** of `build_allocation_v2` → `execute_scoring_v2`. That ancestry now embeds finalized weight receipts (via allocation-history binding + weight-execution-receipt ancestry preservation), whose graphs carry a **`validator_weights` boot**.

`build_release_lineage_boot_verifier_v2` treated every ancestry boot as a gateway release role and called `role_expectation(release, "validator_weights")` → `unknown release role` (the only three gateway roles are `gateway_coordinator`, `gateway_scoring`, `gateway_autoresearch`; confirmed against the live boot-identity table, where the only non-gateway role is `validator_weights`). Separately, `_required_commits` collected the validator commit and `load_approved_release_lineage_v2` would try to fetch a gateway release channel that does not exist for it.

## Fix

Validator enclaves are built dynamically from Git and verified against the gateway's reproducible **PCR0 build cache**, not a six-build gateway release channel. Branch validator boots accordingly in `release_lineage_v2`, mirroring the established `/weights/submit/v2` boot check (`_verify_authoritative_v2_boot`):

- `_required_commits` excludes validator boots — no gateway release channel is required or fetched for their commit.
- the lineage boot verifier routes validator boots to dynamic PCR0 verification (`verify_pcr0` cache membership + commit match) followed by the same issuance-time Nitro attestation check gateway boots get.

Gateway-boot verification is byte-for-byte unchanged. Unknown validator PCR0 or a commit mismatch still fails closed.

## Verification

- `tests/test_release_lineage_v2.py` +5: validator commit excluded from required channels; loader never hit for a validator commit; verifier routes validator boot to dynamic PCR0 + Nitro; fails closed on absent PCR0; rejects commit mismatch. Existing gateway-lineage tests unchanged and green (14 passed).
- `tests/test_protected_workflows.py` green — regenerated the gateway protected-workflow manifest for the one changed AST (`build_release_lineage_boot_verifier_v2`).
- Standalone repro of the exact production crash path (mixed gateway+validator ancestry) passes on this branch.

## Deploy note

Gateway-only change (parent-process verifier). Needs merge + a gateway restart; no validator rebuild. A restart alone will re-wedge until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)