### PR TITLE
Reduce Research Lab worker egress: batched provider-usage ledger inserts (+ plan)

### DIFF
--- a/gateway/research_lab/trajectory_projector.py
+++ b/gateway/research_lab/trajectory_projector.py
@@ -284,6 +284,11 @@ class GatewayProjectorStore:
 
         return await store.update_row(table, values, filters=filters)
 
+    async def call_rpc(self, function_name: str, params: Mapping[str, Any]):
+        from gateway.research_lab import store
+
+        return await store.call_rpc(function_name, params)
+
 
 def _deterministic_uuid(*parts: Any) -> str:
     from gateway.research_lab.store import deterministic_uuid
@@ -4031,6 +4036,89 @@ async def _insert_provider_usage_ledger_row(
         return False
 
 
+_PROVIDER_USAGE_LEDGER_COLUMNS = (
+    "usage_row_id",
+    "schema_version",
+    "utc_day",
+    "recorded_at",
+    "provider_id",
+    "endpoint_class",
+    "request_fingerprint",
+    "evidence",
+    "status",
+    "est_cost_microusd",
+    "caller_doc",
+)
+
+
+def _json_safe_ledger_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Project a ledger row to its known JSON-serializable columns.
+
+    ``recorded_at`` is already an ISO string and ``caller_doc`` a dict in the
+    projector's build path; datetimes are coerced defensively so the RPC's
+    JSON payload never fails to serialize.
+    """
+    safe: dict[str, Any] = {}
+    for column in _PROVIDER_USAGE_LEDGER_COLUMNS:
+        value = row.get(column)
+        if hasattr(value, "isoformat"):
+            value = value.isoformat()
+        safe[column] = value
+    return safe
+
+
+def _batch_inserted_count(result: Any) -> int:
+    """Extract the inserted-row count from the batch-insert RPC response."""
+    payload = result
+    if isinstance(payload, list):
+        payload = payload[0] if payload else {}
+    if isinstance(payload, Mapping):
+        try:
+            return int(payload.get("inserted") or 0)
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+async def _insert_provider_usage_ledger_rows_batch(
+    store: Any, rows: Sequence[Mapping[str, Any]]
+) -> int:
+    """Conflict-safe batched insert of provider-usage ledger rows.
+
+    Replaces the per-row existence-check + insert (~13.28M weekly PostgREST
+    requests) with one server-side ``INSERT ... ON CONFLICT (usage_row_id)
+    DO NOTHING``. The rows carry deterministic PKs, so the removed existence
+    checks changed no outcome — only request volume. Returns the number of
+    newly-inserted rows.
+
+    Falls back to the per-row path for injected stores that do not expose
+    ``call_rpc`` (test fakes), preserving existing behavior exactly.
+    """
+    candidate_rows = [dict(row) for row in rows if row.get("usage_row_id")]
+    if not candidate_rows:
+        return 0
+    if not hasattr(store, "call_rpc"):
+        written = 0
+        for row in candidate_rows:
+            if await _insert_provider_usage_ledger_row(store, row):
+                written += 1
+        return written
+    payload = [_json_safe_ledger_row(row) for row in candidate_rows]
+    try:
+        result = await store.call_rpc(
+            "insert_research_lab_provider_usage_ledger_rows",
+            {"rows": payload},
+        )
+    except Exception as exc:
+        logger.warning(
+            "research_lab_provider_usage_ledger_batch_insert_failed count=%s error=%s",
+            len(candidate_rows),
+            str(exc)[:300],
+        )
+        return 0
+    return _batch_inserted_count(result)
+
+
 async def _write_missing_corpus_trace_rows(
     store: Any, projection: TrajectoryProjection
 ) -> tuple[int, int, int]:
@@ -4045,10 +4133,9 @@ async def _write_missing_corpus_trace_rows(
         evidence_status = await _upsert_evidence_bundle_row(store, row)
         if evidence_status in {"inserted", "updated"}:
             evidence_written += 1
-    provider_usage_written = 0
-    for row in projection.provider_usage_ledger_rows:
-        if await _insert_provider_usage_ledger_row(store, row):
-            provider_usage_written += 1
+    provider_usage_written = await _insert_provider_usage_ledger_rows_batch(
+        store, projection.provider_usage_ledger_rows
+    )
     return trace_changed, evidence_written, provider_usage_written
 
 
@@ -4457,17 +4544,30 @@ async def backfill_run_corpus_trace_rows(
             for row in projection.evidence_bundle_rows
             if await _evidence_bundle_row_needs_write(store, row)
         ]
-        missing_provider_usage = [
-            row
-            for row in projection.provider_usage_ledger_rows
-            if await _provider_usage_ledger_row_needs_write(store, row)
-        ]
+        # Provider-usage rows: the write path uses one conflict-safe batched
+        # insert (the dominant weekly egress source), replacing per-row
+        # existence-check + insert. Dry-run must not write, so it counts the
+        # missing rows read-only (dry-run is a rare, manual path).
+        if dry_run:
+            missing_provider_usage = [
+                row
+                for row in projection.provider_usage_ledger_rows
+                if await _provider_usage_ledger_row_needs_write(store, row)
+            ]
+            provider_usage_written = 0
+            provider_usage_pending = bool(missing_provider_usage)
+        else:
+            missing_provider_usage = []
+            provider_usage_written = await _insert_provider_usage_ledger_rows_batch(
+                store, projection.provider_usage_ledger_rows
+            )
+            provider_usage_pending = provider_usage_written > 0
         if not (
             missing_events
             or missing_ledger
             or missing_traces
             or missing_evidence
-            or missing_provider_usage
+            or provider_usage_pending
         ):
             return ProjectionResult(
                 run_id=run_id, status="skipped_traces_existing", trajectory_id=tid
@@ -4506,10 +4606,7 @@ async def backfill_run_corpus_trace_rows(
             evidence_status = await _upsert_evidence_bundle_row(store, row)
             if evidence_status in {"inserted", "updated"}:
                 evidence_written += 1
-        provider_usage_written = 0
-        for row in missing_provider_usage:
-            if await _insert_provider_usage_ledger_row(store, row):
-                provider_usage_written += 1
+        # provider_usage_written was computed above via the batched insert.
         logger.info(
             "research_lab_projection_backfilled run_id=%s trajectory_id=%s "
             "events=%s ledger_rows=%s execution_traces=%s evidence_bundles=%s "

--- a/scripts/115-research-lab-provider-usage-batch-insert.sql
+++ b/scripts/115-research-lab-provider-usage-batch-insert.sql
@@ -1,0 +1,101 @@
+-- Research Lab egress reduction: conflict-safe batched provider-usage ledger insert.
+--
+-- Today every projected provider-usage row costs one existence SELECT (in the
+-- project path) or two (in the backfill path) plus one INSERT. The rows are
+-- deterministic (PK usage_row_id is a uuid5 over run/event/provider/endpoint),
+-- so the existence checks add no correctness — only ~13.28M weekly PostgREST
+-- requests. This function replaces the per-row read+insert with a single
+-- set-based INSERT ... ON CONFLICT (usage_row_id) DO NOTHING.
+--
+-- Behavior preserved: the table is append-only (BEFORE UPDATE OR DELETE
+-- trigger). ON CONFLICT DO NOTHING performs only INSERTs, so the append-only
+-- guard is not triggered, and previously-written rows are left byte-identical.
+-- The projector's in-memory dedup and deterministic PKs make DO NOTHING exactly
+-- equivalent to the old skip-if-exists behavior.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.insert_research_lab_provider_usage_ledger_rows(
+    rows JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    inserted_ids UUID[];
+    requested_count INTEGER;
+BEGIN
+    -- Fail closed on a malformed batch rather than silently dropping rows.
+    IF rows IS NULL OR pg_catalog.jsonb_typeof(rows) <> 'array' THEN
+        RAISE EXCEPTION 'provider usage ledger batch must be a JSON array'
+            USING ERRCODE = '22023';
+    END IF;
+
+    requested_count := pg_catalog.jsonb_array_length(rows);
+    IF requested_count = 0 THEN
+        RETURN pg_catalog.jsonb_build_object(
+            'requested', 0, 'inserted', 0, 'inserted_ids', '[]'::JSONB
+        );
+    END IF;
+    -- Bounded batch: the projector writes at most a few hundred rows per run.
+    IF requested_count > 5000 THEN
+        RAISE EXCEPTION 'provider usage ledger batch exceeds 5000 rows'
+            USING ERRCODE = '22023';
+    END IF;
+
+    WITH incoming AS (
+        SELECT * FROM pg_catalog.jsonb_to_recordset(rows) AS r(
+            usage_row_id        UUID,
+            schema_version      TEXT,
+            utc_day             TEXT,
+            recorded_at         TIMESTAMPTZ,
+            provider_id         TEXT,
+            endpoint_class      TEXT,
+            request_fingerprint TEXT,
+            evidence            TEXT,
+            status              INTEGER,
+            est_cost_microusd   BIGINT,
+            caller_doc          JSONB
+        )
+    ),
+    ins AS (
+        INSERT INTO public.research_lab_provider_usage_ledger AS l (
+            usage_row_id, schema_version, utc_day, recorded_at, provider_id,
+            endpoint_class, request_fingerprint, evidence, status,
+            est_cost_microusd, caller_doc
+        )
+        SELECT
+            i.usage_row_id,
+            pg_catalog.coalesce(i.schema_version, '1.0'),
+            i.utc_day,
+            pg_catalog.coalesce(i.recorded_at, pg_catalog.now()),
+            i.provider_id,
+            pg_catalog.coalesce(i.endpoint_class, ''),
+            pg_catalog.coalesce(i.request_fingerprint, ''),
+            i.evidence,
+            pg_catalog.coalesce(i.status, 0),
+            pg_catalog.coalesce(i.est_cost_microusd, 0),
+            pg_catalog.coalesce(i.caller_doc, '{}'::JSONB)
+        FROM incoming i
+        WHERE i.usage_row_id IS NOT NULL
+        ON CONFLICT (usage_row_id) DO NOTHING
+        RETURNING l.usage_row_id
+    )
+    SELECT pg_catalog.array_agg(usage_row_id) INTO inserted_ids FROM ins;
+
+    RETURN pg_catalog.jsonb_build_object(
+        'requested', requested_count,
+        'inserted', pg_catalog.coalesce(pg_catalog.array_length(inserted_ids, 1), 0),
+        'inserted_ids', pg_catalog.to_jsonb(pg_catalog.coalesce(inserted_ids, ARRAY[]::UUID[]))
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.insert_research_lab_provider_usage_ledger_rows(JSONB)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.insert_research_lab_provider_usage_ledger_rows(JSONB)
+    TO service_role;
+
+COMMIT;

--- a/tests/test_provider_usage_batch_insert.py
+++ b/tests/test_provider_usage_batch_insert.py
@@ -1,0 +1,181 @@
+"""Regression tests for the conflict-safe batched provider-usage ledger insert.
+
+Egress reduction: the projector previously issued one existence SELECT (project
+path) or two (backfill path) plus one INSERT per provider-usage ledger row —
+the dominant weekly PostgREST volume. These tests pin that:
+  * the write path issues exactly ONE server-side RPC for a whole batch,
+  * the removed per-row existence reads are gone,
+  * behavior degrades to the old per-row path only for injected fakes without
+    call_rpc, and
+  * the SQL is conflict-safe (ON CONFLICT DO NOTHING), locked-down, and bounded.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import gateway.research_lab.trajectory_projector as tp
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = (
+    ROOT / "scripts" / "115-research-lab-provider-usage-batch-insert.sql"
+).read_text(encoding="utf-8")
+
+
+def _row(row_id: str, **overrides: Any) -> dict[str, Any]:
+    row = {
+        "usage_row_id": row_id,
+        "schema_version": "1.0",
+        "utc_day": "2026-07-22",
+        "recorded_at": "2026-07-22T00:00:00+00:00",
+        "provider_id": "exa",
+        "endpoint_class": "search",
+        "request_fingerprint": "fp",
+        "evidence": "hit",
+        "status": 0,
+        "est_cost_microusd": 12,
+        "caller_doc": {"worker": "scorer-1"},
+    }
+    row.update(overrides)
+    return row
+
+
+class _RpcStore:
+    """Fake store exposing call_rpc; records the single batch call."""
+
+    def __init__(self, inserted: int) -> None:
+        self.inserted = inserted
+        self.rpc_calls: list[tuple[str, dict[str, Any]]] = []
+        self.select_one_calls = 0
+        self.insert_calls = 0
+
+    async def call_rpc(self, function_name: str, params: dict[str, Any]) -> Any:
+        self.rpc_calls.append((function_name, params))
+        return {"requested": len(params["rows"]), "inserted": self.inserted}
+
+    async def select_one(self, *args: Any, **kwargs: Any) -> Any:
+        self.select_one_calls += 1
+        return None
+
+    async def insert_row(self, *args: Any, **kwargs: Any) -> Any:
+        self.insert_calls += 1
+        return {}
+
+
+class _PerRowStore:
+    """Fake store WITHOUT call_rpc: must fall back to per-row inserts."""
+
+    def __init__(self) -> None:
+        self.select_one_calls = 0
+        self.insert_calls = 0
+
+    async def select_one(self, *args: Any, **kwargs: Any) -> Any:
+        self.select_one_calls += 1
+        return None
+
+    async def insert_row(self, *args: Any, **kwargs: Any) -> Any:
+        self.insert_calls += 1
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_batch_insert_issues_one_rpc_for_the_whole_batch() -> None:
+    store = _RpcStore(inserted=3)
+    rows = [_row(f"{i:032d}") for i in range(3)]
+
+    written = await tp._insert_provider_usage_ledger_rows_batch(store, rows)
+
+    assert written == 3
+    # Exactly one server-side call for the whole batch — not one per row.
+    assert len(store.rpc_calls) == 1
+    name, params = store.rpc_calls[0]
+    assert name == "insert_research_lab_provider_usage_ledger_rows"
+    assert len(params["rows"]) == 3
+    # The removed per-row existence reads must not happen on the RPC path.
+    assert store.select_one_calls == 0
+    assert store.insert_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_batch_insert_skips_rows_without_a_primary_key() -> None:
+    store = _RpcStore(inserted=1)
+    rows = [_row("a" * 32), {"provider_id": "exa"}]  # second has no usage_row_id
+
+    await tp._insert_provider_usage_ledger_rows_batch(store, rows)
+
+    assert len(store.rpc_calls) == 1
+    assert len(store.rpc_calls[0][1]["rows"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_batch_insert_empty_is_a_noop() -> None:
+    store = _RpcStore(inserted=0)
+    assert await tp._insert_provider_usage_ledger_rows_batch(store, []) == 0
+    assert store.rpc_calls == []
+
+
+@pytest.mark.asyncio
+async def test_batch_insert_falls_back_to_per_row_without_call_rpc() -> None:
+    store = _PerRowStore()
+    rows = [_row(f"{i:032d}") for i in range(4)]
+
+    written = await tp._insert_provider_usage_ledger_rows_batch(store, rows)
+
+    # Fallback preserves the old per-row behavior exactly for injected fakes.
+    assert written == 4
+    assert store.insert_calls == 4
+
+
+@pytest.mark.asyncio
+async def test_batch_insert_returns_zero_and_does_not_raise_on_rpc_error() -> None:
+    class _Boom:
+        async def call_rpc(self, *args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError("edge blip")
+
+    written = await tp._insert_provider_usage_ledger_rows_batch(
+        _Boom(), [_row("f" * 32)]
+    )
+    assert written == 0
+
+
+def test_json_safe_row_projects_columns_and_coerces_datetime() -> None:
+    row = _row(
+        "d" * 32,
+        recorded_at=datetime.datetime(2026, 7, 22, tzinfo=datetime.timezone.utc),
+        extra_unknown_field="dropped",
+    )
+    safe = tp._json_safe_ledger_row(row)
+    assert set(safe) == set(tp._PROVIDER_USAGE_LEDGER_COLUMNS)
+    assert "extra_unknown_field" not in safe
+    assert isinstance(safe["recorded_at"], str)
+    assert safe["recorded_at"].startswith("2026-07-22T00:00:00")
+
+
+def test_batch_inserted_count_handles_dict_list_and_garbage() -> None:
+    assert tp._batch_inserted_count({"inserted": 5}) == 5
+    assert tp._batch_inserted_count([{"inserted": 2}]) == 2
+    assert tp._batch_inserted_count([]) == 0
+    assert tp._batch_inserted_count(None) == 0
+    assert tp._batch_inserted_count({"inserted": "bad"}) == 0
+
+
+def test_migration_is_conflict_safe_and_locked_down() -> None:
+    assert "ON CONFLICT (usage_row_id) DO NOTHING" in MIGRATION
+    assert "SECURITY DEFINER" in MIGRATION
+    assert "SET search_path = ''" in MIGRATION
+    assert (
+        "GRANT EXECUTE ON FUNCTION "
+        "public.insert_research_lab_provider_usage_ledger_rows(JSONB)\n"
+        "    TO service_role;" in MIGRATION
+    )
+    assert "FROM PUBLIC, anon, authenticated;" in MIGRATION
+    # Bounded batch + fail-closed on malformed input (no silent row drops).
+    assert "exceeds 5000 rows" in MIGRATION
+    assert "must be a JSON array" in MIGRATION
+    # Never UPDATEs (the table is append-only): the only write is a plain INSERT.
+    assert "UPDATE public.research_lab_provider_usage_ledger" not in MIGRATION


### PR DESCRIPTION
## Why

Research Lab worker egress is ~10× what it should be. The root causes (from the investigation) are **multiplicative**: N worker processes × per-pass global maintenance × per-row DB existence checks. This PR opens the fix with the **single largest observed endpoint** and lays out a precise, de-risked plan for the rest.

> "No bugs / no drawbacks acceptable." So this first commit is the one change that is unambiguously correct and highest-impact; the remaining items — several of which touch **reward selection**, **claim races**, or the **encrypted-proxy attestation path** — are specified below with their exact edit sites and risks so they can land as focused, individually-reviewable follow-ups rather than a sweeping rewrite.

## Shipped in this PR — batched, conflict-safe provider-usage ledger insert (the ~13.28M weekly-request endpoint)

`trajectory_projector.py` wrote provider-usage ledger rows **one at a time**, each costing an existence `SELECT` (project path) or **two** (backfill path) plus one `INSERT`. The rows carry deterministic PKs (`usage_row_id` is a uuid5 over run/event/provider/endpoint), so the existence checks changed **no outcome** — only request volume.

- New migration `scripts/115-…`: `insert_research_lab_provider_usage_ledger_rows(rows JSONB)` — one set-based `INSERT … ON CONFLICT (usage_row_id) DO NOTHING`. `SECURITY DEFINER`, `SET search_path=''`, granted only to `service_role`, bounded to 5000 rows, fail-closed on malformed input.
- The table's append-only trigger fires only on `UPDATE/DELETE`, so `DO NOTHING` (INSERT-only) is safe and previously-written rows are byte-identical.
- **Dry-run preserved**: dry-run counts missing rows read-only and writes nothing.
- **Backward-compatible**: injected stores without `call_rpc` (test fakes) fall back to the exact old per-row path.
- 8 new regression tests: one RPC per batch (not per row), zero per-row reads on the RPC path, PK-less rows skipped, empty no-op, error → 0 (no raise), JSON-safety/datetime coercion, count parsing, and SQL lockdown/conflict-safety. All existing trajectory tests still pass (40 total).

**Net effect on this path:** per-run provider-usage DB requests drop from `O(rows) reads + O(rows) inserts` to **one** RPC.

## Planned follow-ups (exact edit sites + risk, from the subsystem investigation)

Ordered by impact ÷ risk. Each is independently shippable.

1. **Trajectory discovery as a DB-side delta (`project_completed_runs` / `backfill_corpus_trace_rows`).** Today: download ≤5000 terminal runs, then one existence query per run. **Design note / risk:** `research_trajectories` has **no `run_id` column** — the join key `trajectory_id_for_run(run_id)` is a client-side uuid5. So the anti-join needs either (a) a `run_id` column added + backfilled to `research_trajectories` (then a trivial `LEFT JOIN … WHERE t.trajectory_id IS NULL LIMIT 25` RPC), or (b) exact uuid5 reproduction in plpgsql verified byte-for-byte against Python. (a) is safer. Preserve `_missing_trajectory_event_rows`'s fail-closed hash-drift guard.

2. **Decouple worker count from proxy count** (`worker_autostart.py:183`, `config.py:387`). Make `RESEARCH_LAB_HOSTED_WORKER_PROCESS_COUNT` / `RESEARCH_LAB_SCORING_WORKER_PROCESS_COUNT` authoritative (hard max 500), assign proxies round-robin at `_start_child`. **Risk:** the encrypted-proxy **TLS profile** lookup (`provider_profiles_v2.load_provider_profile_v2`) is keyed per contiguous `worker_index` `0..N-1`; round-robin workers past the proxy/profile count must have the profile lookup round-robin too, and `restart_preflight_v2.py:322` must relax `worker_count == profile_count` to `worker_count >= profile_count`. Also reconcile the env-name mismatch (`*_PROCESS_COUNT` vs `*_TOTAL_WORKERS`). This touches attested proxy provisioning — review carefully.

3. **Single-owner maintenance lease** (worker.py:1461 / `_run_periodic_reconciles`:1724). Move the 9 global sweeps behind **one DB-backed lease**, reusing the existing CAS-lease pattern (`global_icp_queue.py` `_cas_update` + `lease_expires_at` + `recover_stale_leases`). **Reward-critical:** `reconcile_pending_champion_rewards` and `reconcile_champion_reward_statuses` run here — gate *which* worker runs them (ops unchanged); fail-closed = they simply wait for a lease holder. Fold `_recover_stale_candidate_claims` / `_requeue_quarantined_candidates` under the same lease (item 5).

4. **Atomic candidate claim** (`scoring_worker.py:4929`). Replace `columns="*"` download-50 + re-read + append + re-read with a `claim_next_research_lab_candidate(...)` RPC (`FOR UPDATE SKIP LOCKED`) returning only the ~19 columns scoring/promotion actually use. **Reward-critical:** must still write the `assigned` event with the same shape (the retry-budget accounting `_candidate_claim_attempt_count` and the `stale_gateway_scoring_retry_limit_exceeded` terminal path depend on it) and return `parent_artifact_hash`, `miner_hotkey`, `island`, the manifest docs, `receipt_id`, etc. The reward/weight hand-off keys off the later `scored` event + signed `research_evaluation_score_bundles` + `research_lab_candidate_promotion_events`, none of which the claim writes — so a correct atomic claim is reward-safe.

5. **Atomic hosted-run claim** (`worker.py:1701` `_next_queued_run`). Replace download-window-then-pick-locally with `claim_next_research_loop_run(...)` (mirror `global_icp_queue.claim_next_job`, honoring `queue_priority`/`current_status_at`), removing the read-check-write-recheck claim race.

6. **Dedup maintenance-control reads** (`maintenance.py:58`). Read each scope's `research_lab_gateway_control_current` **once per pass** and pass it into `preflight_gate`; preserve the fail-closed-on-Supabase-error (`paused=True`) and the `provider_preflight:` marker auto-resume fall-through.

7. **Idle backoff + jitter** — hosted/scoring poll 15 → 30 → 60s with jitter, reset on work; keep recovery/reward schedules independent of job polling.

8. **Trim `columns="*"`** on queue/candidate polling to the fields actually consumed.

9. **`get_chain_summaries(ids[])`** batching for `subnet71.com`'s three chain RPCs — **outside this repo**; the caller still needs locating.

## Regression-test coverage plan (per the request)

Included now: conflict-safe batch insert, one-request-per-batch. Follow-ups will add: 20 proxies ≠ 20 processes unless configured; exactly one maintenance-lease holder runs sweeps; idle request count flat as worker count grows; claim RPCs cannot double-assign a run/candidate; and champion rewards / reimbursements / score bundles / Research Lab emissions / validator weight mutation / on-chain submission remain intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPfUeW3DFtUKbrkXbqDr9u
