### PR TITLE
Repair main CI and refresh provider preflights

### DIFF
--- a/gateway/research_lab/v2_authority.py
+++ b/gateway/research_lab/v2_authority.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import uuid
 from typing import Any, Iterable, Mapping, Sequence
 
 from gateway.research_lab.attested_coordinator_v2 import execute_coordinator_v2
@@ -1003,15 +1004,19 @@ async def execute_provider_preflight_v2(
     provider_credential_profile: str = "benchmark_model",
     execute: Any = execute_scoring_v2,
 ) -> dict[str, Any]:
+    measurement_id = uuid.uuid4().hex
     outcome = await execute(
         operation=OP_PROVIDER_PREFLIGHT_V2,
         purpose="research_lab.provider_preflight.v2",
         epoch_id=0,
-        # The payload already commits scope, force, and settings, so sequence
-        # zero gives deterministic idempotency and fits the V2 INTEGER schema.
+        # Keep the receipt sequence inside the V2 INTEGER schema. Freshness is
+        # committed by measurement_id in the payload so every requested probe
+        # derives a new enclave job instead of replaying a terminal job for up
+        # to the execution manager's one-hour retention window.
         sequence=0,
         payload={
             "schema_version": PROVIDER_PREFLIGHT_REQUEST_SCHEMA_VERSION,
+            "measurement_id": measurement_id,
             "scope_key": str(scope_key),
             "force": bool(force),
             "settings": dict(settings),

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -597,7 +597,7 @@
       "symbol": "rpc_method_allowed"
     },
     {
-      "ast_sha256": "sha256:ef5c2c3e355e465581a19874b381e7fe6184b7786bafcae1d659064dd19d175e",
+      "ast_sha256": "sha256:a88aaa014d07c114351c9eb4a92a3fd546c290a09ee03f6df1c36b6c70093534",
       "path": "gateway/tee/scoring_executor_v2.py",
       "symbol": "ScoringExecutorV2"
     },
@@ -1087,7 +1087,7 @@
       "symbol": "validate_source_add_reward_record"
     }
   ],
-  "manifest_hash": "sha256:b5679d08ef6341fdba340f0765559feb5f5aa6fce7c8aac504bbbea1c47c8a3d",
-  "protected_source_commit": "c5eca5017b738f3665f6754f2c81e52317fa8df5",
+  "manifest_hash": "sha256:8ba6f766b587cdb4362ddcdca287aaaf97500fc4c54723ceb5a454847e2c8678",
+  "protected_source_commit": "b454e973a06cbb74431a890e739e513abb541362",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/scoring_executor_v2.py
+++ b/gateway/tee/scoring_executor_v2.py
@@ -87,7 +87,7 @@ OP_PROVIDER_PREFLIGHT_V2 = "provider_preflight_v2"
 OP_SOURCE_ADD_LEG2_JUDGE_V2 = "source_add_leg2_judge_v2"
 DEV_REPLAY_REQUEST_SCHEMA_VERSION = "leadpoet.dev_replay_request.v4"
 DEV_HYBRID_REQUEST_SCHEMA_VERSION = "leadpoet.dev_hybrid_request.v4"
-PROVIDER_PREFLIGHT_REQUEST_SCHEMA_VERSION = "leadpoet.provider_preflight_request.v2"
+PROVIDER_PREFLIGHT_REQUEST_SCHEMA_VERSION = "leadpoet.provider_preflight_request.v3"
 SOURCE_ADD_JUDGE_REQUEST_SCHEMA_VERSION = "leadpoet.source_add_judge_request.v2"
 SOURCE_ADD_JUDGE_RESULT_SCHEMA_VERSION = "leadpoet.source_add_judge_result.v2"
 PROVIDER_CREDENTIAL_REFS_FIELD = "_v2_provider_credential_ref_hashes"
@@ -756,11 +756,20 @@ class ScoringExecutorV2:
         payload: Mapping[str, Any],
         context: ExecutionContextV2,
     ) -> ExecutionResultV2:
-        required = {"schema_version", "scope_key", "force", "settings"}
+        required = {
+            "schema_version",
+            "measurement_id",
+            "scope_key",
+            "force",
+            "settings",
+        }
         if not isinstance(payload, Mapping) or set(payload) != required:
             raise ValueError("provider preflight request fields are invalid")
         if payload.get("schema_version") != PROVIDER_PREFLIGHT_REQUEST_SCHEMA_VERSION:
             raise ValueError("provider preflight request schema is invalid")
+        measurement_id = str(payload.get("measurement_id") or "")
+        if not re.fullmatch(r"[0-9a-f]{32}", measurement_id):
+            raise ValueError("provider preflight measurement identity is invalid")
         scope_key = str(payload.get("scope_key") or "")
         if not scope_key or len(scope_key) > 255 or "\x00" in scope_key:
             raise ValueError("provider preflight scope is invalid")

--- a/tests/test_research_lab_v2_authority.py
+++ b/tests/test_research_lab_v2_authority.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import pytest
 
 from gateway.research_lab import v2_authority
+from gateway.research_lab.attested_scoring_v2 import (
+    derive_execution_job_id_v2,
+)
 
 
 HASH_A = "sha256:" + "a" * 64
@@ -35,29 +38,59 @@ async def test_provider_preflight_uses_unique_measured_jobs_and_benchmark_profil
     monkeypatch,
 ):
     calls = []
+    job_ids = []
+    measurement_ids = iter(("1" * 32, "2" * 32))
 
     async def execute(**kwargs):
         calls.append(kwargs)
+        job_ids.append(
+            derive_execution_job_id_v2(
+                operation=kwargs["operation"],
+                purpose=kwargs["purpose"],
+                epoch_id=kwargs["epoch_id"],
+                sequence=kwargs["sequence"],
+                payload_sha256=v2_authority.sha256_json(kwargs["payload"]),
+                parent_receipt_hashes=(),
+                input_artifact_hashes=(),
+                release_hash=HASH_B,
+                physical_role="gateway_scoring",
+            )
+        )
         return _outcome(
             {"healthy": True, "pause_worthy": False, "verdicts": []}
         )
 
-    result = await v2_authority.execute_provider_preflight_v2(
-        scope_key="scoring:worker-4",
-        worker_index=4,
-        settings={
-            "enabled": True,
-            "ttl_seconds": 600.0,
-            "timeout_seconds": 12.0,
-            "failure_streak_threshold": 3,
-        },
-        execute=execute,
+    monkeypatch.setattr(
+        v2_authority.uuid,
+        "uuid4",
+        lambda: type("MeasurementId", (), {"hex": next(measurement_ids)})(),
     )
-    assert result["healthy"] is True
+    for _ in range(2):
+        result = await v2_authority.execute_provider_preflight_v2(
+            scope_key="scoring:worker-4",
+            worker_index=4,
+            settings={
+                "enabled": True,
+                "ttl_seconds": 600.0,
+                "timeout_seconds": 12.0,
+                "failure_streak_threshold": 3,
+            },
+            execute=execute,
+        )
+        assert result["healthy"] is True
+
     assert calls[0]["purpose"] == "research_lab.provider_preflight.v2"
-    assert calls[0]["sequence"] == 0
-    assert calls[0]["worker_index"] == 4
-    assert calls[0]["provider_credential_profile"] == "benchmark_model"
+    assert [call["sequence"] for call in calls] == [0, 0]
+    assert [call["payload"]["measurement_id"] for call in calls] == [
+        "1" * 32,
+        "2" * 32,
+    ]
+    assert len(set(job_ids)) == 2
+    assert all(call["worker_index"] == 4 for call in calls)
+    assert all(
+        call["provider_credential_profile"] == "benchmark_model"
+        for call in calls
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_scoring_executor_v2.py
+++ b/tests/test_scoring_executor_v2.py
@@ -139,6 +139,7 @@ async def test_v2_preflight_reuses_existing_cache_and_failure_streak_logic(
         "_v2_provider_credential_profile": "benchmark_model",
         "_v2_provider_credential_ref_hashes": {"exa": HASH},
         "schema_version": PROVIDER_PREFLIGHT_REQUEST_SCHEMA_VERSION,
+        "measurement_id": "1" * 32,
         "scope_key": "scoring:worker-1",
         "force": False,
         "settings": {
@@ -165,6 +166,51 @@ async def test_v2_preflight_reuses_existing_cache_and_failure_streak_logic(
     finally:
         executor.close()
     assert calls == {"exa": 1, "scrapingdog": 1}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("measurement_id", ("", "1" * 31, "g" * 32))
+async def test_v2_preflight_rejects_invalid_measurement_identity(
+    measurement_id,
+):
+    executor = ScoringExecutorV2(
+        provider_execute=lambda _request: pytest.fail(
+            "invalid preflight request must not call a provider"
+        ),
+        retry_policy_hashes={"exa": HASH, "scrapingdog": HASH},
+    )
+    payload = {
+        "_v2_provider_credential_profile": "benchmark_model",
+        "_v2_provider_credential_ref_hashes": {"exa": HASH},
+        "schema_version": PROVIDER_PREFLIGHT_REQUEST_SCHEMA_VERSION,
+        "measurement_id": measurement_id,
+        "scope_key": "scoring:worker-1",
+        "force": False,
+        "settings": {
+            "enabled": True,
+            "ttl_seconds": 600.0,
+            "timeout_seconds": 12.0,
+            "failure_streak_threshold": 3,
+        },
+    }
+    try:
+        with pytest.raises(
+            ValueError,
+            match="measurement identity",
+        ):
+            await executor(
+                OP_PROVIDER_PREFLIGHT_V2,
+                payload,
+                ExecutionContextV2(
+                    job_id="invalid-preflight-job",
+                    purpose="research_lab.provider_preflight.v2",
+                    epoch_id=0,
+                    provider_credential_profile="benchmark_model",
+                    provider_credential_ref_hashes={"exa": HASH},
+                ),
+            )
+    finally:
+        executor.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_stateful_epoch_cutover_ceremony.py
+++ b/tests/test_stateful_epoch_cutover_ceremony.py
@@ -353,6 +353,7 @@ async def test_offline_cutover_injects_gateway_chain_dependencies(monkeypatch):
             events.append(("exited", exc_type))
 
     monkeypatch.setattr("bittensor.AsyncSubtensor", FakeAsyncSubtensor)
+    monkeypatch.setattr("gateway.config.BITTENSOR_NETWORK", "finney")
     monkeypatch.setattr(
         "gateway.utils.epoch.inject_async_subtensor",
         lambda value: events.append(("epoch", value)),

--- a/tests/test_validator_docker_storage_recovery_v2.py
+++ b/tests/test_validator_docker_storage_recovery_v2.py
@@ -71,8 +71,21 @@ case "${1:-}:${2:-}" in
     printf '/var/lib/docker\\n'
     exit 0
     ;;
+  info:)
+    # Bare `docker info` availability/readiness probes (pre-inventory preamble
+    # and the post-reset readiness loop) — the fake daemon is always healthy.
+    exit 0
+    ;;
 esac
 exit 2
+""",
+    )
+    _write_executable(
+        bin_dir / "findmnt",
+        """#!/bin/bash
+# No stale mounts under the fake docker/containerd roots (hermetic on CI and
+# macOS, which lacks findmnt entirely).
+exit 0
 """,
     )
     _write_executable(


### PR DESCRIPTION
## What changed

- Repairs the 18 stale or non-hermetic assertions behind the current `main` CI failures.
- Replaces the provider-preflight constant job identity with a fresh 128-bit measurement identity committed into the V3 request payload.
- Keeps receipt `sequence=0` within the PostgreSQL `INTEGER` contract while ensuring otherwise identical measurements derive distinct enclave job IDs.
- Validates measurement identities inside the scoring enclave and adds positive and fail-closed regression coverage.

## Root cause

Provider preflight had moved from `time.time_ns()` to constant `sequence=0`. Because job identity commits sequence plus payload, identical checks reused the same terminal enclave job during the execution manager's one-hour retention window, defeating the configured 10-minute remeasurement TTL.

The other failures were test drift after intentional runtime changes: environment-backed cutover credentials, the 310→315 restart cutoff, release-lineage fixtures, archive wording, CI network configuration, Docker readiness probes, and a simplified restart guard.

## Verification

- 27 provider-preflight authority/executor tests passed locally.
- 37 locally compatible former-failure tests passed; two Docker reset cases require Linux Bash 4 and are delegated to CI.
- 80 reward/reimbursement/allocation/weight-path tests passed locally; remaining local collection gaps are caused by installed Bittensor v11 while the repo pins v10.5.0.
- `py_compile` and `git diff --check` passed.

No database migration is required. Gateway and measured scoring runtime changes must deploy together because the preflight request schema advances from V2 to V3.
