### PR TITLE
Recover fulfillment workers and enforce epoch authority

### DIFF
--- a/Leadpoet/utils/cloud_db.py
+++ b/Leadpoet/utils/cloud_db.py
@@ -2632,9 +2632,10 @@ def gateway_submit_fulfillment_scores(
     scores: List[Dict],
     validator_hotkey: str = "",
 ) -> bool:
-    """Submit fulfillment scores for a request (validator)."""
+    """Submit fulfillment scores or raise after all delivery attempts fail."""
     import uuid
     vhk = validator_hotkey or wallet.hotkey.ss58_address
+    last_err: Optional[Exception] = None
 
     for attempt in range(1, 4):
         try:
@@ -2659,13 +2660,21 @@ def gateway_submit_fulfillment_scores(
             bt.logging.info(f"Fulfillment scores submitted for {request_id[:8]}...")
             return True
         except Exception as e:
+            last_err = e
             if attempt < 3:
-                bt.logging.warning(f"Score submit attempt {attempt}/3 failed: {e}")
+                bt.logging.warning(
+                    "fulfillment_score_submit_retry "
+                    f"attempt={attempt}/3 error_type={type(e).__name__} error={e}"
+                )
                 time.sleep(2)
             else:
-                bt.logging.error(f"All 3 score submit attempts failed: {e}")
-                return False
-    return False
+                bt.logging.error(
+                    "fulfillment_score_submit_exhausted "
+                    f"attempts=3 error_type={type(e).__name__} error={e}"
+                )
+    raise RuntimeError(
+        f"Failed to submit fulfillment scores after 3 attempts: {last_err}"
+    ) from last_err
 
 
 def gateway_get_fulfillment_leaderboard_snapshot(

--- a/Leadpoet/utils/subnet_epoch.py
+++ b/Leadpoet/utils/subnet_epoch.py
@@ -21,6 +21,7 @@ import ipaddress
 import json
 import os
 from pathlib import Path
+import time
 from typing import Any, Mapping, Optional
 from urllib.parse import urlparse
 
@@ -28,6 +29,7 @@ from urllib.parse import urlparse
 EPOCH_SCHEME = "bittensor.subnet_epoch_index.v1"
 CUTOVER_SCHEMA_VERSION = "leadpoet.subnet_epoch_cutover.v1"
 SNAPSHOT_SCHEMA_VERSION = "leadpoet.subnet_epoch_snapshot.v1"
+VALIDATOR_SHARED_EPOCH_SCHEMA_VERSION = "leadpoet.validator_shared_epoch.v3"
 CUTOVER_JSON_ENV = "LEADPOET_SUBNET_EPOCH_CUTOVER_JSON"
 CUTOVER_PATH_ENV = "LEADPOET_SUBNET_EPOCH_CUTOVER_PATH"
 # The activated SN71 settlement mapping is public, immutable chain data.
@@ -432,6 +434,75 @@ class SubnetEpochSnapshot:
             "observed_at",
         }
         return cls(**{key: value[key] for key in allowed if key in value})
+
+
+def validate_validator_shared_epoch_file(
+    path: Any,
+    *,
+    max_age_seconds: int,
+    environ: Optional[Mapping[str, str]] = None,
+    cutover: Optional[SubnetEpochCutover] = None,
+) -> SubnetEpochSnapshot:
+    """Validate a coordinator-written worker epoch document without runtime imports."""
+
+    if environ is not None and cutover is not None:
+        raise ValueError("set only one of environ or cutover")
+    try:
+        document = json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SubnetEpochError("shared epoch file is unreadable") from exc
+
+    expected_fields = {
+        "schema_version",
+        "block",
+        "epoch",
+        "blocks_into_epoch",
+        "blocks_remaining",
+        "epoch_start_block",
+        "next_epoch_block",
+        "tempo",
+        "subnet_epoch_index",
+        "epoch_ref",
+        "authority",
+        "timestamp",
+    }
+    if not isinstance(document, dict) or set(document) != expected_fields:
+        raise SubnetEpochError("shared epoch file fields are invalid")
+    if document.get("schema_version") != VALIDATOR_SHARED_EPOCH_SCHEMA_VERSION:
+        raise SubnetEpochError("shared epoch file schema is unsupported")
+    try:
+        age = int(time.time()) - int(document["timestamp"])
+    except (TypeError, ValueError) as exc:
+        raise SubnetEpochError("shared epoch file timestamp is invalid") from exc
+    if age < -30 or age > int(max_age_seconds):
+        raise SubnetEpochError(f"shared epoch file is stale ({age}s old)")
+
+    authority = document.get("authority")
+    if not isinstance(authority, dict):
+        raise SubnetEpochError("shared official epoch authority is missing")
+    snapshot = SubnetEpochSnapshot.from_mapping(authority)
+    effective_cutover = cutover or load_subnet_epoch_cutover(environ)
+    if authority != snapshot.to_dict(cutover=effective_cutover):
+        raise SubnetEpochError(
+            "shared official epoch authority is not canonical"
+        )
+
+    observed = {
+        "block": snapshot.current_block,
+        "epoch": snapshot.settlement_epoch_id(effective_cutover),
+        "blocks_into_epoch": snapshot.epoch_block,
+        "blocks_remaining": snapshot.blocks_remaining,
+        "epoch_start_block": snapshot.last_epoch_block,
+        "next_epoch_block": snapshot.next_epoch_block,
+        "tempo": snapshot.tempo,
+        "subnet_epoch_index": snapshot.subnet_epoch_index,
+        "epoch_ref": snapshot.epoch_ref,
+    }
+    if any(document[key] != value for key, value in observed.items()):
+        raise SubnetEpochError("shared epoch file derived fields are inconsistent")
+    return snapshot
 
 
 def read_subnet_epoch_snapshot(

--- a/gateway/research_lab/worker_autostart.py
+++ b/gateway/research_lab/worker_autostart.py
@@ -13,6 +13,11 @@ import threading
 import time
 from typing import Mapping
 
+from Leadpoet.utils.subnet_epoch import (
+    SubnetEpochError,
+    load_subnet_epoch_cutover,
+)
+
 
 TRUTHY = {"1", "true", "yes", "on"}
 WORKER_READY_FD_ENV = "RESEARCH_LAB_WORKER_READY_FD"
@@ -20,6 +25,7 @@ WORKER_READY_FD_ENV = "RESEARCH_LAB_WORKER_READY_FD"
 
 class ResearchLabWorkerStartupError(RuntimeError):
     """An authoritative worker failed before entering its poll loop."""
+
 
 HOSTED_PROXY_PREFIXES = (
     "RESEARCH_LAB_AUTO_RESEARCH_WEBSHARE_PROXY",
@@ -92,6 +98,37 @@ def _int_env(env: Mapping[str, str], name: str, default: int = 0) -> int:
         return int(str(env.get(name, str(default))).strip())
     except (TypeError, ValueError):
         return default
+
+
+def build_research_lab_worker_environment(
+    source: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Copy and validate the exact environment inherited by worker children."""
+
+    env = dict(os.environ if source is None else source)
+    try:
+        cutover = load_subnet_epoch_cutover(env)
+    except SubnetEpochError as exc:
+        raise ResearchLabWorkerStartupError(
+            "Research Lab worker epoch authority is missing or invalid"
+        ) from exc
+
+    raw_netuid = (
+        env.get("BITTENSOR_NETUID")
+        or env.get("NETUID")
+        or str(cutover.netuid)
+    )
+    try:
+        netuid = int(raw_netuid)
+    except (TypeError, ValueError) as exc:
+        raise ResearchLabWorkerStartupError(
+            "Research Lab worker netuid is invalid"
+        ) from exc
+    if netuid != cutover.netuid:
+        raise ResearchLabWorkerStartupError(
+            "Research Lab worker epoch authority targets a different netuid"
+        )
+    return env
 
 
 def _configured_proxies(env: Mapping[str, str], prefixes: tuple[str, ...]) -> tuple[str, ...]:
@@ -278,7 +315,7 @@ class ResearchLabWorkerSupervisor:
             self._ready_children.add(key)
 
     def _start_child(self, fleet: ResearchLabWorkerFleetPlan, index: int) -> subprocess.Popen[bytes]:
-        env = os.environ.copy()
+        env = build_research_lab_worker_environment()
         env.setdefault("PYTHONUNBUFFERED", "1")
         read_fd, write_fd = os.pipe()
         env[WORKER_READY_FD_ENV] = str(write_fd)

--- a/gateway/research_lab/worker_process.py
+++ b/gateway/research_lab/worker_process.py
@@ -26,6 +26,9 @@ from gateway.research_lab.git_tree_models import TreePolicy  # noqa: E402
 from gateway.research_lab.logging_utils import format_worker_block  # noqa: E402
 from gateway.research_lab.scoring_worker import ResearchLabGatewayScoringWorker  # noqa: E402
 from gateway.research_lab.worker import ResearchLabHostedWorker  # noqa: E402
+from gateway.research_lab.worker_autostart import (  # noqa: E402
+    build_research_lab_worker_environment,
+)
 
 
 HOSTED_PROXY_PREFIXES = (
@@ -166,6 +169,7 @@ def main() -> int:
     parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
+    build_research_lab_worker_environment()
     _configure_logging(args.log_level)
 
     if args.kind == "hosted":

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -48,8 +48,10 @@ from Leadpoet.utils.subnet_epoch import (
     SubnetEpochCutover,
     SubnetEpochError,
     SubnetEpochSnapshot,
+    VALIDATOR_SHARED_EPOCH_SCHEMA_VERSION,
     load_subnet_epoch_cutover,
     read_subnet_epoch_snapshot,
+    validate_validator_shared_epoch_file,
     validate_subnet_epoch_cutover_anchor,
 )
 from Leadpoet.validator.reward import start_epoch_monitor, stop_epoch_monitor
@@ -358,7 +360,7 @@ QUALIFICATION_PROXY_ENV_RE = re.compile(r"^QUALIFICATION_WEBSHARE_PROXY_(\d+)$")
 QUALIFICATION_WORK_FILE_RE = re.compile(r"^qual_worker_(\d+)_work_(\d+)$")
 
 _TRUTHY_ENV_VALUES = {"true", "1", "yes", "y", "on"}
-_SHARED_EPOCH_SCHEMA_VERSION = "leadpoet.validator_shared_epoch.v3"
+_SHARED_EPOCH_SCHEMA_VERSION = VALIDATOR_SHARED_EPOCH_SCHEMA_VERSION
 
 
 @dataclass(frozen=True)
@@ -439,63 +441,16 @@ def _read_shared_epoch_state_file(*, max_age_seconds: int) -> _ValidatorEpochSta
     path = Path("validator_weights") / "current_block.json"
     if not path.exists():
         raise FileNotFoundError("Coordinator hasn't written block file yet")
-    try:
-        document = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise SubnetEpochError("shared epoch file is unreadable") from exc
-    expected_fields = {
-        "schema_version",
-        "block",
-        "epoch",
-        "blocks_into_epoch",
-        "blocks_remaining",
-        "epoch_start_block",
-        "next_epoch_block",
-        "tempo",
-        "subnet_epoch_index",
-        "epoch_ref",
-        "authority",
-        "timestamp",
-    }
-    if not isinstance(document, dict) or set(document) != expected_fields:
-        raise SubnetEpochError("shared epoch file fields are invalid")
-    if document.get("schema_version") != _SHARED_EPOCH_SCHEMA_VERSION:
-        raise SubnetEpochError("shared epoch file schema is unsupported")
-    try:
-        age = int(time.time()) - int(document["timestamp"])
-    except (TypeError, ValueError) as exc:
-        raise SubnetEpochError("shared epoch file timestamp is invalid") from exc
-    if age < -30 or age > int(max_age_seconds):
-        raise SubnetEpochError(f"shared epoch file is stale ({age}s old)")
-
-    authority = document.get("authority")
-    if not isinstance(authority, dict):
-        raise SubnetEpochError("shared official epoch authority is missing")
-    snapshot = SubnetEpochSnapshot.from_mapping(authority)
     cutover = load_subnet_epoch_cutover()
-    if authority != snapshot.to_dict(cutover=cutover):
-        raise SubnetEpochError(
-            "shared official epoch authority is not canonical"
-        )
-    state = _ValidatorEpochState.from_snapshot(
+    snapshot = validate_validator_shared_epoch_file(
+        path,
+        max_age_seconds=max_age_seconds,
+        cutover=cutover,
+    )
+    return _ValidatorEpochState.from_snapshot(
         snapshot,
         cutover,
     )
-
-    observed = {
-        "block": state.current_block,
-        "epoch": state.workflow_epoch_id,
-        "blocks_into_epoch": state.epoch_block,
-        "blocks_remaining": state.blocks_remaining,
-        "epoch_start_block": state.epoch_start_block,
-        "next_epoch_block": state.next_epoch_block,
-        "tempo": state.tempo,
-        "subnet_epoch_index": state.subnet_epoch_index,
-        "epoch_ref": state.epoch_ref,
-    }
-    if any(document[key] != value for key, value in observed.items()):
-        raise SubnetEpochError("shared epoch file derived fields are inconsistent")
-    return state
 
 
 def _env_flag(name: str, default: bool = False) -> bool:
@@ -647,22 +602,35 @@ def _verify_burn_target_owner(metagraph: Any, uid: int, expected_hotkey: Optiona
 # ════════════════════════════════════════════════════════════════════════════
 # DEDICATED FULFILLMENT CONTAINERS CONFIGURATION
 # ════════════════════════════════════════════════════════════════════════════
-# 5 containers dedicated ONLY to scoring fulfillment leads.
+# Containers dedicated ONLY to scoring fulfillment leads.
 # These run PARALLEL to sourcing (similar to qualification workers).
-# Set via FULFILLMENT_WEBSHARE_PROXY_1 through FULFILLMENT_WEBSHARE_PROXY_5
+# Worker IDs are discovered from every configured
+# FULFILLMENT_WEBSHARE_PROXY_N variable. Do not hard-code a count here:
+# production currently deploys 10 workers and a fixed count silently left
+# workers 6-10 idle.
 # ════════════════════════════════════════════════════════════════════════════
 
-FULFILLMENT_CONTAINERS_COUNT = 5
+FULFILLMENT_PROXY_ENV_RE = re.compile(r"^FULFILLMENT_WEBSHARE_PROXY_(\d+)$")
+
+
+def detect_fulfillment_worker_ids() -> List[int]:
+    """Return every configured fulfillment worker ID in numeric order."""
+
+    worker_ids = []
+    for proxy_var, proxy_value in os.environ.items():
+        match = FULFILLMENT_PROXY_ENV_RE.match(proxy_var)
+        if not match or not str(proxy_value or "").strip():
+            continue
+        worker_id = int(match.group(1))
+        if worker_id > 0:
+            worker_ids.append(worker_id)
+    return sorted(set(worker_ids))
+
 
 def detect_fulfillment_proxies():
-    """Detect FULFILLMENT_WEBSHARE_PROXY_* environment variables."""
-    proxies_found = []
-    for i in range(1, FULFILLMENT_CONTAINERS_COUNT + 1):
-        proxy_var = f"FULFILLMENT_WEBSHARE_PROXY_{i}"
-        proxy_value = os.getenv(proxy_var)
-        if proxy_value:
-            proxies_found.append(i)
-    return proxies_found
+    """Backward-compatible alias returning configured fulfillment worker IDs."""
+
+    return detect_fulfillment_worker_ids()
 
 def detect_qualification_proxies():
     """Detect QUALIFICATION_WEBSHARE_PROXY_* environment variables."""
@@ -5562,8 +5530,8 @@ class Validator(BaseValidatorNeuron):
             bt.logging.warning(f"Fulfillment workflow setup failed: {e}")
             return
 
-        fulfillment_proxies = detect_fulfillment_proxies()
-        num_workers = len(fulfillment_proxies) if fulfillment_proxies else 0
+        fulfillment_worker_ids = detect_fulfillment_worker_ids()
+        num_workers = len(fulfillment_worker_ids)
 
         # ═══════════════════════════════════════════════════════════════════
         # PHASE 1: DISTRIBUTE — fetch scoring-ready reveals, write work files
@@ -5665,7 +5633,7 @@ class Validator(BaseValidatorNeuron):
                 if scoring_requests:
                     # Option A parallelization: 1 request per worker container.
                     # Each container scores ALL submissions for its assigned request
-                    # end-to-end. Up to num_workers (5) requests processed in parallel.
+                    # end-to-end. Up to num_workers requests processed in parallel.
                     requests_to_process = scoring_requests[:num_workers] if num_workers > 0 else scoring_requests[:1]
 
                     print(f"\n🔍 Fulfillment: {len(requests_to_process)} request(s) ready for scoring "
@@ -5697,8 +5665,10 @@ class Validator(BaseValidatorNeuron):
                             # Plenty of requests — keep original 1-per-worker
                             # mapping (avoids unnecessary cross-request work
                             # file proliferation when load is balanced).
-                            for req_idx, req in enumerate(requests_to_process):
-                                worker_id = req_idx + 1
+                            for worker_id, req in zip(
+                                fulfillment_worker_ids,
+                                requests_to_process,
+                            ):
                                 request_id = req.get("request_id", "")
                                 icp_details = req.get("icp", {})
                                 submissions = req.get("submissions", [])
@@ -5721,7 +5691,7 @@ class Validator(BaseValidatorNeuron):
 
                             by_worker = {}
                             for idx, (request_id, icp_details, sub) in enumerate(flat):
-                                worker_id = (idx % num_workers) + 1
+                                worker_id = fulfillment_worker_ids[idx % num_workers]
                                 by_req = by_worker.setdefault(worker_id, {})
                                 if request_id not in by_req:
                                     by_req[request_id] = (icp_details, [])
@@ -5775,9 +5745,13 @@ class Validator(BaseValidatorNeuron):
                                         miner_hk, lead_ids, results,
                                         request_id=request_id, submission_id=sub_id,
                                     )
-                                    gateway_submit_fulfillment_scores(
+                                    if not gateway_submit_fulfillment_scores(
                                         self.wallet, request_id, scores_payload,
-                                    )
+                                    ):
+                                        raise RuntimeError(
+                                            "gateway rejected fulfillment scores "
+                                            "without raising an exception"
+                                        )
                                     print(f"   ✅ Inline: submitted {len(scores_payload)} scores for {miner_hk[:8]}...")
                                 except Exception as e:
                                     print(f"   ❌ Inline scoring failed for {miner_hk[:8]}: {e}")
@@ -5868,15 +5842,29 @@ class Validator(BaseValidatorNeuron):
                 submission_results = worker_data.get("submission_results", [])
 
                 if worker_data.get("error"):
-                    print(f"   ⚠️ Worker {wid_token} (req {request_id[:8]}) error: {worker_data['error']}")
-                    # Worker-level error is terminal (scoring itself failed,
-                    # not gateway submit).  There's nothing to retry, so we
-                    # clean up to avoid perpetual replays.
+                    print(
+                        f"   ⚠️ fulfillment_worker_retryable_error worker "
+                        f"{wid_token} (req {request_id[:8]}): "
+                        f"{worker_data['error']}"
+                    )
+                    # A worker-level exception is validator infrastructure
+                    # failure, not evidence that a miner's leads are invalid.
+                    # Keep the work assignment, renew its dispatch lease, and
+                    # remove only the error result so the worker retries it.
+                    # Submitting synthetic zero scores here would unfairly
+                    # punish miners; deleting both files would silently drop
+                    # the request until a later redispatch.
                     try:
-                        os.remove(work_file)
-                        os.remove(results_file)
-                    except Exception:
+                        results_file.unlink()
+                        work_file.touch()
+                    except FileNotFoundError:
                         pass
+                    except Exception as retry_exc:
+                        print(
+                            "   ❌ fulfillment_worker_retry_prepare_failed "
+                            f"worker {wid_token}: {retry_exc}"
+                        )
+                    any_submit_failed = True
                     continue
 
                 print(f"   Worker {wid_token} → request {request_id[:8]}: "
@@ -5905,9 +5893,13 @@ class Validator(BaseValidatorNeuron):
                             miner_hk, lead_ids, results,
                             request_id=request_id, submission_id=sub_id,
                         )
-                        gateway_submit_fulfillment_scores(
+                        if not gateway_submit_fulfillment_scores(
                             self.wallet, request_id, scores_payload,
-                        )
+                        ):
+                            raise RuntimeError(
+                                "gateway rejected fulfillment scores "
+                                "without raising an exception"
+                            )
                         print(f"   ✅ Submitted {len(scores_payload)} scores for miner {miner_hk[:8]}...")
                     except Exception as e:
                         worker_all_ok = False
@@ -11204,6 +11196,7 @@ def run_dedicated_fulfillment_worker(config):
 
             lease_task = asyncio.create_task(_refresh_lease())
 
+            request_id = ""
             try:
                 with open(work_file, 'r') as f:
                     work_data = json.load(f)
@@ -11366,6 +11359,8 @@ def run_dedicated_fulfillment_worker(config):
                     json.dump({
                         "epoch": current_epoch,
                         "fulfillment_worker_id": fid,
+                        "request_id": request_id,
+                        "error_type": type(e).__name__,
                         "error": str(e),
                         "submission_results": [],
                         "timestamp": time.time(),

--- a/qualification/scoring/fulfillment_scorer.py
+++ b/qualification/scoring/fulfillment_scorer.py
@@ -162,6 +162,11 @@ def format_scores_for_gateway(
     Each entry is a dict with ``lead_id``, ``request_id``, ``submission_id``
     plus the score breakdown fields expected by the RPC function.
     """
+    if len(lead_ids) != len(results):
+        raise ValueError(
+            "fulfillment score cardinality mismatch: "
+            f"{len(lead_ids)} lead IDs but {len(results)} results"
+        )
     out: List[dict] = []
     for lid, result in zip(lead_ids, results):
         d = result.model_dump()

--- a/scripts/run_research_lab_hosted_worker.py
+++ b/scripts/run_research_lab_hosted_worker.py
@@ -19,6 +19,9 @@ if str(ROOT) not in sys.path:
 from gateway.research_lab.config import ResearchLabGatewayConfig  # noqa: E402
 from gateway.research_lab.git_tree_models import TreePolicy  # noqa: E402
 from gateway.research_lab.worker import ResearchLabHostedWorker  # noqa: E402
+from gateway.research_lab.worker_autostart import (  # noqa: E402
+    build_research_lab_worker_environment,
+)
 
 
 def _proxy_ref(proxy_url: str) -> str:
@@ -76,6 +79,7 @@ def main() -> int:
     if args.total_workers is not None:
         os.environ["RESEARCH_LAB_HOSTED_WORKER_TOTAL_WORKERS"] = str(args.total_workers)
 
+    build_research_lab_worker_environment()
     _configure_logging(args.log_level)
     config = ResearchLabGatewayConfig.from_env()
     _print_startup_banner(config, worker_id=args.worker_id, once=args.once)

--- a/scripts/run_research_lab_hosted_worker_fleet.py
+++ b/scripts/run_research_lab_hosted_worker_fleet.py
@@ -14,6 +14,12 @@ import time
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKER_SCRIPT = ROOT / "scripts" / "run_research_lab_hosted_worker.py"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from gateway.research_lab.worker_autostart import (  # noqa: E402
+    build_research_lab_worker_environment,
+)
 
 
 def main() -> int:
@@ -26,11 +32,12 @@ def main() -> int:
 
     configured_count = int(os.getenv("RESEARCH_LAB_HOSTED_WORKER_PROCESS_COUNT", "0") or "0")
     worker_count = max(1, args.workers or configured_count or _configured_proxy_count() or 1)
+    worker_environment = build_research_lab_worker_environment()
     children: dict[int, subprocess.Popen[bytes]] = {}
     stopping = False
 
     def start_worker(index: int) -> subprocess.Popen[bytes]:
-        env = os.environ.copy()
+        env = worker_environment.copy()
         env["RESEARCH_LAB_HOSTED_WORKER_TOTAL_WORKERS"] = str(worker_count)
         env["RESEARCH_LAB_HOSTED_WORKER_INDEX"] = str(index)
         env["RESEARCH_LAB_HOSTED_WORKER_ID"] = f"{args.worker_prefix}-{index + 1}"

--- a/scripts/run_research_lab_scoring_worker.py
+++ b/scripts/run_research_lab_scoring_worker.py
@@ -18,6 +18,9 @@ if str(ROOT) not in sys.path:
 
 from gateway.research_lab.config import ResearchLabGatewayConfig  # noqa: E402
 from gateway.research_lab.scoring_worker import ResearchLabGatewayScoringWorker  # noqa: E402
+from gateway.research_lab.worker_autostart import (  # noqa: E402
+    build_research_lab_worker_environment,
+)
 from research_lab.observability.langfuse_client import flush_langfuse  # noqa: E402
 
 
@@ -68,6 +71,7 @@ def main() -> int:
     if args.total_workers is not None:
         os.environ["RESEARCH_LAB_SCORING_WORKER_TOTAL_WORKERS"] = str(args.total_workers)
 
+    build_research_lab_worker_environment()
     _configure_logging(args.log_level)
     config = ResearchLabGatewayConfig.from_env()
     _print_startup_banner(config, worker_id=args.worker_id, once=args.once)

--- a/scripts/run_research_lab_scoring_worker_fleet.py
+++ b/scripts/run_research_lab_scoring_worker_fleet.py
@@ -14,6 +14,12 @@ import time
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKER_SCRIPT = ROOT / "scripts" / "run_research_lab_scoring_worker.py"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from gateway.research_lab.worker_autostart import (  # noqa: E402
+    build_research_lab_worker_environment,
+)
 
 
 def main() -> int:
@@ -26,11 +32,12 @@ def main() -> int:
 
     configured_count = int(os.getenv("RESEARCH_LAB_SCORING_WORKER_PROCESS_COUNT", "0") or "0")
     worker_count = max(1, args.workers or configured_count or _configured_proxy_count() or 1)
+    worker_environment = build_research_lab_worker_environment()
     children: dict[int, subprocess.Popen[bytes]] = {}
     stopping = False
 
     def start_worker(index: int) -> subprocess.Popen[bytes]:
-        env = os.environ.copy()
+        env = worker_environment.copy()
         env["RESEARCH_LAB_SCORING_WORKER_TOTAL_WORKERS"] = str(worker_count)
         env["RESEARCH_LAB_SCORING_WORKER_INDEX"] = str(index)
         env["RESEARCH_LAB_SCORING_WORKER_ID"] = f"{args.worker_prefix}-{index + 1}"

--- a/tests/test_fulfillment_runtime_recovery.py
+++ b/tests/test_fulfillment_runtime_recovery.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+from Leadpoet.utils import cloud_db
+from gateway.fulfillment.models import FulfillmentScoreResult
+from gateway.research_lab.worker_autostart import (
+    ResearchLabWorkerStartupError,
+    build_research_lab_worker_environment,
+)
+from neurons.validator import (
+    Validator,
+    _ValidatorEpochState,
+    detect_fulfillment_worker_ids,
+)
+from qualification.scoring.fulfillment_scorer import format_scores_for_gateway
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _clear_fulfillment_proxies(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in tuple(os.environ):
+        if name.startswith("FULFILLMENT_WEBSHARE_PROXY_"):
+            monkeypatch.delenv(name, raising=False)
+
+
+def _epoch_state(epoch: int = 24_105) -> _ValidatorEpochState:
+    return _ValidatorEpochState(
+        current_block=8_682_450,
+        workflow_epoch_id=epoch,
+        epoch_block=245,
+        blocks_remaining=115,
+        epoch_start_block=8_682_205,
+        next_epoch_block=8_682_565,
+        tempo=360,
+        subnet_epoch_index=epoch,
+        epoch_ref="sha256:" + "1" * 64,
+    )
+
+
+def _validator_stub(*, last_processed_epoch: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        wallet=SimpleNamespace(),
+        _last_processed_epoch=last_processed_epoch,
+    )
+
+
+def _work_paths(
+    tmp_path: Path,
+    *,
+    worker_id: int = 1,
+    epoch: int = 24_105,
+    request_id: str = "43c6bc55-80f9-49e3-af0c-7a6ae6e39358",
+) -> tuple[Path, Path]:
+    weights = tmp_path / "validator_weights"
+    weights.mkdir(exist_ok=True)
+    work = weights / (f"fulfillment_worker_{worker_id}_work_{epoch}_{request_id}.json")
+    results = weights / work.name.replace("_work_", "_results_", 1)
+    return work, results
+
+
+def test_fulfillment_worker_detection_uses_all_configured_numeric_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_fulfillment_proxies(monkeypatch)
+    monkeypatch.setenv("FULFILLMENT_WEBSHARE_PROXY_10", "http://proxy-10")
+    monkeypatch.setenv("FULFILLMENT_WEBSHARE_PROXY_3", "http://proxy-3")
+    monkeypatch.setenv("FULFILLMENT_WEBSHARE_PROXY_1", "http://proxy-1")
+    monkeypatch.setenv("FULFILLMENT_WEBSHARE_PROXY_0", "ignored")
+    monkeypatch.setenv("FULFILLMENT_WEBSHARE_PROXY_7", "")
+    monkeypatch.setenv("FULFILLMENT_WEBSHARE_PROXY_BAD", "ignored")
+
+    assert detect_fulfillment_worker_ids() == [1, 3, 10]
+
+
+@pytest.mark.asyncio
+async def test_single_request_fans_out_across_all_ten_fulfillment_workers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ENABLE_FULFILLMENT", "true")
+    _clear_fulfillment_proxies(monkeypatch)
+    for worker_id in range(1, 11):
+        monkeypatch.setenv(
+            f"FULFILLMENT_WEBSHARE_PROXY_{worker_id}",
+            f"http://proxy-{worker_id}",
+        )
+
+    request_id = "43c6bc55-80f9-49e3-af0c-7a6ae6e39358"
+    submissions = [
+        {
+            "submission_id": f"submission-{index}",
+            "miner_hotkey": f"miner-{index}",
+            "lead_ids": [f"lead-{index}"],
+            "leads": [{"lead": index}],
+        }
+        for index in range(15)
+    ]
+    monkeypatch.setattr(
+        cloud_db,
+        "gateway_get_fulfillment_reveals",
+        lambda _wallet: {
+            "requests": [
+                {
+                    "request_id": request_id,
+                    "status": "scoring",
+                    "icp": {"prompt": "test"},
+                    "submissions": submissions,
+                }
+            ]
+        },
+    )
+
+    await Validator.process_fulfillment_workflow(
+        _validator_stub(last_processed_epoch=-1),
+        _epoch_state(),
+    )
+
+    files = sorted((tmp_path / "validator_weights").glob("*_work_*.json"))
+    assert len(files) == 10
+    observed_workers = {int(path.name.split("_")[2]) for path in files}
+    assert observed_workers == set(range(1, 11))
+    assigned_submissions = []
+    for path in files:
+        assigned_submissions.extend(
+            json.loads(path.read_text(encoding="utf-8"))["submissions"]
+        )
+    assert {row["submission_id"] for row in assigned_submissions} == {
+        row["submission_id"] for row in submissions
+    }
+    assert len(assigned_submissions) == len(submissions)
+
+
+@pytest.mark.asyncio
+async def test_false_gateway_ack_keeps_fulfillment_files_for_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ENABLE_FULFILLMENT", "true")
+    _clear_fulfillment_proxies(monkeypatch)
+    monkeypatch.setenv("FULFILLMENT_WEBSHARE_PROXY_1", "http://proxy-1")
+    monkeypatch.setattr(
+        cloud_db,
+        "gateway_get_fulfillment_reveals",
+        lambda _wallet: {"requests": []},
+    )
+    monkeypatch.setattr(
+        cloud_db,
+        "gateway_submit_fulfillment_scores",
+        lambda *_args, **_kwargs: False,
+    )
+
+    epoch = 24_105
+    request_id = "43c6bc55-80f9-49e3-af0c-7a6ae6e39358"
+    work, results = _work_paths(
+        tmp_path,
+        epoch=epoch,
+        request_id=request_id,
+    )
+    work.write_text(
+        json.dumps(
+            {
+                "epoch": epoch,
+                "request_id": request_id,
+                "icp": {},
+                "submissions": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    results.write_text(
+        json.dumps(
+            {
+                "epoch": epoch,
+                "fulfillment_worker_id": 1,
+                "request_id": request_id,
+                "submission_results": [
+                    {
+                        "miner_hotkey": "miner-1",
+                        "submission_id": "submission-1",
+                        "lead_ids": ["lead-1"],
+                        "results": [
+                            FulfillmentScoreResult(
+                                lead_id="lead-1",
+                                failure_reason="test",
+                            ).model_dump()
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    await Validator.process_fulfillment_workflow(
+        _validator_stub(last_processed_epoch=epoch),
+        _epoch_state(epoch),
+    )
+
+    assert work.exists()
+    assert results.exists()
+
+
+@pytest.mark.asyncio
+async def test_worker_infrastructure_error_retries_without_scoring_miners_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ENABLE_FULFILLMENT", "true")
+    _clear_fulfillment_proxies(monkeypatch)
+    monkeypatch.setenv("FULFILLMENT_WEBSHARE_PROXY_1", "http://proxy-1")
+    monkeypatch.setattr(
+        cloud_db,
+        "gateway_get_fulfillment_reveals",
+        lambda _wallet: {"requests": []},
+    )
+
+    epoch = 24_105
+    request_id = "43c6bc55-80f9-49e3-af0c-7a6ae6e39358"
+    work, results = _work_paths(
+        tmp_path,
+        epoch=epoch,
+        request_id=request_id,
+    )
+    work.write_text(
+        json.dumps(
+            {
+                "epoch": epoch,
+                "request_id": request_id,
+                "icp": {},
+                "submissions": [{"submission_id": "submission-1"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    original_mtime = work.stat().st_mtime
+    results.write_text(
+        json.dumps(
+            {
+                "epoch": epoch,
+                "fulfillment_worker_id": 1,
+                "request_id": request_id,
+                "error_type": "RuntimeError",
+                "error": "provider infrastructure unavailable",
+                "submission_results": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    await Validator.process_fulfillment_workflow(
+        _validator_stub(last_processed_epoch=epoch),
+        _epoch_state(epoch),
+    )
+
+    assert work.exists()
+    assert work.stat().st_mtime >= original_mtime
+    assert not results.exists()
+
+
+def test_score_formatter_rejects_cardinality_mismatch() -> None:
+    with pytest.raises(ValueError, match="cardinality mismatch"):
+        format_scores_for_gateway(
+            "miner-1",
+            ["lead-1", "lead-2"],
+            [FulfillmentScoreResult()],
+            request_id="request-1",
+            submission_id="submission-1",
+        )
+
+
+def test_gateway_score_submit_raises_after_exactly_three_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = []
+    sleeps = []
+
+    def fail_post(*_args, **_kwargs):
+        attempts.append(1)
+        raise requests.ConnectionError("gateway unavailable")
+
+    monkeypatch.setattr(cloud_db.requests, "post", fail_post)
+    monkeypatch.setattr(cloud_db.time, "sleep", sleeps.append)
+    wallet = SimpleNamespace(
+        hotkey=SimpleNamespace(
+            ss58_address="validator-hotkey",
+            sign=lambda _message: b"signature",
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="after 3 attempts"):
+        cloud_db.gateway_submit_fulfillment_scores(
+            wallet,
+            "43c6bc55-80f9-49e3-af0c-7a6ae6e39358",
+            [{"lead_id": "lead-1"}],
+        )
+
+    assert len(attempts) == 3
+    assert sleeps == [2, 2]
+
+
+def test_research_lab_child_environment_requires_matching_epoch_authority(
+    tmp_path: Path,
+) -> None:
+    manifest = (ROOT / "config" / "stateful-epoch-cutover-sn71.json").read_text(
+        encoding="utf-8"
+    )
+    env = {
+        "LEADPOET_SUBNET_EPOCH_CUTOVER_JSON": manifest,
+        "BITTENSOR_NETUID": "71",
+        "SENTINEL": "preserved",
+    }
+
+    child = build_research_lab_worker_environment(env)
+
+    assert child == env
+    with pytest.raises(ResearchLabWorkerStartupError, match="missing or invalid"):
+        build_research_lab_worker_environment({"BITTENSOR_NETUID": "71"})
+    with pytest.raises(ResearchLabWorkerStartupError, match="different netuid"):
+        build_research_lab_worker_environment(
+            {
+                "LEADPOET_SUBNET_EPOCH_CUTOVER_JSON": manifest,
+                "BITTENSOR_NETUID": "72",
+            }
+        )
+
+    path = tmp_path / "cutover.json"
+    path.write_text(manifest, encoding="utf-8")
+    path_child = build_research_lab_worker_environment(
+        {
+            "LEADPOET_SUBNET_EPOCH_CUTOVER_PATH": str(path),
+            "NETUID": "71",
+        }
+    )
+    assert path_child["LEADPOET_SUBNET_EPOCH_CUTOVER_PATH"] == str(path)
+
+
+def test_every_validator_and_research_worker_launch_has_epoch_guard() -> None:
+    deploy = (
+        ROOT / "validator_models" / "containerizing" / "deploy_dynamic.sh"
+    ).read_text(encoding="utf-8")
+    env_arg = (
+        "-e LEADPOET_SUBNET_EPOCH_CUTOVER_JSON="
+        '"${LEADPOET_SUBNET_EPOCH_CUTOVER_JSON:-}"'
+    )
+
+    assert deploy.count(env_arg) == 3
+    assert "validate_worker_epoch_authority" in deploy
+    assert "validate_validator_shared_epoch_file(" in deploy
+    assert "from neurons.validator" not in deploy
+    for container in (
+        "leadpoet-validator-worker-$i",
+        "leadpoet-qual-worker-$i",
+        "leadpoet-ff-worker-$i",
+    ):
+        assert f'validate_worker_epoch_authority "{container}"' in deploy
+
+    for script_name in (
+        "run_research_lab_hosted_worker.py",
+        "run_research_lab_hosted_worker_fleet.py",
+        "run_research_lab_scoring_worker.py",
+        "run_research_lab_scoring_worker_fleet.py",
+    ):
+        source = (ROOT / "scripts" / script_name).read_text(encoding="utf-8")
+        assert "build_research_lab_worker_environment()" in source
+        if script_name.endswith("_fleet.py"):
+            assert "env = worker_environment.copy()" in source
+
+    worker_process = (
+        ROOT / "gateway" / "research_lab" / "worker_process.py"
+    ).read_text(encoding="utf-8")
+    assert "build_research_lab_worker_environment()" in worker_process

--- a/tests/test_validator_restart_wrapper_v2.py
+++ b/tests/test_validator_restart_wrapper_v2.py
@@ -60,7 +60,7 @@ def test_cutover_preparation_stops_before_full_validator_and_preserves_start():
     ) in script
     assert "stateful cutover enclave preparation requires a captured restart start" in script
     preserve = script.index(
-        '&& [ "$REQUESTED_STATEFUL_CUTOVER_PREPARE_ONLY" != "1" ]; then'
+        'if [ "$REQUESTED_STATEFUL_CUTOVER_PREPARE_ONLY" != "1" ]; then'
     )
     delete_start = script.index('rm -f "$VALIDATOR_RESTART_START_PATH"', preserve)
     hotkey = script.index("python3 -m validator_tee.host.hotkey_bootstrap_v2")

--- a/validator_models/containerizing/deploy_dynamic.sh
+++ b/validator_models/containerizing/deploy_dynamic.sh
@@ -552,6 +552,7 @@ if [ $QUAL_PROXY_COUNT -gt 0 ]; then
           -e PYTHONUNBUFFERED=1 \
           -e LEADPOET_CONTAINER_MODE=1 \
           -e LEADPOET_WRAPPER_ACTIVE=1 \
+          -e LEADPOET_SUBNET_EPOCH_CUTOVER_JSON="${LEADPOET_SUBNET_EPOCH_CUTOVER_JSON:-}" \
           -e GATEWAY_URL="${GATEWAY_URL:-https://gateway.subnet71.com}" \
       -e LEADPOET_INTERNAL_SECRET="${LEADPOET_INTERNAL_SECRET:-}" \
           -e RESEARCH_LAB_INTERNAL_API_KEY="${RESEARCH_LAB_INTERNAL_API_KEY:-}" \
@@ -649,6 +650,7 @@ if [ $FF_PROXY_COUNT -gt 0 ]; then
           -e PYTHONUNBUFFERED=1 \
           -e LEADPOET_CONTAINER_MODE=1 \
           -e LEADPOET_WRAPPER_ACTIVE=1 \
+          -e LEADPOET_SUBNET_EPOCH_CUTOVER_JSON="${LEADPOET_SUBNET_EPOCH_CUTOVER_JSON:-}" \
           -e ENABLE_FULFILLMENT=true \
           -e GATEWAY_URL="${GATEWAY_URL:-https://gateway.subnet71.com}" \
       -e LEADPOET_INTERNAL_SECRET="${LEADPOET_INTERNAL_SECRET:-}" \
@@ -827,6 +829,74 @@ print(
 )
 PY
 echo "✅ Authoritative validator coordinator runtime verified"
+echo ""
+
+validate_worker_epoch_authority() {
+    local container_name="$1"
+    local shared_epoch_ready=0
+
+    if [ "$(docker inspect -f '{{.State.Running}}' "$container_name")" != "true" ]; then
+        echo "❌ ERROR: $container_name is not running" >&2
+        return 1
+    fi
+    if [ "$(docker inspect -f '{{.RestartCount}}' "$container_name")" != "0" ]; then
+        echo "❌ ERROR: $container_name restarted during startup" >&2
+        return 1
+    fi
+    if ! docker exec "$container_name" sh -c \
+        'test -n "${LEADPOET_SUBNET_EPOCH_CUTOVER_JSON:-}"'; then
+        echo "❌ ERROR: $container_name is missing the official epoch cutover manifest" >&2
+        return 1
+    fi
+
+    for _attempt in $(seq 1 30); do
+        if docker exec "$container_name" \
+            sh -c 'test -s /app/validator_weights/current_block.json'; then
+            shared_epoch_ready=1
+            break
+        fi
+        sleep 2
+    done
+    if [ "$shared_epoch_ready" != "1" ]; then
+        echo "❌ ERROR: $container_name cannot see the shared epoch document" >&2
+        return 1
+    fi
+
+    docker exec -i "$container_name" sh -c 'cd /app && python3 -' <<'PY'
+import json
+
+from Leadpoet.utils.subnet_epoch import validate_validator_shared_epoch_file
+
+snapshot = validate_validator_shared_epoch_file(
+    "validator_weights/current_block.json",
+    max_age_seconds=1800,
+)
+print(
+    json.dumps(
+        {
+            "schema_version": "leadpoet.validator_worker_epoch_preflight.v1",
+            "status": "ready",
+            "subnet_epoch_index": snapshot.subnet_epoch_index,
+            "epoch_block": snapshot.epoch_block,
+        },
+        sort_keys=True,
+    )
+)
+PY
+    echo "✅ $container_name official epoch authority verified"
+}
+
+echo "🔐 Verifying official epoch authority in every validator worker..."
+for i in $(seq 1 "$PROXY_COUNT"); do
+    validate_worker_epoch_authority "leadpoet-validator-worker-$i"
+done
+for i in $(seq 1 "$QUAL_PROXY_COUNT"); do
+    validate_worker_epoch_authority "leadpoet-qual-worker-$i"
+done
+for i in $(seq 1 "$FF_PROXY_COUNT"); do
+    validate_worker_epoch_authority "leadpoet-ff-worker-$i"
+done
+echo "✅ All validator worker epoch authorities verified"
 echo ""
 
 ALL_IPS=()


### PR DESCRIPTION
## Summary

Production fulfillment is not currently completing. The live validator has 10 fulfillment containers, but representative workers do not receive the official epoch cutover manifest; the coordinator also discovers only five workers, and score-delivery failures can be acknowledged locally and then discarded.

This PR closes the recovery chain rather than treating the missing environment variable as the only defect.

## Changes

- Pass `LEADPOET_SUBNET_EPOCH_CUTOVER_JSON` into qualification and fulfillment containers, then fail deployment unless every sourcing, qualification, and fulfillment worker can validate the canonical shared epoch document.
- Extract shared worker-epoch validation into a lightweight helper so deploy preflight does not import the full validator runtime or expose unrelated runtime configuration.
- Require the same official epoch manifest in gateway-supervised Research Lab children, standalone hosted/scoring fleets, and direct hosted/scoring worker entrypoints before scoring or loops are activated.
- Discover all configured fulfillment worker IDs instead of the hard-coded five-worker ceiling; preserve sparse numeric IDs and fan one request across all ten configured workers.
- Make fulfillment score delivery raise after three failed attempts; callers retain work/results for idempotent retry instead of deleting unacknowledged scores.
- Treat outer worker failures as retryable validator infrastructure failures rather than terminal miner outcomes.
- Reject lead/result cardinality mismatches before `zip` can silently truncate scores.
- Include `request_id` and `error_type` in worker error artifacts.
- Repair a stale restart-wrapper assertion left by the current-main restart sequencing refactor.

## Verification

- 188 focused/cross-cutting tests passed across fulfillment, epoch authority, validator restart safety, Research Lab worker startup, gateway stateful epochs, and champion/reimbursement/weight submission paths.
- Whole-package `compileall`, changed-file `py_compile`, `bash -n`, flake8 on new/guard code, and `git diff --check` passed.
- Gateway-like import with the production package parent and canonical manifest passed.
- Live read-only production-shape checks confirmed the gateway main/hosted/scoring processes use `/home/ec2-user/leadpoet_repo`, inherit netuid 71 and the canonical manifest path, and resolve the shared epoch module there.
- The new lightweight validator preflight validated the current live `current_block.json` without importing the full validator runtime.
- A CI-shaped full local run reached 3,334 passing tests; remaining local failures/errors were sandbox-restricted loopback/process tests and unrelated current-main inconsistencies.
- GitHub Actions completed 3,369 passing tests with 18 failures. The exact base commit on `main` had the same 18 failures plus the stale restart-wrapper assertion fixed here (3,360 passed / 19 failed), so this branch introduced no new full-suite failure. The downstream Docker build was skipped because the repository-wide test job remains red on those baseline failures.

## Deployment / live-proof requirements

No production files, services, or Supabase rows were changed by this PR, and there is no schema migration.

After authenticated merge to `main`:

1. Wait for the attested release for the merged commit.
2. Recheck the official epoch position and complete both gateway and validator restarts before block 300 (or wait for the next safe window).
3. Verify every validator worker passes the deploy epoch preflight and all 10 fulfillment workers are discoverable.
4. Verify post-restart fulfillment artifacts and Supabase evidence reach scoring submission and consensus; a healthy process alone is not end-to-end proof.
5. Verify gateway/validator PCR0 alignment and the champion, reimbursement, Research Lab allocation, score-bundle, weight mutation, and on-chain submission paths.

Until those post-merge checks pass, this is code- and deploy-ready recovery, not a claim that production is already online.
