### PR TITLE
Fail closed before activating Research Lab loops and scoring

### DIFF
--- a/gateway/research_lab/api.py
+++ b/gateway/research_lab/api.py
@@ -29,6 +29,10 @@ from gateway.qualification.utils.chain import (
 )
 from gateway.utils.bans import is_hotkey_banned
 from gateway.utils.rate_limiter import reserve_submission_slot
+from research_lab.eval.promotion_metric import (
+    benchmark_relative_score_deltas,
+    promotion_improvement_metric,
+)
 
 from .allocations import build_research_lab_allocation_bundle
 from .arweave_audit import latest_arweave_anchor
@@ -3946,11 +3950,21 @@ async def _candidate_score_summary(score_bundle_id: str) -> dict[str, Any] | Non
         return None
     bundle = row.get("score_bundle_doc") if isinstance(row.get("score_bundle_doc"), Mapping) else {}
     aggregates = bundle.get("aggregates") if isinstance(bundle.get("aggregates"), Mapping) else {}
+    mean_delta, delta_lcb = benchmark_relative_score_deltas(bundle)
+    metric = promotion_improvement_metric(bundle)
     summary = {
-        "base_score": _float_or_none(aggregates.get("base_score")),
-        "candidate_score": _float_or_none(aggregates.get("candidate_score")),
-        "mean_delta": _float_or_none(aggregates.get("mean_delta")),
-        "delta_lcb": _float_or_none(aggregates.get("delta_lcb")),
+        "base_score": (
+            metric.baseline_aggregate_score
+            if metric.baseline_aggregate_score is not None
+            else _float_or_none(aggregates.get("base_score"))
+        ),
+        "candidate_score": (
+            metric.candidate_total_score
+            if metric.candidate_total_score is not None
+            else _float_or_none(aggregates.get("candidate_score"))
+        ),
+        "mean_delta": mean_delta,
+        "delta_lcb": delta_lcb,
         "icp_count": _int_or_none(aggregates.get("icp_count")),
         "successful_icp_count": _int_or_none(aggregates.get("successful_icp_count")),
         "failure_count": _int_or_none(aggregates.get("failure_count")),

--- a/gateway/research_lab/config.py
+++ b/gateway/research_lab/config.py
@@ -957,7 +957,7 @@ class ResearchLabGatewayConfig:
                 max(0.0, _float("RESEARCH_LAB_SCORING_HEALTH_MAX_CANDIDATE_ZERO_COMPANY_RATE", 1.0)),
             ),
             scoring_health_max_provider_error_rate=min(
-                1.0,
+                0.10,
                 max(0.0, _float("RESEARCH_LAB_SCORING_HEALTH_MAX_PROVIDER_ERROR_RATE", 0.10)),
             ),
             scoring_health_max_timeout_rate=min(

--- a/gateway/research_lab/house_arm.py
+++ b/gateway/research_lab/house_arm.py
@@ -77,6 +77,7 @@ from research_lab.counterfactual_gate import (
     CounterfactualYieldRecord,
     build_matched_budget_comparison,
 )
+from research_lab.eval.promotion_metric import benchmark_relative_score_deltas
 
 from .config import DEFAULT_ACTIVE_LOOP_STALE_AFTER_SECONDS, ResearchLabGatewayConfig
 from .maintenance import (
@@ -1016,21 +1017,19 @@ def _arm_metrics_template() -> dict[str, Any]:
     }
 
 
-async def _score_bundle_mean_delta(score_bundle_id: str) -> float | None:
+async def _score_bundle_deltas(
+    score_bundle_id: str,
+) -> tuple[float | None, float | None]:
     if not score_bundle_id:
-        return None
+        return None, None
     row = await select_one(
         "research_evaluation_score_bundle_current",
         filters=(("score_bundle_id", score_bundle_id),),
     )
     if not row:
-        return None
+        return None, None
     doc = row.get("score_bundle_doc") if isinstance(row.get("score_bundle_doc"), Mapping) else {}
-    aggregates = doc.get("aggregates") if isinstance(doc.get("aggregates"), Mapping) else {}
-    try:
-        return float(aggregates.get("mean_delta"))
-    except (TypeError, ValueError):
-        return None
+    return benchmark_relative_score_deltas(doc)
 
 
 async def collect_house_arm_comparison_metrics(
@@ -1066,12 +1065,15 @@ async def collect_house_arm_comparison_metrics(
         if str(candidate.get("current_candidate_status") or "") != "scored":
             continue
         arm["candidates_scored"] += 1
-        mean_delta = await _score_bundle_mean_delta(str(candidate.get("current_score_bundle_id") or ""))
+        mean_delta, delta_lcb = await _score_bundle_deltas(
+            str(candidate.get("current_score_bundle_id") or "")
+        )
         if mean_delta is None:
             continue
         arm["deltas"].append(round(mean_delta, 6))
         arm["verified_points"] += max(0.0, mean_delta)
-        if mean_delta >= improvement_threshold_points:
+        keep_metric = delta_lcb if delta_lcb is not None else mean_delta
+        if keep_metric >= improvement_threshold_points:
             arm["keeps"] += 1
 
     payments = await select_all(

--- a/gateway/research_lab/miner_diagnostics.py
+++ b/gateway/research_lab/miner_diagnostics.py
@@ -29,6 +29,10 @@ from collections import Counter
 from typing import Any, Mapping, Optional, Sequence
 
 from gateway.research_lab.bundles import contains_secret_material, redact_secret_material
+from research_lab.eval.promotion_metric import (
+    benchmark_relative_score_deltas,
+    promotion_improvement_metric,
+)
 
 
 SCHEMA_VERSION = "1.0"
@@ -143,6 +147,14 @@ def _num(value: Any, default: float = 0.0) -> float:
     return result
 
 
+def _num_or_none(value: Any) -> float | None:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
 _WITHHELD = "[summary withheld: contained a redacted token]"
 
 
@@ -246,9 +258,31 @@ def build_candidate_diagnostics(
     # bundle_doc is guaranteed a Mapping here (per_icp is non-empty above).
     raw_excluded = bundle_doc.get("provider_excluded_icp_ids")
     provider_excluded = {str(x) for x in raw_excluded} if isinstance(raw_excluded, Sequence) and not isinstance(raw_excluded, str) else set()
+    gate = (
+        bundle_doc.get("private_holdout_gate")
+        if isinstance(bundle_doc.get("private_holdout_gate"), Mapping)
+        else None
+    )
+    reference_mode = str(
+        aggregates.get("reference_evaluation_mode")
+        or (gate or {}).get("reference_evaluation_mode")
+        or ""
+    )
+    stored_daily_baseline = (
+        reference_mode == "stored_daily_baseline" or gate is not None
+    )
+    raw_baseline_scores = aggregates.get("baseline_per_icp_scores")
+    baseline_per_icp_scores: dict[str, float] = {}
+    if isinstance(raw_baseline_scores, Mapping):
+        for ref, value in raw_baseline_scores.items():
+            normalized_ref = str(ref or "").strip()
+            score = _num_or_none(value)
+            if normalized_ref and score is not None:
+                baseline_per_icp_scores[normalized_ref] = score
 
     public_icps: list[dict[str, Any]] = []
     priv_helped = priv_hurt = priv_flat = priv_infra = priv_total = 0
+    priv_comparison_unavailable = 0
     priv_budget = 0
     pub_infra = 0
     scored_score_sum = 0.0
@@ -259,9 +293,14 @@ def build_candidate_diagnostics(
         ref = str(row.get("icp_ref") or "")
         is_budget = _is_cost_budget_row(row)
         is_infra = _is_infra_row(row, provider_excluded)
-        delta = _num(row.get("delta_vs_base"))
         cand_score = _num(row.get("candidate_per_icp_score"))
-        base_score = _num(row.get("base_per_icp_score"))
+        comparison_available = not stored_daily_baseline or ref in baseline_per_icp_scores
+        if stored_daily_baseline and comparison_available:
+            base_score = baseline_per_icp_scores[ref]
+            delta = cand_score - base_score
+        else:
+            base_score = _num(row.get("base_per_icp_score"))
+            delta = _num(row.get("delta_vs_base"))
 
         # scored-company stats (count + avg ONLY — never the raw vector)
         raw_scores = row.get("candidate_company_scores")
@@ -275,9 +314,12 @@ def build_candidate_diagnostics(
             entry = {
                 "icp_ref": ref,
                 "candidate_score": round(cand_score, 4),
-                "base_score": round(base_score, 4),
-                "delta": round(delta, 4),
             }
+            if comparison_available:
+                entry["base_score"] = round(base_score, 4)
+                entry["delta"] = round(delta, 4)
+            else:
+                entry["comparison_status"] = "benchmark_per_icp_score_unavailable"
             if is_budget:
                 entry["status"] = _BUDGET_EXCEEDED_STATUS
                 entry["reason"] = _BUDGET_EXCEEDED_LABEL
@@ -297,6 +339,8 @@ def build_candidate_diagnostics(
                 priv_budget += 1
             elif is_infra:
                 priv_infra += 1
+            elif not comparison_available:
+                priv_comparison_unavailable += 1
             else:
                 band = _delta_band(delta, flat_band)
                 if band == "helped":
@@ -310,7 +354,6 @@ def build_candidate_diagnostics(
     infra_total = pub_infra + priv_infra
     infra_fraction = (infra_total / total_icps) if total_icps else 0.0
 
-    gate = bundle_doc.get("private_holdout_gate") if isinstance(bundle_doc, Mapping) else None
     gate_out: dict[str, Any] = {}
     if isinstance(gate, Mapping):
         gate_out = {
@@ -320,11 +363,27 @@ def build_candidate_diagnostics(
             "baseline_public_score": round(_num(gate.get("baseline_public_score")), 4),
         }
 
+    mean_delta, delta_lcb = benchmark_relative_score_deltas(bundle_doc)
+    metric = promotion_improvement_metric(bundle_doc)
     aggregate_out = {
-        "candidate_score": round(_num(aggregates.get("candidate_score")), 4),
-        "base_score": round(_num(aggregates.get("base_score")), 4),
-        "mean_delta": round(_num(aggregates.get("mean_delta")), 4),
-        "delta_lcb": round(_num(aggregates.get("delta_lcb")), 4),
+        "candidate_score": round(
+            _num(
+                metric.candidate_total_score
+                if metric.candidate_total_score is not None
+                else aggregates.get("candidate_score")
+            ),
+            4,
+        ),
+        "base_score": round(
+            _num(
+                metric.baseline_aggregate_score
+                if metric.baseline_aggregate_score is not None
+                else aggregates.get("base_score")
+            ),
+            4,
+        ),
+        "mean_delta": round(_num(mean_delta), 4),
+        "delta_lcb": round(_num(delta_lcb), 4),
         "icp_count": total_icps,
         "gate": gate_out,
         "infra": {
@@ -344,6 +403,7 @@ def build_candidate_diagnostics(
         "flat": priv_flat,
         "infra_excluded": priv_infra,
         "cost_budget_exceeded": priv_budget,
+        "comparison_unavailable": priv_comparison_unavailable,
     }
 
     scored_companies = {

--- a/gateway/research_lab/public_activity.py
+++ b/gateway/research_lab/public_activity.py
@@ -11,6 +11,8 @@ import os
 import re
 from typing import Any, Iterable, Mapping, Sequence
 
+from research_lab.eval.promotion_metric import benchmark_relative_score_deltas
+
 from .candidate_diagnostics import (
     NO_BUILDABLE_CANDIDATE_EVENT_TYPE,
     build_candidate_generation_failure_summary,
@@ -1536,14 +1538,8 @@ def _score_bundle_delta(row: Mapping[str, Any] | None) -> tuple[float, float]:
     if not row:
         return 0.0, 0.0
     doc = row.get("score_bundle_doc") if isinstance(row.get("score_bundle_doc"), Mapping) else {}
-    gate = doc.get("private_holdout_gate") if isinstance(doc.get("private_holdout_gate"), Mapping) else {}
-    if str(gate.get("decision") or "") == "rejected_before_private_holdout":
-        return 0.0, 0.0
-    daily_delta = gate.get("candidate_delta_vs_daily_baseline")
-    if daily_delta is not None:
-        return _float(daily_delta), 0.0
-    aggregates = doc.get("aggregates") if isinstance(doc.get("aggregates"), Mapping) else {}
-    return _float(aggregates.get("mean_delta")), _float(aggregates.get("delta_lcb"))
+    mean_delta, delta_lcb = benchmark_relative_score_deltas(doc)
+    return _float(mean_delta), _float(delta_lcb)
 
 
 def _float(value: Any) -> float:

--- a/gateway/research_lab/score_backfill.py
+++ b/gateway/research_lab/score_backfill.py
@@ -32,10 +32,13 @@ import math
 import os
 from typing import Any, Mapping, Sequence
 
+from research_lab.eval.promotion_metric import benchmark_relative_score_deltas
+
 logger = logging.getLogger(__name__)
 
 SCORE_BACKFILL_ENABLED_ENV = "RESEARCH_LAB_SCORE_BACKFILL_ENABLED"
 SCORE_CALIBRATION_TABLE = "research_lab_score_calibration"
+SCORE_BUNDLE_CURRENT = "research_evaluation_score_bundle_current"
 
 
 def score_backfill_enabled() -> bool:
@@ -133,8 +136,9 @@ def build_calibration_row(
     hypothesis = hypothesis if isinstance(hypothesis, Mapping) else {}
     build_doc = candidate.get("candidate_build_doc")
     build_doc = build_doc if isinstance(build_doc, Mapping) else {}
-    aggregates = score_bundle.get("aggregates")
-    aggregates = aggregates if isinstance(aggregates, Mapping) else {}
+    realized_mean_delta, realized_delta_lcb = benchmark_relative_score_deltas(
+        score_bundle
+    )
     return {
         "schema_version": "1.0",
         "candidate_id": str(candidate.get("candidate_id") or "")[:120],
@@ -146,8 +150,8 @@ def build_calibration_row(
         "predicted_delta": _float_or_none(hypothesis.get("predicted_delta")),
         "dev_score": _float_or_none(build_doc.get("loop_dev_score")),
         "dev_score_version": str(build_doc.get("loop_dev_score_version") or "")[:120],
-        "realized_mean_delta": _float_or_none(aggregates.get("mean_delta")),
-        "realized_delta_lcb": _float_or_none(aggregates.get("delta_lcb")),
+        "realized_mean_delta": realized_mean_delta,
+        "realized_delta_lcb": realized_delta_lcb,
         "outcome": str(outcome or "")[:80],
         "score_bundle_id": str(score_bundle_id or "")[:120],
         "created_by": str(created_by or "")[:120],
@@ -235,7 +239,7 @@ async def fetch_score_enrichments_by_node(
     unique_node_ids = list(dict.fromkeys(wanted))
     columns = (
         "node_id,candidate_id,lane,plan_path_id,predicted_delta,dev_score,"
-        "realized_mean_delta,realized_delta_lcb,outcome,created_at"
+        "realized_mean_delta,realized_delta_lcb,outcome,score_bundle_id,created_at"
     )
     filters = [("node_id", "in", unique_node_ids)]
     if hasattr(store, "select_all"):
@@ -255,21 +259,81 @@ async def fetch_score_enrichments_by_node(
             order_by=[("created_at", True)],
             limit=max(1000, len(unique_node_ids) * 100),
         )
-    enrichments: dict[str, dict[str, Any]] = {}
+    newest_rows: dict[str, Mapping[str, Any]] = {}
     wanted_set = set(unique_node_ids)
     for row in rows or []:
         if not isinstance(row, Mapping):
             continue
         node_id = str(row.get("node_id") or "")
-        if not node_id or node_id not in wanted_set or node_id in enrichments:
+        if not node_id or node_id not in wanted_set or node_id in newest_rows:
             continue
+        newest_rows[node_id] = row
+        if len(newest_rows) >= max(1, int(limit)):
+            break
+
+    bundle_ids = list(
+        dict.fromkeys(
+            str(row.get("score_bundle_id") or "")
+            for row in newest_rows.values()
+            if str(row.get("score_bundle_id") or "")
+        )
+    )
+    bundle_docs: dict[str, Mapping[str, Any]] = {}
+    if bundle_ids:
+        try:
+            bundle_filters = [("score_bundle_id", "in", bundle_ids)]
+            if hasattr(store, "select_all"):
+                bundle_rows = await store.select_all(
+                    SCORE_BUNDLE_CURRENT,
+                    columns="score_bundle_id,score_bundle_doc",
+                    filters=bundle_filters,
+                    order_by=(),
+                    batch_size=500,
+                    max_rows=max(1000, len(bundle_ids) * 2),
+                )
+            else:
+                bundle_rows = await store.select_many(
+                    SCORE_BUNDLE_CURRENT,
+                    columns="score_bundle_id,score_bundle_doc",
+                    filters=bundle_filters,
+                    order_by=(),
+                    limit=max(1000, len(bundle_ids) * 2),
+                )
+            for bundle_row in bundle_rows or []:
+                if not isinstance(bundle_row, Mapping):
+                    continue
+                bundle_id = str(bundle_row.get("score_bundle_id") or "")
+                bundle_doc = bundle_row.get("score_bundle_doc")
+                if bundle_id and isinstance(bundle_doc, Mapping):
+                    bundle_docs[bundle_id] = bundle_doc
+        except Exception as exc:
+            logger.warning(
+                "research_lab_score_calibration_bundle_lookup_failed error=%s",
+                str(exc)[:200],
+            )
+
+    missing_bundle_ids = sorted(set(bundle_ids) - set(bundle_docs))
+    if missing_bundle_ids:
+        logger.warning(
+            "research_lab_score_calibration_bundle_missing count=%d",
+            len(missing_bundle_ids),
+        )
+
+    enrichments: dict[str, dict[str, Any]] = {}
+    for node_id, row in newest_rows.items():
+        bundle_id = str(row.get("score_bundle_id") or "")
+        bundle_doc = bundle_docs.get(bundle_id)
+        realized_delta: float | None = None
+        realized_delta_lcb: float | None = None
+        if bundle_doc is not None:
+            realized_delta, realized_delta_lcb = (
+                benchmark_relative_score_deltas(bundle_doc)
+            )
         enrichments[node_id] = {
-            "realized_delta": _float_or_none(row.get("realized_mean_delta")),
-            "realized_delta_lcb": _float_or_none(row.get("realized_delta_lcb")),
+            "realized_delta": realized_delta,
+            "realized_delta_lcb": realized_delta_lcb,
             "predicted_delta": _float_or_none(row.get("predicted_delta")),
             "dev_score": _float_or_none(row.get("dev_score")),
             "scored_outcome": str(row.get("outcome") or "")[:80],
         }
-        if len(enrichments) >= max(1, int(limit)):
-            break
     return enrichments

--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -14,12 +14,13 @@ import importlib
 import inspect
 import json
 import logging
+import math
 import os
 from pathlib import Path
 import re
 import threading
 import time
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, Sequence
 from urllib.parse import urlsplit, urlunsplit
 from urllib import request as urlrequest
 from urllib.error import HTTPError, URLError
@@ -198,6 +199,7 @@ from research_lab.eval.provider_costs import (
     summarize_provider_cost_trace_entries,
 )
 from research_lab.eval.promotion_metric import (
+    PAIRED_LCB_PROMOTION_METRIC_VERSION,
     preliminary_promotion_gate_projection,
     promotion_gate_decision,
 )
@@ -3805,7 +3807,10 @@ class ResearchLabGatewayScoringWorker:
         run_context = self._candidate_run_context(
             candidate, window_hash=window.window_hash, evaluation_epoch=evaluation_epoch
         )
-        evaluation_policy = self._evaluation_policy()
+        evaluation_policy = _stored_daily_baseline_evaluation_policy(
+            self._evaluation_policy(),
+            gate,
+        )
         scoring_config_hash = scoring_configuration_hash()
         public_refs = {str(r) for r in (gate.get("public_icp_refs") or ()) if str(r).strip()}
         conditional_required = bool(gate.get("conditional_validation_required"))
@@ -4722,7 +4727,10 @@ class ResearchLabGatewayScoringWorker:
                 candidate_artifact=ctx["candidate_artifact"],
                 preliminary_results=preliminary_results,
                 run_context={**ctx["run_context"], "signature_ref": "pending"},
-                policy=self._preliminary_evaluation_policy(),
+                policy=_stored_daily_baseline_evaluation_policy(
+                    self._preliminary_evaluation_policy(),
+                    ctx["gate"],
+                ),
                 preliminary_gate=preliminary_gate,
                 parent_receipts=_queue_attested_parent_receipts(
                     docs,
@@ -5855,7 +5863,10 @@ class ResearchLabGatewayScoringWorker:
                 window_hash=window.window_hash,
                 evaluation_epoch=evaluation_epoch,
             )
-            evaluation_policy = self._evaluation_policy()
+            evaluation_policy = _stored_daily_baseline_evaluation_policy(
+                self._evaluation_policy(),
+                private_holdout_gate,
+            )
             scoring_config_hash = scoring_configuration_hash()
             checkpoint_commitment_hash = ""
             if bool(private_holdout_gate.get("conditional_validation_required")):
@@ -5961,7 +5972,10 @@ class ResearchLabGatewayScoringWorker:
                     candidate_artifact=candidate_artifact,
                     preliminary_results=[dict(item) for item in preliminary_results_raw],
                     run_context=unsigned_run_context,
-                    policy=self._preliminary_evaluation_policy(),
+                    policy=_stored_daily_baseline_evaluation_policy(
+                        self._preliminary_evaluation_policy(),
+                        private_holdout_gate,
+                    ),
                     preliminary_gate=payload,
                     parent_receipts=_attested_receipts_from(
                         candidate_runner,
@@ -12406,6 +12420,7 @@ def _private_holdout_gate_from_baseline_row(row: Mapping[str, Any]) -> dict[str,
         policy = assignment.get("policy") if isinstance(assignment.get("policy"), Mapping) else {}
         return {
             "schema_version": "1.1",
+            "promotion_metric_version": PAIRED_LCB_PROMOTION_METRIC_VERSION,
             "gate_type": "public_private_then_conditional_validation",
             "baseline_benchmark_bundle_id": str(row.get("benchmark_bundle_id") or ""),
             "baseline_benchmark_hash": canonical_hash(doc) if doc else "",
@@ -12484,6 +12499,7 @@ def _private_holdout_gate_from_baseline_row(row: Mapping[str, Any]) -> dict[str,
     )
     return {
         "schema_version": "1.0",
+        "promotion_metric_version": PAIRED_LCB_PROMOTION_METRIC_VERSION,
         "gate_type": "public_score_before_private_holdout",
         "baseline_benchmark_bundle_id": str(row.get("benchmark_bundle_id") or ""),
         "baseline_benchmark_hash": canonical_hash(doc) if doc else "",
@@ -12510,6 +12526,9 @@ def _candidate_gate_event_doc(value: Any) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         return {}
     return {
+        "promotion_metric_version": str(
+            value.get("promotion_metric_version") or ""
+        ),
         "gate_type": str(value.get("gate_type") or ""),
         "decision": str(value.get("decision") or ""),
         "baseline_benchmark_bundle_id": str(value.get("baseline_benchmark_bundle_id") or ""),
@@ -12850,6 +12869,40 @@ def _safe_float(value: Any, *, default: float = 0.0) -> float:
         return float(value)
     except (TypeError, ValueError):
         return default
+
+
+def _stored_daily_baseline_evaluation_policy(
+    policy: Mapping[str, Any],
+    gate: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Bind score-bundle arithmetic to the frozen daily baseline per ICP."""
+
+    effective = dict(policy)
+    effective["reference_evaluation_mode"] = "stored_daily_baseline"
+    raw_scores = gate.get("baseline_per_icp_scores")
+    if isinstance(raw_scores, Mapping):
+        baseline_scores: dict[str, float] = {}
+        for key, value in raw_scores.items():
+            ref = str(key or "").strip()
+            if not ref:
+                continue
+            try:
+                score = float(value)
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(score):
+                baseline_scores[ref] = score
+        if baseline_scores:
+            effective["baseline_per_icp_scores"] = baseline_scores
+    excluded = gate.get("provider_excluded_icp_ids")
+    if (
+        isinstance(excluded, Sequence)
+        and not isinstance(excluded, (str, bytes, bytearray))
+    ):
+        effective["provider_excluded_icp_ids"] = sorted(
+            {str(item).strip() for item in excluded if str(item).strip()}
+        )
+    return effective
 
 
 def _safe_int(value: Any, *, default: int) -> int:

--- a/gateway/research_lab/trajectory_projector.py
+++ b/gateway/research_lab/trajectory_projector.py
@@ -97,6 +97,10 @@ from typing import Any, Mapping, Sequence
 
 from research_lab.axis_provenance import axis_rollup, provenance_for_stage
 from research_lab.canonical import coerce_iso_z, sha256_json, utc_now_iso
+from research_lab.eval.promotion_metric import (
+    benchmark_relative_score_deltas,
+    promotion_improvement_metric,
+)
 from research_lab.schema_validation import validate_schema_record
 from research_lab.trajectory_corpus import (
     PROTECTED_CORPUS_KEYS,
@@ -1556,12 +1560,20 @@ def _aggregates_summary(bundle_row: Mapping[str, Any] | None) -> dict[str, Any]:
     for key in (
         "base_score",
         "candidate_score",
-        "mean_delta",
-        "delta_lcb",
         "total_cost_usd",
     ):
         if aggregates.get(key) is not None:
             summary[key] = _f(aggregates.get(key))
+    mean_delta, delta_lcb = benchmark_relative_score_deltas(doc)
+    metric = promotion_improvement_metric(doc)
+    if metric.baseline_aggregate_score is not None:
+        summary["base_score"] = _f(metric.baseline_aggregate_score)
+    if metric.candidate_total_score is not None:
+        summary["candidate_score"] = _f(metric.candidate_total_score)
+    if mean_delta is not None:
+        summary["mean_delta"] = _f(mean_delta)
+    if delta_lcb is not None:
+        summary["delta_lcb"] = _f(delta_lcb)
     return summary
 
 

--- a/gateway/research_lab/worker.py
+++ b/gateway/research_lab/worker.py
@@ -20,6 +20,7 @@ from typing import Any, Iterable, Mapping, Sequence
 from urllib import parse as urlparse
 from urllib import request as urlrequest
 from urllib.error import HTTPError, URLError
+from uuid import UUID
 
 from gateway.research_lab.candidate_diagnostics import (
     build_candidate_generation_failure_summary,
@@ -151,6 +152,7 @@ from research_lab.eval import (
 
 
 logger = logging.getLogger(__name__)
+HOSTED_RUN_ALLOWLIST_ENV = "RESEARCH_LAB_HOSTED_RUN_ALLOWLIST"
 _POSTGREST_TIMESTAMP_RE = re.compile(
     r"^(?P<prefix>\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2})"
     r"\.(?P<fraction>\d{1,9})(?P<suffix>Z|[+-]\d{2}(?::?\d{2})?)?$"
@@ -169,6 +171,40 @@ def _error_backoff_seconds() -> float:
         return max(5.0, float(os.getenv("RESEARCH_LAB_WORKER_ERROR_BACKOFF_SECONDS", "60")))
     except ValueError:
         return 60.0
+
+
+def _hosted_run_allowlist() -> tuple[str, ...]:
+    """Return the canonical run IDs that this worker may claim.
+
+    The empty/default value preserves normal fleet behavior. A configured
+    value is intentionally strict: an invalid canary ID must stop queue
+    selection instead of silently widening the worker back to every paid run.
+    """
+
+    raw = str(os.getenv(HOSTED_RUN_ALLOWLIST_ENV) or "").strip()
+    if not raw:
+        return ()
+    run_ids: set[str] = set()
+    for item in raw.split(","):
+        value = item.strip().lower()
+        if not value:
+            continue
+        try:
+            parsed = str(UUID(value))
+        except (ValueError, AttributeError) as exc:
+            raise HostedResearchLabWorkerError(
+                f"{HOSTED_RUN_ALLOWLIST_ENV} contains an invalid run ID"
+            ) from exc
+        if parsed != value:
+            raise HostedResearchLabWorkerError(
+                f"{HOSTED_RUN_ALLOWLIST_ENV} must contain canonical UUIDs"
+            )
+        run_ids.add(parsed)
+    if not run_ids:
+        raise HostedResearchLabWorkerError(
+            f"{HOSTED_RUN_ALLOWLIST_ENV} contains no run IDs"
+        )
+    return tuple(sorted(run_ids))
 
 
 def _openrouter_generation_attempts() -> int:
@@ -1262,6 +1298,41 @@ def _tree_evaluator_commitment(
     }
 
 
+def _tree_authority_evaluator_commitment(
+    authority_row: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Validate and return the immutable evaluator pinned by a tree row."""
+
+    tree_doc = (
+        dict(authority_row.get("tree_doc") or {})
+        if isinstance(authority_row.get("tree_doc"), Mapping)
+        else {}
+    )
+    raw_commitment = tree_doc.get("evaluator_commitment")
+    commitment = (
+        dict(raw_commitment)
+        if isinstance(raw_commitment, Mapping)
+        and raw_commitment.get("schema_version")
+        == "research_lab.git_tree_evaluator_commitment.v3"
+        else None
+    )
+    if commitment is None:
+        return None
+    resolved_snapshot_uri = str(
+        commitment.get("resolved_snapshot_uri") or ""
+    ).strip()
+    if (
+        not resolved_snapshot_uri
+        or resolved_snapshot_uri.endswith("/current.json")
+        or sha256_json(commitment)
+        != str(authority_row.get("evaluator_commitment_hash") or "")
+    ):
+        raise HostedResearchLabWorkerError(
+            "Git-tree evaluator commitment differs from its authority"
+        )
+    return commitment
+
+
 def _replacement_resume_state(
     checkpoint_doc: Mapping[str, Any] | None,
     *,
@@ -1577,6 +1648,10 @@ class ResearchLabHostedWorker:
 
     async def run_once(self) -> HostedWorkerOutcome:
         self._require_enabled()
+        # Validate the canary boundary before any recovery/reconciliation
+        # write. A typo must fail closed before stale-run reapers can widen the
+        # activation beyond the intended run.
+        _hosted_run_allowlist()
         if not self.config.hosted_worker_dry_run:
             await self._recover_stale_started_runs()
             await self._reconcile_stale_loop_projections()
@@ -1673,6 +1748,32 @@ class ResearchLabHostedWorker:
                 error=str(exc)[:500],
             )
         context = await self._load_run_context(queued)
+        try:
+            tree_preflight_reason = await self._preclaim_tree_readiness(context)
+        except Exception as exc:
+            tree_preflight_reason = (
+                "tree_preclaim_readiness_unavailable:"
+                f"{exc.__class__.__name__}"
+            )
+            logger.warning(
+                "research_lab_git_tree_preclaim_failed run_id=%s error=%s",
+                compact_ref(run_id),
+                str(exc)[:240],
+            )
+        if tree_preflight_reason:
+            logger.warning(
+                "research_lab_git_tree_preclaim_deferred run_id=%s reason=%s",
+                compact_ref(run_id),
+                tree_preflight_reason[:300],
+            )
+            return HostedWorkerOutcome(
+                processed=False,
+                dry_run=False,
+                run_id=run_id,
+                ticket_id=ticket_id,
+                status="tree_preflight_deferred",
+                error=tree_preflight_reason[:500],
+            )
         try:
             return await self._process_run(context)
         except HostedResearchLabClaimLost as exc:
@@ -1816,13 +1917,159 @@ class ResearchLabHostedWorker:
             ) from exc
 
     async def _next_queued_run(self) -> Mapping[str, Any] | None:
+        allowlist = _hosted_run_allowlist()
+        filters: list[tuple[Any, ...]] = [
+            ("current_queue_status", "queued")
+        ]
+        if allowlist:
+            filters.append(("run_id", "in", allowlist))
         rows = await select_many(
             "research_loop_run_queue_current",
-            filters=(("current_queue_status", "queued"),),
+            filters=tuple(filters),
             order_by=(("queue_priority", False), ("current_status_at", False)),
             limit=self.config.hosted_worker_queue_fetch_limit,
         )
+        if allowlist:
+            allowed = set(allowlist)
+            rows = [
+                row for row in rows if str(row.get("run_id") or "") in allowed
+            ]
         return self._select_preferred_queued_row(rows)
+
+    async def _preclaim_tree_readiness(
+        self,
+        context: HostedRunContext,
+    ) -> str:
+        """Check the exact evaluator inputs before any paid-run state mutation."""
+
+        try:
+            await maybe_refresh_dev_snapshot(
+                self.config,
+                worker_index=int(self.config.hosted_worker_index or 0),
+                tree_policy=self.tree_policy,
+            )
+        except Exception as exc:
+            # A refresh failure does not make a still-current immutable
+            # snapshot unusable. The exact readiness check below remains the
+            # fail-closed authority.
+            logger.warning(
+                "research_lab_preclaim_dev_snapshot_refresh_failed "
+                "worker_ref=%s error=%s",
+                self.worker_ref,
+                str(exc)[:200],
+            )
+        active = await load_active_private_model(
+            self.config,
+            register_bootstrap=False,
+        )
+        artifact = active.artifact
+        authority = await select_one(
+            "research_lab_autoresearch_run_tree_current",
+            columns=(
+                "root_artifact_hash,root_manifest_hash,policy_hash,"
+                "evaluator_commitment_hash,tree_doc"
+            ),
+            filters=(("run_id", context.run_id),),
+        )
+        pinned_evaluator_commitment: Mapping[str, Any] | None = None
+        if (
+            isinstance(authority, Mapping)
+            and str(authority.get("root_artifact_hash") or "")
+            == str(artifact.model_artifact_hash or "")
+            and str(authority.get("root_manifest_hash") or "")
+            == str(artifact.manifest_hash or "")
+            and str(authority.get("policy_hash") or "")
+            == self.tree_policy.policy_hash
+        ):
+            pinned_evaluator_commitment = (
+                _tree_authority_evaluator_commitment(authority)
+            )
+        _readiness, _commitment, reason = (
+            await self._load_tree_snapshot_readiness(
+                context=context,
+                artifact=artifact,
+                pinned_evaluator_commitment=pinned_evaluator_commitment,
+            )
+        )
+        return reason
+
+    async def _load_tree_snapshot_readiness(
+        self,
+        *,
+        context: HostedRunContext,
+        artifact: Any,
+        pinned_evaluator_commitment: Mapping[str, Any] | None,
+    ) -> tuple[dict[str, Any], dict[str, Any], str]:
+        ticket_doc = (
+            context.ticket.get("ticket_doc")
+            if isinstance(context.ticket.get("ticket_doc"), Mapping)
+            else {}
+        )
+        miner_direction = str(
+            ticket_doc.get("brief_public_summary")
+            or context.ticket.get("brief_public_summary")
+            or ""
+        )
+        snapshot_uri = str(
+            (
+                pinned_evaluator_commitment.get("resolved_snapshot_uri")
+                if pinned_evaluator_commitment is not None
+                else None
+            )
+            or os.getenv("RESEARCH_LAB_DEV_SNAPSHOT_URI")
+            or DEFAULT_RESEARCH_LAB_DEV_SNAPSHOT_URI
+        )
+        readiness = await asyncio.to_thread(
+            snapshot_readiness,
+            snapshot_uri,
+            expected_dev_icp_count=self.tree_policy.live_max_icps_per_node,
+            selection_seed=str(context.run_id),
+            miner_direction=miner_direction,
+            require_current_day=pinned_evaluator_commitment is None,
+        )
+        reason = ""
+        if not dev_eval_runner_enabled():
+            reason = "tree_dev_evaluator_kill_switch_disabled"
+        elif not bool(readiness.get("ready")):
+            reason = "tree_snapshot_not_ready:" + str(
+                readiness.get("reason") or "unknown"
+            )
+        elif float(readiness.get("snapshot_age_seconds") or 0.0) > 14 * 86400:
+            reason = "tree_snapshot_stale"
+        elif str(readiness.get("champion_image_digest") or "") != str(
+            artifact.image_digest or ""
+        ):
+            reason = "tree_snapshot_champion_image_differs_from_active_model"
+        elif str(readiness.get("private_model_manifest_hash") or "") != str(
+            artifact.manifest_hash or ""
+        ):
+            reason = "tree_snapshot_benchmark_model_differs_from_active_model"
+
+        evaluator_commitment: dict[str, Any] = {}
+        if not reason:
+            evaluator_commitment = _tree_evaluator_commitment(
+                readiness,
+                policy=self.tree_policy,
+                snapshot_pointer_hash=(
+                    str(
+                        pinned_evaluator_commitment.get(
+                            "snapshot_pointer_hash"
+                        )
+                        or ""
+                    )
+                    if pinned_evaluator_commitment is not None
+                    else None
+                ),
+            )
+            if (
+                pinned_evaluator_commitment is not None
+                and evaluator_commitment
+                != dict(pinned_evaluator_commitment)
+            ):
+                reason = (
+                    "tree_snapshot_commitment_does_not_match_pinned_tree"
+                )
+        return dict(readiness), evaluator_commitment, reason
 
     def _select_preferred_queued_row(self, rows: Sequence[Mapping[str, Any]]) -> Mapping[str, Any] | None:
         if not rows:
@@ -2141,20 +2388,29 @@ class ResearchLabHostedWorker:
             60,
             int(self.config.active_loop_stale_after_seconds or DEFAULT_ACTIVE_LOOP_STALE_AFTER_SECONDS),
         )
+        allowlist = _hosted_run_allowlist()
+        filters: list[tuple[Any, ...]] = [
+            ("current_queue_status", "started")
+        ]
+        if allowlist:
+            filters.append(("run_id", "in", allowlist))
         rows = await select_many(
             "research_loop_run_queue_current",
             columns=(
                 "run_id,ticket_id,current_queue_status,current_status_at,"
                 "current_event_hash,queue_priority,worker_ref"
             ),
-            filters=(("current_queue_status", "started"),),
+            filters=tuple(filters),
             # Oldest-first so the stalest rows are still seen when the backlog
             # exceeds the fetch limit.
             order_by=(("current_status_at", False),),
             limit=50,
         )
         recovered = 0
+        allowed = set(allowlist)
         for row in rows:
+            if allowed and str(row.get("run_id") or "") not in allowed:
+                continue
             if not _status_is_stale(row.get("current_status_at"), stale_after_seconds):
                 continue
             run_id = str(row.get("run_id") or "")
@@ -2201,20 +2457,29 @@ class ResearchLabHostedWorker:
             60,
             int(self.config.active_loop_stale_after_seconds or DEFAULT_ACTIVE_LOOP_STALE_AFTER_SECONDS),
         )
+        allowlist = _hosted_run_allowlist()
+        filters: list[tuple[Any, ...]] = [
+            ("current_queue_status", "paused")
+        ]
+        if allowlist:
+            filters.append(("run_id", "in", allowlist))
         rows = await select_many(
             "research_loop_run_queue_current",
             columns=(
                 "run_id,ticket_id,current_queue_status,current_reason,current_status_at,"
                 "current_event_hash,queue_priority,worker_ref"
             ),
-            filters=(("current_queue_status", "paused"),),
+            filters=tuple(filters),
             # Oldest-first so the stalest rows are still seen when the backlog
             # exceeds the fetch limit.
             order_by=(("current_status_at", False),),
             limit=50,
         )
         recovered = 0
+        allowed = set(allowlist)
         for row in rows:
+            if allowed and str(row.get("run_id") or "") not in allowed:
+                continue
             if str(row.get("current_reason") or "") in _STALE_PAUSED_REAPER_EXCLUDED_REASONS:
                 # Deliberately parked runs (e.g. blocked_for_credit awaiting a
                 # key top-up) are only revived by their explicit resume paths.
@@ -2392,83 +2657,18 @@ class ResearchLabHostedWorker:
             return tree_authority.outcome
         tree_id = tree_authority.tree_id
         resume_state = tree_authority.resume_state
-        ticket_doc = (
-            context.ticket.get("ticket_doc")
-            if isinstance(context.ticket.get("ticket_doc"), Mapping)
-            else {}
-        )
-        miner_direction = str(
-            ticket_doc.get("brief_public_summary")
-            or context.ticket.get("brief_public_summary")
-            or ""
-        )
-        dev_selection_seed = str(context.run_id)
         pinned_evaluator_commitment = (
             dict(tree_authority.evaluator_commitment)
             if isinstance(tree_authority.evaluator_commitment, Mapping)
             else None
         )
-        snapshot_uri = str(
-            (
-                pinned_evaluator_commitment.get("resolved_snapshot_uri")
-                if pinned_evaluator_commitment is not None
-                else None
+        readiness, evaluator_commitment, tree_preflight_reason = (
+            await self._load_tree_snapshot_readiness(
+                context=context,
+                artifact=artifact,
+                pinned_evaluator_commitment=pinned_evaluator_commitment,
             )
-            or os.getenv("RESEARCH_LAB_DEV_SNAPSHOT_URI")
-            or DEFAULT_RESEARCH_LAB_DEV_SNAPSHOT_URI
         )
-        readiness = await asyncio.to_thread(
-            snapshot_readiness,
-            snapshot_uri,
-            expected_dev_icp_count=self.tree_policy.live_max_icps_per_node,
-            selection_seed=dev_selection_seed,
-            miner_direction=miner_direction,
-            require_current_day=pinned_evaluator_commitment is None,
-        )
-        tree_preflight_reason = ""
-        if not dev_eval_runner_enabled():
-            tree_preflight_reason = "tree_dev_evaluator_kill_switch_disabled"
-        elif not bool(readiness.get("ready")):
-            tree_preflight_reason = "tree_snapshot_not_ready:" + str(
-                readiness.get("reason") or "unknown"
-            )
-        elif float(readiness.get("snapshot_age_seconds") or 0.0) > 14 * 86400:
-            tree_preflight_reason = "tree_snapshot_stale"
-        elif str(readiness.get("champion_image_digest") or "") != str(
-            artifact.image_digest or ""
-        ):
-            tree_preflight_reason = (
-                "tree_snapshot_champion_image_differs_from_active_model"
-            )
-        elif str(readiness.get("private_model_manifest_hash") or "") != str(
-            artifact.manifest_hash or ""
-        ):
-            tree_preflight_reason = (
-                "tree_snapshot_benchmark_model_differs_from_active_model"
-            )
-        evaluator_commitment: dict[str, Any] = {}
-        if not tree_preflight_reason:
-            evaluator_commitment = _tree_evaluator_commitment(
-                readiness,
-                policy=self.tree_policy,
-                snapshot_pointer_hash=(
-                    str(
-                        pinned_evaluator_commitment.get(
-                            "snapshot_pointer_hash"
-                        )
-                        or ""
-                    )
-                    if pinned_evaluator_commitment is not None
-                    else None
-                ),
-            )
-            if (
-                pinned_evaluator_commitment is not None
-                and evaluator_commitment != pinned_evaluator_commitment
-            ):
-                tree_preflight_reason = (
-                    "tree_snapshot_commitment_does_not_match_pinned_tree"
-                )
         if tree_preflight_reason:
             logger.warning(
                 "research_lab_git_tree_preflight_deferred run_id=%s reason=%s",
@@ -4253,28 +4453,7 @@ class ResearchLabHostedWorker:
             if isinstance(existing.get("tree_doc"), Mapping)
             else {}
         )
-        raw_evaluator_commitment = tree_doc.get("evaluator_commitment")
-        evaluator_commitment = (
-            dict(raw_evaluator_commitment)
-            if isinstance(raw_evaluator_commitment, Mapping)
-            and raw_evaluator_commitment.get("schema_version")
-            == "research_lab.git_tree_evaluator_commitment.v3"
-            else None
-        )
-        if evaluator_commitment is not None:
-            if (
-                not str(
-                    evaluator_commitment.get("resolved_snapshot_uri") or ""
-                ).strip()
-                or str(
-                    evaluator_commitment.get("resolved_snapshot_uri") or ""
-                ).endswith("/current.json")
-                or sha256_json(evaluator_commitment)
-                != str(existing.get("evaluator_commitment_hash") or "")
-            ):
-                raise HostedResearchLabWorkerError(
-                    "Git-tree evaluator commitment differs from its authority"
-                )
+        evaluator_commitment = _tree_authority_evaluator_commitment(existing)
         generation = max(0, int(existing.get("tree_generation") or 0))
         current_event_type = str(existing.get("current_event_type") or "")
         current_event_doc = (

--- a/gateway/research_lab/worker.py
+++ b/gateway/research_lab/worker.py
@@ -149,6 +149,7 @@ from research_lab.eval import (
     DockerPrivateModelSpec,
     private_model_env_passthrough,
 )
+from research_lab.eval.promotion_metric import promotion_improvement_metric
 
 
 logger = logging.getLogger(__name__)
@@ -6345,12 +6346,8 @@ class ResearchLabHostedWorker:
         for row in score_bundles:
             bundle_id = str(row.get("score_bundle_id") or "")
             doc = row.get("score_bundle_doc") if isinstance(row.get("score_bundle_doc"), Mapping) else {}
-            aggregates = doc.get("aggregates") if isinstance(doc.get("aggregates"), Mapping) else {}
-            if bundle_id and aggregates:
-                bundle_deltas[bundle_id] = {
-                    "score_delta": _safe_float_for_memory(aggregates.get("mean_delta")),
-                    "score_delta_lcb": _safe_float_for_memory(aggregates.get("delta_lcb")),
-                }
+            if bundle_id and doc:
+                bundle_deltas[bundle_id] = _realized_score_delta_for_memory(doc)
         lane_counts: Counter[str] = Counter()
         target_file_counts: Counter[str] = Counter()
         status_counts: Counter[str] = Counter()
@@ -6399,8 +6396,9 @@ class ResearchLabHostedWorker:
             if not aggregates:
                 continue
             scored_count += 1
-            mean_delta = _safe_float_for_memory(aggregates.get("mean_delta"))
-            delta_lcb = _safe_float_for_memory(aggregates.get("delta_lcb"))
+            realized = _realized_score_delta_for_memory(doc)
+            mean_delta = realized["score_delta"]
+            delta_lcb = realized["score_delta_lcb"]
             if mean_delta > 0:
                 positive_delta_count += 1
             else:
@@ -6777,6 +6775,46 @@ def _safe_float_for_memory(value: Any) -> float:
         return float(value)
     except (TypeError, ValueError):
         return 0.0
+
+
+def _realized_score_delta_for_memory(
+    score_bundle: Mapping[str, Any],
+) -> dict[str, float]:
+    """Return benchmark-relative deltas for loop-planner feedback.
+
+    Stored-daily-baseline bundles record candidate-vs-zero arithmetic in
+    ``aggregates`` for historical hash compatibility. Those values are not
+    improvement deltas. New stamped bundles carry the verifier-recomputed
+    paired mean/LCB in the promotion metric; historical holdout bundles retain
+    their aggregate daily-baseline delta but have no trustworthy paired LCB.
+    Truly paired legacy bundles have no holdout gate and keep their original
+    aggregate semantics.
+    """
+
+    aggregates = (
+        score_bundle.get("aggregates")
+        if isinstance(score_bundle.get("aggregates"), Mapping)
+        else {}
+    )
+    holdout_gate = score_bundle.get("private_holdout_gate")
+    if not isinstance(holdout_gate, Mapping):
+        return {
+            "score_delta": _safe_float_for_memory(aggregates.get("mean_delta")),
+            "score_delta_lcb": _safe_float_for_memory(
+                aggregates.get("delta_lcb")
+            ),
+        }
+
+    metric = promotion_improvement_metric(score_bundle)
+    mean_delta = (
+        metric.paired_mean_delta
+        if metric.paired_mean_delta is not None
+        else metric.improvement_points
+    )
+    return {
+        "score_delta": _safe_float_for_memory(mean_delta),
+        "score_delta_lcb": _safe_float_for_memory(metric.paired_delta_lcb),
+    }
 
 
 def _looks_secret_like(value: str) -> bool:

--- a/gateway/research_lab/worker.py
+++ b/gateway/research_lab/worker.py
@@ -149,7 +149,7 @@ from research_lab.eval import (
     DockerPrivateModelSpec,
     private_model_env_passthrough,
 )
-from research_lab.eval.promotion_metric import promotion_improvement_metric
+from research_lab.eval.promotion_metric import benchmark_relative_score_deltas
 
 
 logger = logging.getLogger(__name__)
@@ -6791,29 +6791,10 @@ def _realized_score_delta_for_memory(
     aggregate semantics.
     """
 
-    aggregates = (
-        score_bundle.get("aggregates")
-        if isinstance(score_bundle.get("aggregates"), Mapping)
-        else {}
-    )
-    holdout_gate = score_bundle.get("private_holdout_gate")
-    if not isinstance(holdout_gate, Mapping):
-        return {
-            "score_delta": _safe_float_for_memory(aggregates.get("mean_delta")),
-            "score_delta_lcb": _safe_float_for_memory(
-                aggregates.get("delta_lcb")
-            ),
-        }
-
-    metric = promotion_improvement_metric(score_bundle)
-    mean_delta = (
-        metric.paired_mean_delta
-        if metric.paired_mean_delta is not None
-        else metric.improvement_points
-    )
+    mean_delta, delta_lcb = benchmark_relative_score_deltas(score_bundle)
     return {
         "score_delta": _safe_float_for_memory(mean_delta),
-        "score_delta_lcb": _safe_float_for_memory(metric.paired_delta_lcb),
+        "score_delta_lcb": _safe_float_for_memory(delta_lcb),
     }
 
 

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -967,7 +967,7 @@
       "symbol": "benchmark_icp_score_from_company_scores"
     },
     {
-      "ast_sha256": "sha256:d81609dced8f91216b7593a0f77c11ef66bf9f012bb41c9ed44b1b6d3dcf44ed",
+      "ast_sha256": "sha256:c769fd46954ce732607031b6447c5efcec937a2bc40a8216ac58ac1a1066479a",
       "path": "research_lab/eval/evaluator.py",
       "symbol": "build_holdout_gate_result"
     },
@@ -997,12 +997,17 @@
       "symbol": "score_private_model_pair_items"
     },
     {
+      "ast_sha256": "sha256:0c4b4b82fd3d9ce38d145133a881860f3f1841aaa1251ea43d754cc7196db6ca",
+      "path": "research_lab/eval/promotion_metric.py",
+      "symbol": "_paired_lcb_promotion_metric"
+    },
+    {
       "ast_sha256": "sha256:b5d4acbc586cbfefe5952aff229d0e0c23e5649bca00c48f90944017aa280891",
       "path": "research_lab/eval/promotion_metric.py",
       "symbol": "promotion_gate_decision"
     },
     {
-      "ast_sha256": "sha256:b35f57d35e61e28b57d9fd1b625225e56737cd96e26d20adf5e7f61064f9c130",
+      "ast_sha256": "sha256:170428e83bd8ce5e15e6c2f64b4d28b54acf48c74badb03d61d28ad745436dbc",
       "path": "research_lab/eval/promotion_metric.py",
       "symbol": "promotion_improvement_metric"
     },

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1092,7 +1092,7 @@
       "symbol": "validate_source_add_reward_record"
     }
   ],
-  "manifest_hash": "sha256:8ba6f766b587cdb4362ddcdca287aaaf97500fc4c54723ceb5a454847e2c8678",
-  "protected_source_commit": "b454e973a06cbb74431a890e739e513abb541362",
+  "manifest_hash": "sha256:3d347ee91485a14bce19e7884e870e11aabe425fe140d6e1618dfda42d2af72f",
+  "protected_source_commit": "59999ceee060e35b447492db455b5f7f4bcac14a",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/protected_workflows.py
+++ b/gateway/tee/protected_workflows.py
@@ -161,6 +161,7 @@ PROTECTED_SYMBOLS = {
         "build_baseline_score_summary",
     ),
     "research_lab/eval/promotion_metric.py": (
+        "_paired_lcb_promotion_metric",
         "promotion_improvement_metric",
         "promotion_gate_decision",
     ),

--- a/gateway/tee/research_lab_runtime_config_v2.py
+++ b/gateway/tee/research_lab_runtime_config_v2.py
@@ -49,7 +49,7 @@ from research_lab.eval.snapshot_store import (
 )
 
 
-SCHEMA_VERSION = "leadpoet.research_lab_execution_config.v3"
+SCHEMA_VERSION = "leadpoet.research_lab_execution_config.v4"
 _CONFIG_FIELD_NAMES_HASH = (
     "sha256:7b7b8623e08d23e400fe2e75f40f076c7b6e6a2c2e58df8779c41c393d2224d6"
 )
@@ -71,6 +71,7 @@ HOST_ONLY_SECRET_FIELDS = frozenset(
 # successful path while preventing enclave-local defaults from taking over.
 AUTORESEARCH_BEHAVIOR_ENV_NAMES = (
     "RESEARCH_LAB_DEV_SNAPSHOT_URI",
+    "RESEARCH_LAB_HOSTED_RUN_ALLOWLIST",
     "RESEARCH_LAB_LOOP_BUILD_HEARTBEAT",
     "RESEARCH_LAB_LOOP_DEV_EVAL_ENABLED",
     "RESEARCH_LAB_LOOP_DEV_EVAL_ICP_TIMEOUT_SECONDS",

--- a/research_lab/eval/evaluator.py
+++ b/research_lab/eval/evaluator.py
@@ -39,6 +39,7 @@ from .private_runtime import (
     publish_incontainer_trace_entries,
 )
 from .provider_costs import summarize_provider_cost_trace_entries
+from .promotion_metric import PAIRED_LCB_PROMOTION_METRIC_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -1712,6 +1713,16 @@ def build_holdout_gate_result(
         "private_holdout_icp_count": private_icp_count,
         "private_holdout_evaluated": bool(passed_public_gate),
         "provider_excluded_icp_ids": _provider_excluded_icp_ids(public_results),
+        **(
+            {
+                "promotion_metric_version": str(
+                    gate.get("promotion_metric_version")
+                )
+            }
+            if str(gate.get("promotion_metric_version") or "")
+            == PAIRED_LCB_PROMOTION_METRIC_VERSION
+            else {}
+        ),
     }
     if not passed_public_gate:
         return list(public_results), gate_result
@@ -1783,6 +1794,16 @@ def _build_conditional_holdout_gate_result(
             gate.get("conditional_validation_policy_hash") or ""
         ),
         "provider_excluded_icp_ids": _provider_excluded_icp_ids(public_results),
+        **(
+            {
+                "promotion_metric_version": str(
+                    gate.get("promotion_metric_version")
+                )
+            }
+            if str(gate.get("promotion_metric_version") or "")
+            == PAIRED_LCB_PROMOTION_METRIC_VERSION
+            else {}
+        ),
     }
     if not passed_public_gate:
         return list(public_results), base_result

--- a/research_lab/eval/promotion_metric.py
+++ b/research_lab/eval/promotion_metric.py
@@ -7,6 +7,9 @@ import math
 from typing import Any, Mapping, Sequence
 
 
+PAIRED_LCB_PROMOTION_METRIC_VERSION = "paired_lcb_v1"
+
+
 @dataclass(frozen=True)
 class PromotionImprovementMetric:
     improvement_points: float
@@ -19,6 +22,11 @@ class PromotionImprovementMetric:
     provider_excluded_icp_ids: tuple[str, ...] = ()
     baseline_basis_adjusted: bool = False
     unadjusted_baseline_aggregate_score: float | None = None
+    promotion_metric_version: str = ""
+    paired_mean_delta: float | None = None
+    paired_se_delta: float | None = None
+    paired_delta_lcb: float | None = None
+    paired_icp_count: int | None = None
 
     def event_doc(self) -> dict[str, Any]:
         return {
@@ -31,6 +39,11 @@ class PromotionImprovementMetric:
             "provider_excluded_icp_ids": list(self.provider_excluded_icp_ids),
             "baseline_basis_adjusted": self.baseline_basis_adjusted,
             "unadjusted_baseline_aggregate_score": self.unadjusted_baseline_aggregate_score,
+            "promotion_metric_version": self.promotion_metric_version,
+            "paired_mean_delta": self.paired_mean_delta,
+            "paired_se_delta": self.paired_se_delta,
+            "paired_delta_lcb": self.paired_delta_lcb,
+            "paired_icp_count": self.paired_icp_count,
         }
 
 
@@ -131,6 +144,17 @@ def promotion_improvement_metric(
                 and bool(gate.get("conditional_holdout_evaluated"))
                 and daily_delta is not None
             ):
+                if (
+                    str(gate.get("promotion_metric_version") or "")
+                    == PAIRED_LCB_PROMOTION_METRIC_VERSION
+                ):
+                    return _paired_lcb_promotion_metric(
+                        score_bundle,
+                        baseline_aggregate=baseline_aggregate,
+                        candidate_total=candidate_total,
+                        daily_delta=daily_delta,
+                        excluded_icp_ids=excluded_icp_ids,
+                    )
                 return PromotionImprovementMetric(
                     improvement_points=float(daily_delta),
                     basis="stored_daily_baseline_conditional_full_bank_delta",
@@ -168,6 +192,17 @@ def promotion_improvement_metric(
             and bool(gate.get("private_holdout_evaluated"))
             and daily_delta is not None
         ):
+            if (
+                str(gate.get("promotion_metric_version") or "")
+                == PAIRED_LCB_PROMOTION_METRIC_VERSION
+            ):
+                return _paired_lcb_promotion_metric(
+                    score_bundle,
+                    baseline_aggregate=baseline_aggregate,
+                    candidate_total=candidate_total,
+                    daily_delta=daily_delta,
+                    excluded_icp_ids=excluded_icp_ids,
+                )
             return PromotionImprovementMetric(
                 improvement_points=float(daily_delta),
                 basis="stored_daily_baseline_total_delta",
@@ -198,6 +233,84 @@ def promotion_improvement_metric(
         improvement_points=float(legacy_delta),
         basis="legacy_paired_mean_delta_no_holdout_gate",
         daily_baseline_available=False,
+    )
+
+
+def _paired_lcb_promotion_metric(
+    score_bundle: Mapping[str, Any],
+    *,
+    baseline_aggregate: float | None,
+    candidate_total: float | None,
+    daily_delta: float,
+    excluded_icp_ids: tuple[str, ...],
+) -> PromotionImprovementMetric:
+    """Use the verifier-recomputed lower confidence bound for new scores."""
+
+    improvement_gate = score_bundle.get("improvement_gate")
+    gate_doc = (
+        improvement_gate if isinstance(improvement_gate, Mapping) else {}
+    )
+    reference_mode = str(
+        gate_doc.get("reference_evaluation_mode") or ""
+    )
+    advisory_basis = str(gate_doc.get("advisory_basis") or "")
+    mean_delta = _finite_optional_float(gate_doc.get("mean_delta"))
+    se_delta = _finite_optional_float(gate_doc.get("se_delta"))
+    delta_lcb = _finite_optional_float(gate_doc.get("delta_lcb"))
+    try:
+        compared_icp_count = int(gate_doc.get("compared_icp_count") or 0)
+    except (TypeError, ValueError):
+        compared_icp_count = 0
+    blockers = gate_doc.get("blockers")
+    blocker_list = (
+        [str(item) for item in blockers]
+        if isinstance(blockers, Sequence)
+        and not isinstance(blockers, (str, bytes, bytearray))
+        else []
+    )
+    confidence_available = (
+        reference_mode == "stored_daily_baseline"
+        and advisory_basis
+        == "recomputed_candidate_vs_stored_daily_baseline_per_icp"
+        and mean_delta is not None
+        and se_delta is not None
+        and se_delta >= 0.0
+        and delta_lcb is not None
+        and compared_icp_count > 0
+    )
+    if not confidence_available:
+        return PromotionImprovementMetric(
+            improvement_points=0.0,
+            basis="stored_daily_baseline_paired_lcb_unavailable",
+            daily_baseline_available=False,
+            baseline_aggregate_score=baseline_aggregate,
+            candidate_total_score=candidate_total,
+            candidate_delta_vs_daily_baseline=float(daily_delta),
+            rejection_status="rejected_paired_lcb_unavailable",
+            provider_excluded_icp_ids=excluded_icp_ids,
+            promotion_metric_version=PAIRED_LCB_PROMOTION_METRIC_VERSION,
+        )
+    rejection_status = None
+    if (
+        str(gate_doc.get("decision") or "") != "eligible_for_probation"
+        or not bool(gate_doc.get("eligible_for_probation"))
+        or blocker_list
+    ):
+        rejection_status = "rejected_paired_lcb_gate_ineligible"
+    return PromotionImprovementMetric(
+        improvement_points=float(delta_lcb),
+        basis="stored_daily_baseline_paired_delta_lcb",
+        daily_baseline_available=True,
+        baseline_aggregate_score=baseline_aggregate,
+        candidate_total_score=candidate_total,
+        candidate_delta_vs_daily_baseline=float(daily_delta),
+        rejection_status=rejection_status,
+        provider_excluded_icp_ids=excluded_icp_ids,
+        promotion_metric_version=PAIRED_LCB_PROMOTION_METRIC_VERSION,
+        paired_mean_delta=float(mean_delta),
+        paired_se_delta=float(se_delta),
+        paired_delta_lcb=float(delta_lcb),
+        paired_icp_count=compared_icp_count,
     )
 
 
@@ -261,6 +374,13 @@ def _optional_float(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _finite_optional_float(value: Any) -> float | None:
+    parsed = _optional_float(value)
+    if parsed is None or not math.isfinite(parsed):
+        return None
+    return parsed
 
 
 def _required_finite_score(value: Any, field: str) -> float:

--- a/research_lab/eval/promotion_metric.py
+++ b/research_lab/eval/promotion_metric.py
@@ -236,6 +236,42 @@ def promotion_improvement_metric(
     )
 
 
+def benchmark_relative_score_deltas(
+    score_bundle: Mapping[str, Any],
+) -> tuple[float | None, float | None]:
+    """Return planner-safe realized deltas against the applicable benchmark.
+
+    Historical stored-daily-baseline bundles keep candidate-vs-zero arithmetic
+    in ``aggregates`` for hash compatibility, so those fields are not valid
+    improvement feedback. Truly paired legacy bundles have no holdout gate and
+    retain their aggregate semantics. New stamped bundles expose the verifier-
+    recomputed paired mean and lower confidence bound through the promotion
+    metric.
+    """
+
+    aggregates = (
+        score_bundle.get("aggregates")
+        if isinstance(score_bundle.get("aggregates"), Mapping)
+        else {}
+    )
+    if not isinstance(score_bundle.get("private_holdout_gate"), Mapping):
+        return (
+            _finite_optional_float(aggregates.get("mean_delta")),
+            _finite_optional_float(aggregates.get("delta_lcb")),
+        )
+
+    metric = promotion_improvement_metric(score_bundle)
+    mean_delta = (
+        metric.paired_mean_delta
+        if metric.paired_mean_delta is not None
+        else metric.improvement_points
+    )
+    return (
+        _finite_optional_float(mean_delta),
+        _finite_optional_float(metric.paired_delta_lcb),
+    )
+
+
 def _paired_lcb_promotion_metric(
     score_bundle: Mapping[str, Any],
     *,

--- a/research_lab/improvement_engine/scanner.py
+++ b/research_lab/improvement_engine/scanner.py
@@ -6,6 +6,7 @@ from collections import Counter
 from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping, Sequence
 
+from research_lab.eval.promotion_metric import benchmark_relative_score_deltas
 from research_lab.observability.redaction import redact_for_langfuse
 
 from .clusterer import cluster_events
@@ -37,7 +38,6 @@ def _as_float(value: Any) -> float | None:
 
 def _score_bundle_events(row: Mapping[str, Any]) -> list[EngineTraceEvent]:
     doc = row.get("score_bundle_doc") if isinstance(row.get("score_bundle_doc"), Mapping) else {}
-    aggregates = doc.get("aggregates") if isinstance(doc.get("aggregates"), Mapping) else {}
     scoring_health = doc.get("scoring_health") if isinstance(doc.get("scoring_health"), Mapping) else {}
     baseline_health = doc.get("baseline_health") if isinstance(doc.get("baseline_health"), Mapping) else {}
     events: list[EngineTraceEvent] = []
@@ -45,7 +45,7 @@ def _score_bundle_events(row: Mapping[str, Any]) -> list[EngineTraceEvent]:
     ticket_id = str(row.get("ticket_id") or doc.get("ticket_id") or "")
     score_hash = str(row.get("score_bundle_hash") or doc.get("score_bundle_hash") or "")
     created_at = _event_time(row)
-    delta = _as_float(aggregates.get("mean_delta"))
+    delta, _delta_lcb = benchmark_relative_score_deltas(doc)
     if int(scoring_health.get("sourced_zero_no_error_count") or 0) > 0:
         events.append(
             EngineTraceEvent(

--- a/tests/test_conditional_champion_validation.py
+++ b/tests/test_conditional_champion_validation.py
@@ -567,6 +567,32 @@ def _gate(
     }
 
 
+def test_holdout_result_propagates_paired_promotion_metric_version() -> None:
+    gate = {
+        **_gate(),
+        "promotion_metric_version": "paired_lcb_v1",
+    }
+    public_results = [
+        {
+            "icp_ref": f"icp-{index:02d}",
+            "candidate_company_scores": [50.0],
+        }
+        for index in range(10)
+    ]
+
+    _results, gate_result = evaluator.build_holdout_gate_result(
+        public_results=public_results,
+        private_results=(),
+        conditional_results=(),
+        public_icp_count=10,
+        private_icp_count=10,
+        conditional_icp_count=20,
+        gate=gate,
+    )
+
+    assert gate_result["promotion_metric_version"] == "paired_lcb_v1"
+
+
 async def _run_gate(
     runner: _Runner,
     gate: Mapping[str, Any],

--- a/tests/test_config_fixes.py
+++ b/tests/test_config_fixes.py
@@ -103,6 +103,27 @@ def test_section_6_4_recommended_defaults(clean_env):
     assert config.private_baseline_rebenchmark_enabled is True
 
 
+def test_provider_error_health_threshold_cannot_be_disabled_by_env(clean_env):
+    clean_env.setenv(
+        "RESEARCH_LAB_SCORING_HEALTH_MAX_PROVIDER_ERROR_RATE",
+        "1.0",
+    )
+
+    assert (
+        ResearchLabGatewayConfig.from_env().scoring_health_max_provider_error_rate
+        == pytest.approx(0.10)
+    )
+
+    clean_env.setenv(
+        "RESEARCH_LAB_SCORING_HEALTH_MAX_PROVIDER_ERROR_RATE",
+        "0.05",
+    )
+    assert (
+        ResearchLabGatewayConfig.from_env().scoring_health_max_provider_error_rate
+        == pytest.approx(0.05)
+    )
+
+
 def test_source_intelligence_defaults_and_independent_rollbacks(clean_env):
     config = ResearchLabGatewayConfig.from_env()
     status = config.public_status()

--- a/tests/test_house_arm.py
+++ b/tests/test_house_arm.py
@@ -597,6 +597,56 @@ def _bundle(bundle_id: str, mean_delta: float) -> dict[str, Any]:
     }
 
 
+def _daily_bundle(
+    bundle_id: str, *, recorded_mean_delta: float, benchmark_delta: float
+) -> dict[str, Any]:
+    return {
+        "score_bundle_id": bundle_id,
+        "score_bundle_doc": {
+            "aggregates": {"mean_delta": recorded_mean_delta},
+            "private_holdout_gate": {
+                "decision": "private_holdout_approved",
+                "private_holdout_evaluated": True,
+                "baseline_aggregate_score": 20.0,
+                "candidate_total_score": 20.0 + benchmark_delta,
+                "candidate_delta_vs_daily_baseline": benchmark_delta,
+            },
+        },
+    }
+
+
+def _stamped_daily_bundle(
+    bundle_id: str, *, mean_delta: float, delta_lcb: float
+) -> dict[str, Any]:
+    return {
+        "score_bundle_id": bundle_id,
+        "score_bundle_doc": {
+            "aggregates": {"mean_delta": 40.0, "delta_lcb": 35.0},
+            "private_holdout_gate": {
+                "promotion_metric_version": "paired_lcb_v1",
+                "decision": "private_holdout_approved",
+                "private_holdout_evaluated": True,
+                "baseline_aggregate_score": 20.0,
+                "candidate_total_score": 20.0 + mean_delta,
+                "candidate_delta_vs_daily_baseline": mean_delta,
+            },
+            "improvement_gate": {
+                "decision": "eligible_for_probation",
+                "eligible_for_probation": True,
+                "blockers": [],
+                "reference_evaluation_mode": "stored_daily_baseline",
+                "advisory_basis": (
+                    "recomputed_candidate_vs_stored_daily_baseline_per_icp"
+                ),
+                "mean_delta": mean_delta,
+                "se_delta": 0.5,
+                "delta_lcb": delta_lcb,
+                "compared_icp_count": 20,
+            },
+        },
+    }
+
+
 def _range_payment(hotkey: str, *, fee: float = 0.2, compute: float = 5.0) -> dict[str, Any]:
     row = _house_payment_row(fee=fee, spend_compute=compute)
     row["miner_hotkey"] = hotkey
@@ -650,6 +700,52 @@ async def test_comparison_math_matched_budget_yield_per_dollar(store):
     assert comparison["matched_budget_cents"] == 520
     assert comparison["miner_budget_cents"] == comparison["allocator_budget_cents"] == 520
     assert comparison["state"] == "local_stub"
+
+
+async def test_comparison_uses_daily_benchmark_delta_not_candidate_vs_zero(store):
+    store.payments.append(_range_payment(HOUSE_HOTKEY))
+    store.payments.append(_range_payment(MINER_HOTKEY))
+    store.score_bundles.append(
+        _daily_bundle(
+            "bundle-house-daily",
+            recorded_mean_delta=40.0,
+            benchmark_delta=-1.5,
+        )
+    )
+    store.candidates.append(
+        _candidate(HOUSE_HOTKEY, bundle_id="bundle-house-daily")
+    )
+
+    result = await build_house_arm_comparison_report(
+        start_date="2026-06-01", end_date="2026-06-30", config=_fake_config()
+    )
+    house = result["arms"]["house"]
+    assert house["deltas"] == [-1.5]
+    assert house["verified_points"] == 0.0
+    assert house["keeps"] == 0
+
+
+async def test_comparison_keep_uses_paired_lcb_when_available(store):
+    store.payments.append(_range_payment(HOUSE_HOTKEY))
+    store.payments.append(_range_payment(MINER_HOTKEY))
+    store.score_bundles.append(
+        _stamped_daily_bundle(
+            "bundle-house-stamped",
+            mean_delta=2.0,
+            delta_lcb=0.5,
+        )
+    )
+    store.candidates.append(
+        _candidate(HOUSE_HOTKEY, bundle_id="bundle-house-stamped")
+    )
+
+    result = await build_house_arm_comparison_report(
+        start_date="2026-06-01", end_date="2026-06-30", config=_fake_config()
+    )
+    house = result["arms"]["house"]
+    assert house["deltas"] == [2.0]
+    assert house["verified_points"] == 2.0
+    assert house["keeps"] == 0
 
 
 async def test_comparison_reports_insufficient_data_without_house_spend(store):

--- a/tests/test_improvement_engine_scanner.py
+++ b/tests/test_improvement_engine_scanner.py
@@ -180,6 +180,26 @@ def test_score_bundle_signals_derive_three_categories() -> None:
     }
 
 
+def test_score_bundle_signal_uses_daily_benchmark_delta() -> None:
+    row = {
+        "run_id": "run-1",
+        "bundle_status": "rejected",
+        "score_bundle_doc": {
+            "aggregates": {"mean_delta": 40.0},
+            "private_holdout_gate": {
+                "decision": "private_holdout_approved",
+                "private_holdout_evaluated": True,
+                "baseline_aggregate_score": 20.0,
+                "candidate_total_score": 18.5,
+                "candidate_delta_vs_daily_baseline": -1.5,
+            },
+        },
+    }
+    events = _score_bundle_events(row)
+    assert events
+    assert {event.score_delta for event in events} == {-1.5}
+
+
 def test_cost_reason_maps_to_cost_budget_exceeded() -> None:
     event = _candidate_event_to_engine(
         {"candidate_status": "failed", "reason": "cost budget exceeded", "run_id": "run-1", "created_at": _now_iso()}

--- a/tests/test_miner_diagnostics.py
+++ b/tests/test_miner_diagnostics.py
@@ -30,6 +30,13 @@ def _bundle():
         "aggregates": {
             "candidate_score": 5.4, "base_score": 0.0,
             "mean_delta": 5.4, "delta_lcb": -1.83, "icp_count": 5,
+            "baseline_per_icp_scores": {
+                PUBLIC_REF: 0.0,
+                "icp_pub_infra": 0.0,
+                PRIVATE_REF: 0.0,
+                "icp_priv_flat": 0.0,
+                "icp_INFRA_dead": 0.0,
+            },
             "per_icp_results": [
                 # public, helped
                 {"icp_ref": PUBLIC_REF, "status": "completed", "delta_vs_base": 32.4,
@@ -156,6 +163,7 @@ def test_private_pool_counts():
         "flat": 1,
         "infra_excluded": 1,
         "cost_budget_exceeded": 0,
+        "comparison_unavailable": 0,
     }
 
 
@@ -163,6 +171,53 @@ def test_public_icp_values_and_infra_label():
     pub = {r["icp_ref"]: r for r in _build()["public_icps"]}
     assert pub[PUBLIC_REF]["delta"] == 32.4 and pub[PUBLIC_REF]["candidate_score"] == 32.4
     assert pub["icp_pub_infra"]["status"] == "infra_excluded"
+
+
+def test_daily_baseline_diagnostics_recompute_public_and_private_deltas():
+    bundle = _clone_bundle()
+    bundle["private_holdout_gate"].update(
+        {
+            "decision": "private_holdout_approved",
+            "private_holdout_evaluated": True,
+            "baseline_aggregate_score": 20.0,
+            "candidate_total_score": 18.5,
+            "candidate_delta_vs_daily_baseline": -1.5,
+        }
+    )
+    bundle["aggregates"]["mean_delta"] = 40.0
+    bundle["aggregates"]["delta_lcb"] = 35.0
+    bundle["aggregates"]["baseline_per_icp_scores"][PUBLIC_REF] = 40.0
+    bundle["aggregates"]["baseline_per_icp_scores"][PRIVATE_REF] = 30.0
+    doc = md.build_candidate_diagnostics(
+        candidate_id="candidate:abc",
+        bundle_doc=bundle,
+        patch_manifest=_patch_manifest(),
+        visibility_by_ref=_vis(),
+    )
+    public = {row["icp_ref"]: row for row in doc["public_icps"]}
+    assert public[PUBLIC_REF]["base_score"] == 40.0
+    assert public[PUBLIC_REF]["delta"] == -7.6
+    assert doc["private_pool"]["helped"] == 0
+    assert doc["private_pool"]["hurt"] == 1
+    assert doc["aggregate"]["mean_delta"] == -1.5
+    assert doc["aggregate"]["delta_lcb"] == 0.0
+
+
+def test_daily_baseline_diagnostics_fail_score_blind_without_per_icp_baseline():
+    bundle = _clone_bundle()
+    bundle["aggregates"].pop("baseline_per_icp_scores")
+    doc = md.build_candidate_diagnostics(
+        candidate_id="candidate:abc",
+        bundle_doc=bundle,
+        patch_manifest=_patch_manifest(),
+        visibility_by_ref=_vis(),
+    )
+    public = {row["icp_ref"]: row for row in doc["public_icps"]}
+    assert "delta" not in public[PUBLIC_REF]
+    assert public[PUBLIC_REF]["comparison_status"] == (
+        "benchmark_per_icp_score_unavailable"
+    )
+    assert doc["private_pool"]["comparison_unavailable"] == 2
 
 
 def test_public_cost_budget_exceeded_reason_is_sanitized():

--- a/tests/test_misc_hardening.py
+++ b/tests/test_misc_hardening.py
@@ -96,6 +96,9 @@ def _bundle(delta: float, artifact_hash: str = "hash-1", at: str = T2) -> dict:
         "score_bundle_doc": {
             "private_holdout_gate": {
                 "decision": "private_holdout_approved",
+                "private_holdout_evaluated": True,
+                "baseline_aggregate_score": 20.0,
+                "candidate_total_score": 20.0 + delta,
                 "candidate_delta_vs_daily_baseline": delta,
             }
         },

--- a/tests/test_promotion_fixes.py
+++ b/tests/test_promotion_fixes.py
@@ -46,6 +46,9 @@ from gateway.research_lab.promotion import (
     sync_active_model_to_repo_head,
 )
 from research_lab.canonical import sha256_json
+from research_lab.eval.promotion_metric import (
+    PAIRED_LCB_PROMOTION_METRIC_VERSION,
+)
 from gateway.research_lab.source_add_llm_judge import SourceAddJudgeVerdict
 
 
@@ -394,6 +397,99 @@ def test_metric_approved_gate_has_no_rejection() -> None:
     assert metric.rejection_status is None
     assert metric.daily_baseline_available is True
     assert metric.improvement_points == pytest.approx(2.5)
+
+
+def _paired_improvement_gate(**overrides: Any) -> dict[str, Any]:
+    gate = {
+        "decision": "eligible_for_probation",
+        "eligible_for_probation": True,
+        "blockers": [],
+        "reference_evaluation_mode": "stored_daily_baseline",
+        "advisory_basis": (
+            "recomputed_candidate_vs_stored_daily_baseline_per_icp"
+        ),
+        "mean_delta": 2.5,
+        "se_delta": 0.5,
+        "delta_lcb": 1.5,
+        "compared_icp_count": 20,
+    }
+    gate.update(overrides)
+    return gate
+
+
+def test_new_metric_uses_paired_lcb_instead_of_aggregate_mean() -> None:
+    holdout_gate = _approved_gate(
+        promotion_metric_version=PAIRED_LCB_PROMOTION_METRIC_VERSION,
+    )
+    bundle = {
+        "private_holdout_gate": holdout_gate,
+        "improvement_gate": _paired_improvement_gate(
+            mean_delta=2.5,
+            se_delta=0.9,
+            delta_lcb=0.7,
+        ),
+        "aggregates": {},
+    }
+
+    metric = promotion_improvement_metric(bundle)
+    decision = promotion.promotion_gate_decision(
+        bundle,
+        candidate_kind="image_build",
+        candidate_parent="sha256:parent",
+        active_parent="sha256:parent",
+        threshold_points=1.0,
+        auto_promotion_enabled=True,
+    )
+
+    assert metric.improvement_points == pytest.approx(0.7)
+    assert metric.paired_mean_delta == pytest.approx(2.5)
+    assert metric.paired_delta_lcb == pytest.approx(0.7)
+    assert metric.basis == "stored_daily_baseline_paired_delta_lcb"
+    assert decision.status == "rejected_below_threshold"
+
+
+def test_new_metric_rejects_when_paired_confidence_is_missing() -> None:
+    bundle = {
+        "private_holdout_gate": _approved_gate(
+            promotion_metric_version=PAIRED_LCB_PROMOTION_METRIC_VERSION,
+        ),
+        "improvement_gate": {
+            "decision": "not_applicable",
+            "eligible_for_probation": False,
+            "blockers": ["superseded_metric_not_applicable"],
+            "reference_evaluation_mode": "stored_daily_baseline",
+            "advisory_basis": "superseded_metric_not_applicable",
+        },
+        "aggregates": {},
+    }
+
+    metric = promotion_improvement_metric(bundle)
+
+    assert metric.improvement_points == 0.0
+    assert metric.rejection_status == "rejected_paired_lcb_unavailable"
+    assert metric.daily_baseline_available is False
+
+
+def test_new_metric_passes_when_paired_lcb_clears_threshold() -> None:
+    bundle = {
+        "private_holdout_gate": _approved_gate(
+            promotion_metric_version=PAIRED_LCB_PROMOTION_METRIC_VERSION,
+        ),
+        "improvement_gate": _paired_improvement_gate(delta_lcb=1.25),
+        "aggregates": {},
+    }
+
+    decision = promotion.promotion_gate_decision(
+        bundle,
+        candidate_kind="image_build",
+        candidate_parent="sha256:parent",
+        active_parent="sha256:parent",
+        threshold_points=1.0,
+        auto_promotion_enabled=True,
+    )
+
+    assert decision.status == "promotion_passed"
+    assert decision.improvement_points == pytest.approx(1.25)
 
 
 def test_metric_missing_basis_is_explicit_rejection_not_zero_pass() -> None:

--- a/tests/test_public_activity_fixes.py
+++ b/tests/test_public_activity_fixes.py
@@ -118,6 +118,9 @@ def _bundle(delta: float, artifact_hash: str = "hash-1", at: str = T2) -> dict:
         "score_bundle_doc": {
             "private_holdout_gate": {
                 "decision": "private_holdout_approved",
+                "private_holdout_evaluated": True,
+                "baseline_aggregate_score": 20.0,
+                "candidate_total_score": 20.0 + delta,
                 "candidate_delta_vs_daily_baseline": delta,
             }
         },

--- a/tests/test_research_lab_runtime_config_v2.py
+++ b/tests/test_research_lab_runtime_config_v2.py
@@ -120,7 +120,13 @@ def test_execution_config_commits_and_applies_hosted_run_canary(monkeypatch):
     assert document["behavior_environment"][
         "RESEARCH_LAB_HOSTED_RUN_ALLOWLIST"
     ] == run_id
-    monkeypatch.delenv("RESEARCH_LAB_HOSTED_RUN_ALLOWLIST", raising=False)
+    # Register the environment mutation with monkeypatch before the runtime
+    # applier writes directly to os.environ, so the canary cannot leak into
+    # later worker tests in the same process.
+    monkeypatch.setenv(
+        "RESEARCH_LAB_HOSTED_RUN_ALLOWLIST",
+        "44444444-4444-4444-8444-444444444444",
+    )
     apply_behavior_environment(document)
 
     import os

--- a/tests/test_research_lab_runtime_config_v2.py
+++ b/tests/test_research_lab_runtime_config_v2.py
@@ -109,6 +109,25 @@ def test_behavior_environment_is_exact_and_applied(monkeypatch):
     assert "RESEARCH_LAB_LOOP_STAGE_ERROR_CONTAINMENT" not in os.environ
 
 
+def test_execution_config_commits_and_applies_hosted_run_canary(monkeypatch):
+    run_id = "33333333-3333-4333-8333-333333333333"
+    document = build_research_lab_execution_config(
+        environment=epoch_test_environment(
+            RESEARCH_LAB_HOSTED_RUN_ALLOWLIST=run_id,
+        )
+    )
+
+    assert document["behavior_environment"][
+        "RESEARCH_LAB_HOSTED_RUN_ALLOWLIST"
+    ] == run_id
+    monkeypatch.delenv("RESEARCH_LAB_HOSTED_RUN_ALLOWLIST", raising=False)
+    apply_behavior_environment(document)
+
+    import os
+
+    assert os.environ["RESEARCH_LAB_HOSTED_RUN_ALLOWLIST"] == run_id
+
+
 def test_measured_tree_icp_count_uses_the_committed_override():
     document = build_research_lab_execution_config(
         environment=epoch_test_environment(

--- a/tests/test_score_backfill.py
+++ b/tests/test_score_backfill.py
@@ -21,6 +21,7 @@ import pytest
 from gateway.research_lab import lesson_store, score_backfill
 from gateway.research_lab.score_backfill import (
     SCORE_BACKFILL_ENABLED_ENV,
+    SCORE_BUNDLE_CURRENT,
     SCORE_CALIBRATION_TABLE,
     build_calibration_row,
     fetch_score_enrichments_by_node,
@@ -96,6 +97,24 @@ def _score_bundle() -> dict[str, Any]:
     }
 
 
+def _daily_baseline_bundle(
+    *,
+    score_bundle_id: str = "bundle-daily",
+    daily_delta: float = -1.5,
+) -> dict[str, Any]:
+    return {
+        "score_bundle_id": score_bundle_id,
+        "aggregates": {"mean_delta": 40.0, "delta_lcb": 35.0},
+        "private_holdout_gate": {
+            "decision": "private_holdout_approved",
+            "private_holdout_evaluated": True,
+            "baseline_aggregate_score": 20.0,
+            "candidate_total_score": 20.0 + daily_delta,
+            "candidate_delta_vs_daily_baseline": daily_delta,
+        },
+    }
+
+
 def test_build_calibration_row_projects_all_three_score_sources():
     row = build_calibration_row(
         candidate=_scored_candidate(),
@@ -115,6 +134,16 @@ def test_build_calibration_row_projects_all_three_score_sources():
     assert row["realized_delta_lcb"] == -0.11
     assert row["outcome"] == "promotion_rejected"
     assert row["score_bundle_id"] == "bundle-1"
+
+
+def test_build_calibration_row_uses_daily_benchmark_not_candidate_vs_zero():
+    row = build_calibration_row(
+        candidate=_scored_candidate(),
+        score_bundle=_daily_baseline_bundle(),
+        score_bundle_id="bundle-daily",
+    )
+    assert row["realized_mean_delta"] == -1.5
+    assert row["realized_delta_lcb"] is None
 
 
 def test_calibration_prefers_live_patch_shape_and_rejects_non_finite_scores():
@@ -223,6 +252,7 @@ def test_fetch_score_enrichments_returns_newest_row_per_node(monkeypatch):
             SCORE_CALIBRATION_TABLE: [
                 {
                     "node_id": "node-1",
+                    "score_bundle_id": "bundle-old",
                     "realized_mean_delta": -0.5,
                     "realized_delta_lcb": -0.9,
                     "predicted_delta": 1.0,
@@ -232,6 +262,7 @@ def test_fetch_score_enrichments_returns_newest_row_per_node(monkeypatch):
                 },
                 {
                     "node_id": "node-1",
+                    "score_bundle_id": "bundle-daily",
                     "realized_mean_delta": 0.25,
                     "realized_delta_lcb": 0.05,
                     "predicted_delta": 1.0,
@@ -239,30 +270,51 @@ def test_fetch_score_enrichments_returns_newest_row_per_node(monkeypatch):
                     "outcome": "promotion_approved",
                     "created_at": "2026-07-06T00:00:00Z",
                 },
-            ]
+            ],
+            SCORE_BUNDLE_CURRENT: [
+                {
+                    "score_bundle_id": "bundle-daily",
+                    "score_bundle_doc": _daily_baseline_bundle(),
+                }
+            ],
         }
     )
     enrichments = asyncio.run(
         fetch_score_enrichments_by_node(["node-1", "node-missing"], store=store)
     )
     assert set(enrichments) == {"node-1"}
-    assert enrichments["node-1"]["realized_delta"] == 0.25
+    assert enrichments["node-1"]["realized_delta"] == -1.5
+    assert enrichments["node-1"]["realized_delta_lcb"] is None
     assert enrichments["node-1"]["scored_outcome"] == "promotion_approved"
 
 
-def test_fetch_score_enrichments_bulk_loads_all_nodes_in_one_query():
+def test_fetch_score_enrichments_bulk_loads_nodes_and_bundles():
     class _BulkStore:
         def __init__(self):
             self.calls = []
 
         async def select_all(self, table, **kwargs):
             self.calls.append((table, kwargs))
+            if table == SCORE_CALIBRATION_TABLE:
+                return [
+                    {
+                        "node_id": f"node-{index}",
+                        "score_bundle_id": f"bundle-{index}",
+                        "realized_mean_delta": index / 100,
+                        "realized_delta_lcb": 0.0,
+                        "created_at": "2026-07-06T00:00:00Z",
+                    }
+                    for index in range(40)
+                ]
             return [
                 {
-                    "node_id": f"node-{index}",
-                    "realized_mean_delta": index / 100,
-                    "realized_delta_lcb": 0.0,
-                    "created_at": "2026-07-06T00:00:00Z",
+                    "score_bundle_id": f"bundle-{index}",
+                    "score_bundle_doc": {
+                        "aggregates": {
+                            "mean_delta": index / 100,
+                            "delta_lcb": 0.0,
+                        }
+                    },
                 }
                 for index in range(40)
             ]
@@ -273,10 +325,40 @@ def test_fetch_score_enrichments_bulk_loads_all_nodes_in_one_query():
         fetch_score_enrichments_by_node(node_ids, store=store, limit=50)
     )
     assert len(enrichments) == 40
-    assert len(store.calls) == 1
+    assert len(store.calls) == 2
     table, kwargs = store.calls[0]
     assert table == SCORE_CALIBRATION_TABLE
     assert kwargs["filters"] == [("node_id", "in", node_ids)]
+    bundle_table, bundle_kwargs = store.calls[1]
+    assert bundle_table == SCORE_BUNDLE_CURRENT
+    assert bundle_kwargs["filters"] == [
+        ("score_bundle_id", "in", [f"bundle-{index}" for index in range(40)])
+    ]
+
+
+def test_fetch_score_enrichments_stays_score_blind_when_bundle_is_missing():
+    store = _FakeStore(
+        {
+            SCORE_CALIBRATION_TABLE: [
+                {
+                    "node_id": "node-1",
+                    "score_bundle_id": "bundle-missing",
+                    "realized_mean_delta": 99.0,
+                    "realized_delta_lcb": 98.0,
+                    "predicted_delta": 1.0,
+                    "dev_score": 66.0,
+                    "outcome": "promotion_approved",
+                    "created_at": "2026-07-06T00:00:00Z",
+                }
+            ]
+        }
+    )
+    enrichment = asyncio.run(
+        fetch_score_enrichments_by_node(["node-1"], store=store)
+    )["node-1"]
+    assert enrichment["realized_delta"] is None
+    assert enrichment["realized_delta_lcb"] is None
+    assert enrichment["predicted_delta"] == 1.0
 
 
 def _reflection_event_row(*, node_id: str, created_at: str) -> dict[str, Any]:
@@ -315,6 +397,7 @@ def _lesson_fixture_store() -> _FakeStore:
             SCORE_CALIBRATION_TABLE: [
                 {
                     "node_id": "node-1",
+                    "score_bundle_id": "bundle-1",
                     "realized_mean_delta": -0.02,
                     "realized_delta_lcb": -0.11,
                     "predicted_delta": 1.0,
@@ -322,6 +405,12 @@ def _lesson_fixture_store() -> _FakeStore:
                     "outcome": "promotion_rejected",
                     "created_at": "2026-07-06T00:00:00Z",
                 },
+            ],
+            SCORE_BUNDLE_CURRENT: [
+                {
+                    "score_bundle_id": "bundle-1",
+                    "score_bundle_doc": _score_bundle(),
+                }
             ],
         }
     )

--- a/tests/test_scoring_worker_fixes.py
+++ b/tests/test_scoring_worker_fixes.py
@@ -1747,6 +1747,18 @@ def test_private_holdout_gate_carries_per_icp_baseline_scores():
     }
     assert gate["baseline_public_score"] == 10.0
     assert gate["baseline_private_holdout_icp_count"] == 2
+    assert gate["promotion_metric_version"] == "paired_lcb_v1"
+
+    policy = sw._stored_daily_baseline_evaluation_policy(
+        {"min_delta": 1.0},
+        gate,
+    )
+    assert policy["reference_evaluation_mode"] == "stored_daily_baseline"
+    assert policy["baseline_per_icp_scores"] == {
+        "icp-a": 10.0,
+        "icp-b": 15.0,
+        "icp-c": 20.0,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_trajectory_projector.py
+++ b/tests/test_trajectory_projector.py
@@ -61,6 +61,32 @@ def test_projector_and_trace_join_keys_default_on(monkeypatch):
     assert trajectory_projector_mod._execution_trace_trajectory_id_enabled() is True
 
 
+def test_trajectory_aggregate_summary_uses_daily_benchmark_delta():
+    summary = trajectory_projector_mod._aggregates_summary(
+        {
+            "score_bundle_doc": {
+                "aggregates": {
+                    "base_score": 0.0,
+                    "candidate_score": 40.0,
+                    "mean_delta": 40.0,
+                    "delta_lcb": 35.0,
+                },
+                "private_holdout_gate": {
+                    "decision": "private_holdout_approved",
+                    "private_holdout_evaluated": True,
+                    "baseline_aggregate_score": 20.0,
+                    "candidate_total_score": 18.5,
+                    "candidate_delta_vs_daily_baseline": -1.5,
+                },
+            }
+        }
+    )
+    assert summary["base_score"] == 20.0
+    assert summary["candidate_score"] == 18.5
+    assert summary["mean_delta"] == -1.5
+    assert "delta_lcb" not in summary
+
+
 # ---------------------------------------------------------------------------
 # Fake store
 # ---------------------------------------------------------------------------

--- a/tests/test_worker_fixes.py
+++ b/tests/test_worker_fixes.py
@@ -133,6 +133,108 @@ async def test_tree_mode_off_returns_before_queue_lookup(monkeypatch):
     assert outcome.processed is False
 
 
+def test_hosted_run_allowlist_rejects_invalid_configuration(monkeypatch):
+    monkeypatch.setenv(worker_mod.HOSTED_RUN_ALLOWLIST_ENV, "not-a-run-id")
+
+    with pytest.raises(
+        worker_mod.HostedResearchLabWorkerError,
+        match="invalid run ID",
+    ):
+        worker_mod._hosted_run_allowlist()
+
+
+@pytest.mark.asyncio
+async def test_hosted_run_allowlist_filters_queue_and_response(monkeypatch, hosted_worker):
+    other_run_id = "55555555-5555-4555-8555-555555555555"
+    monkeypatch.setenv(worker_mod.HOSTED_RUN_ALLOWLIST_ENV, RUN_ID)
+    observed = {}
+
+    async def fake_select_many(table, **kwargs):
+        observed["table"] = table
+        observed["filters"] = kwargs["filters"]
+        return [
+            {"run_id": other_run_id, "ticket_id": TICKET_ID},
+            {"run_id": RUN_ID, "ticket_id": TICKET_ID},
+        ]
+
+    monkeypatch.setattr(worker_mod, "select_many", fake_select_many)
+
+    selected = await hosted_worker._next_queued_run()
+
+    assert observed["table"] == "research_loop_run_queue_current"
+    assert ("run_id", "in", (RUN_ID,)) in observed["filters"]
+    assert selected["run_id"] == RUN_ID
+
+
+@pytest.mark.asyncio
+async def test_tree_preflight_defers_before_paid_run_processing(monkeypatch):
+    monkeypatch.setenv("RESEARCH_LAB_TREE_MODE", "active")
+    monkeypatch.setenv("RESEARCH_LAB_TEE_PROTOCOL", "v2")
+    worker = worker_mod.ResearchLabHostedWorker(
+        ResearchLabGatewayConfig(),
+        worker_ref="worker-a",
+    )
+    worker._require_enabled = lambda: None
+    worker._code_edit_builder_unavailable_reason = lambda: None
+    worker._require_worker_proxy_for_execution = lambda: None
+
+    async def noop(*_args, **_kwargs):
+        return None
+
+    for method_name in (
+        "_recover_stale_started_runs",
+        "_reconcile_stale_loop_projections",
+        "_maybe_reconcile_terminal_tickets",
+        "_maybe_refresh_allocator_priors",
+        "_maybe_expire_unpaid_tickets",
+        "_recover_stale_paused_runs",
+        "_run_periodic_reconciles",
+    ):
+        monkeypatch.setattr(worker, method_name, noop)
+
+    async def maintenance_state():
+        return {"paused": False, "reason": ""}
+
+    async def queued_run():
+        return {"run_id": RUN_ID, "ticket_id": TICKET_ID}
+
+    async def provider_preflight(**_kwargs):
+        return {"proceed": True}
+
+    async def load_context(_queued):
+        return _make_context()
+
+    async def failed_tree_preflight(_context):
+        return "tree_snapshot_not_ready:pointer_missing"
+
+    async def forbidden_process(_context):
+        pytest.fail(
+            "a failed snapshot preflight must not append started events or process the run"
+        )
+
+    monkeypatch.setattr(
+        worker_mod,
+        "get_autoresearch_maintenance_state",
+        maintenance_state,
+    )
+    monkeypatch.setattr(worker_mod, "preflight_gate", provider_preflight)
+    monkeypatch.setattr(worker, "_next_queued_run", queued_run)
+    monkeypatch.setattr(worker, "_load_run_context", load_context)
+    monkeypatch.setattr(
+        worker,
+        "_preclaim_tree_readiness",
+        failed_tree_preflight,
+    )
+    monkeypatch.setattr(worker, "_process_run", forbidden_process)
+
+    outcome = await worker.run_once()
+
+    assert outcome.status == "tree_preflight_deferred"
+    assert outcome.processed is False
+    assert outcome.run_id == RUN_ID
+    assert "pointer_missing" in outcome.error
+
+
 def test_inner_loop_rejects_multiple_paid_finalists():
     candidates = (object(), object(), object())
 
@@ -1594,6 +1696,58 @@ async def test_stale_started_reaper_scans_oldest_first(hosted_worker, monkeypatc
     monkeypatch.setattr(worker_mod, "select_many", fake_select_many)
     assert await hosted_worker._recover_stale_started_runs() == 0
     assert captured["order_by"] == (("current_status_at", False),)
+
+
+async def test_canary_allowlist_fences_stale_run_reapers(
+    hosted_worker,
+    monkeypatch,
+):
+    other_run_id = "55555555-5555-4555-8555-555555555555"
+    monkeypatch.setenv(worker_mod.HOSTED_RUN_ALLOWLIST_ENV, RUN_ID)
+    stale_at = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+    observed_filters = []
+    requeued = []
+
+    async def fake_select_many(_table, **kwargs):
+        observed_filters.append(kwargs["filters"])
+        status = kwargs["filters"][0][1]
+        return [
+            {
+                "run_id": other_run_id,
+                "ticket_id": TICKET_ID,
+                "current_queue_status": status,
+                "current_reason": "maintenance_pause_stale_started",
+                "current_status_at": stale_at,
+                "queue_priority": 0,
+            }
+        ]
+
+    async def fake_blocks(_run_id, _stale_after_seconds):
+        return False
+
+    async def fake_create_queue_event(**kwargs):
+        requeued.append(kwargs)
+        return {}
+
+    monkeypatch.setattr(worker_mod, "select_many", fake_select_many)
+    monkeypatch.setattr(
+        hosted_worker,
+        "_loop_activity_blocks_stale_requeue",
+        fake_blocks,
+    )
+    monkeypatch.setattr(
+        worker_mod,
+        "create_queue_event",
+        fake_create_queue_event,
+    )
+
+    assert await hosted_worker._recover_stale_started_runs() == 0
+    assert await hosted_worker._recover_stale_paused_runs() == 0
+    assert all(
+        ("run_id", "in", (RUN_ID,)) in filters
+        for filters in observed_filters
+    )
+    assert requeued == []
 
 
 def test_blocked_for_credit_is_the_only_reaper_exclusion():

--- a/tests/test_worker_fixes.py
+++ b/tests/test_worker_fixes.py
@@ -235,6 +235,76 @@ async def test_tree_preflight_defers_before_paid_run_processing(monkeypatch):
     assert "pointer_missing" in outcome.error
 
 
+def test_outcome_memory_uses_recomputed_daily_baseline_paired_metric():
+    bundle = {
+        "aggregates": {
+            # Stored-daily-baseline bundles retain candidate-vs-zero arithmetic
+            # here for historical hash compatibility. This must never reach
+            # the planner as a realized improvement.
+            "mean_delta": 60.0,
+            "delta_lcb": 55.0,
+        },
+        "private_holdout_gate": {
+            "promotion_metric_version": "paired_lcb_v1",
+            "decision": "private_holdout_approved",
+            "private_holdout_evaluated": True,
+            "baseline_aggregate_score": 20.0,
+            "candidate_total_score": 22.5,
+            "candidate_delta_vs_daily_baseline": 2.5,
+        },
+        "improvement_gate": {
+            "decision": "eligible_for_probation",
+            "eligible_for_probation": True,
+            "blockers": [],
+            "reference_evaluation_mode": "stored_daily_baseline",
+            "advisory_basis": (
+                "recomputed_candidate_vs_stored_daily_baseline_per_icp"
+            ),
+            "mean_delta": 2.5,
+            "se_delta": 0.9,
+            "delta_lcb": 0.7,
+            "compared_icp_count": 20,
+        },
+    }
+
+    assert worker_mod._realized_score_delta_for_memory(bundle) == {
+        "score_delta": 2.5,
+        "score_delta_lcb": 0.7,
+    }
+
+
+def test_outcome_memory_legacy_daily_bundle_never_uses_candidate_vs_zero():
+    bundle = {
+        "aggregates": {"mean_delta": 40.0, "delta_lcb": 35.0},
+        "private_holdout_gate": {
+            "decision": "private_holdout_approved",
+            "private_holdout_evaluated": True,
+            "baseline_aggregate_score": 20.0,
+            "candidate_total_score": 18.5,
+            "candidate_delta_vs_daily_baseline": -1.5,
+        },
+    }
+
+    assert worker_mod._realized_score_delta_for_memory(bundle) == {
+        "score_delta": -1.5,
+        "score_delta_lcb": 0.0,
+    }
+
+
+def test_outcome_memory_preserves_true_paired_legacy_bundle():
+    bundle = {
+        "aggregates": {
+            "mean_delta": -0.2,
+            "delta_lcb": -1.1,
+        },
+    }
+
+    assert worker_mod._realized_score_delta_for_memory(bundle) == {
+        "score_delta": -0.2,
+        "score_delta_lcb": -1.1,
+    }
+
+
 def test_inner_loop_rejects_multiple_paid_finalists():
     candidates = (object(), object(), object())
 


### PR DESCRIPTION
## Summary

This PR removes the activation blockers found in the V2 loop/scoring audit:

- leaves paid loop runs queued until the exact active-model dev snapshot is ready, current, immutable, and model-matched
- adds a measured `RESEARCH_LAB_HOSTED_RUN_ALLOWLIST` canary boundary to queue selection and stale-run recovery, with invalid configuration failing closed
- refreshes the dev snapshot before claim when auto-refresh is enabled
- carries stored per-ICP daily-baseline scores into direct, global-queue, and conditional score bundles
- versions new promotion decisions as `paired_lcb_v1` and requires the verifier-recomputed paired lower confidence bound to clear the promotion threshold
- preserves the historical mean-delta path for already-recorded, unversioned bundles so promotion/reward recovery is not broken
- hard-caps the provider-error health threshold at 10%, even if production still supplies the unsafe historical `1.0` override
- advances the measured Research Lab execution-config schema and refreshes the protected-workflow manifest

## Critical feedback-path corrections

The activation review found that stored-daily-baseline bundles retain candidate-vs-zero values in `aggregates.mean_delta` and `aggregates.delta_lcb` for historical hash compatibility. Those values are absolute scores, not improvement against the current benchmark.

Live evidence confirmed the impact:

- 34 of 80 comparable historical bundles had a sign mismatch, all false-positive feedback
- recorded candidate-vs-zero average: `+11.5765`
- true daily-baseline average: `+0.8746`
- all 4 comparable bundles for the current active parent were false positives: recorded `+5.465` versus true `-6.14`

This PR now uses one benchmark-relative projection for:

- active-parent attempt memory
- persisted score-calibration writes
- read-time repair of the 253 existing calibration rows
- score-aware lesson hydration
- miner diagnostics
- loop top-up continuation context
- public loop projection
- trajectory/training projection
- passive improvement scanning
- house-vs-miner comparison

Historical calibration rows are not mutated. Their immutable score bundles are loaded and recomputed at read time; missing or malformed bundles fail score-blind with warning logs.

The house-vs-miner report still measures verified points using benchmark-relative mean improvement, but counts a keep using paired LCB when available, matching the new promotion gate.

## Why this is required before activation

Before this change, enabling tree mode with a missing or stale snapshot could append started events and then pause a funded run. There was no run-level canary fence, so unpausing the fleet could recover or claim multiple paid runs at once.

Scoring had three separate correctness gaps: per-ICP baseline data did not reach all score paths; promotion consumed a mean rather than a confidence bound; and multiple planner/feedback consumers interpreted candidate-vs-zero aggregates as benchmark improvement.

## Activation behavior after merge

1. Restart with exactly one maintenance-paused run UUID in `RESEARCH_LAB_HOSTED_RUN_ALLOWLIST`.
2. The run remains queued unless active-model snapshot readiness passes; stale recovery is fenced to the same UUID.
3. Resume scoring only after active lineage sync and the newest daily baseline complete.
4. A new candidate can promote only when its paired LCB, not merely its mean, clears the configured threshold.
5. Subsequent planning, lesson memory, miner diagnostics, trajectories, and comparison reports receive benchmark-relative results.
6. Remove the allowlist only after the canary produces source inspection, patch/build artifacts, scoring pickup/result, reward-path evidence, and current-epoch allocation/weight evidence.

No database migration is required.

## Verification

- rebased onto current `main` (`9f384fe9`)
- PR head: `1161314c`
- fresh GitHub Actions run `30036584986` is green
- authoritative Ubuntu CI: 3,449 passed, 1 skipped, 7 warnings
- gateway Docker image build passed
- validator Docker image build passed
- 529 focused loop, scoring, verifier, protected-workflow, promotion, reimbursement, reward, allocation, trajectory, miner-feedback, public-projection, and runtime-config tests passed locally
- 562 tests passed in the broad post-rebase local run
- 13 remaining local failures were isolated to the local toolchain: missing `python-whois`, local Bittensor v11 versus CI-pinned v10.5, local netuid 48 versus fixture 71, and macOS Bash lacking Linux `mapfile`
- 40,000 randomized benchmark-relative projection cases passed across legacy paired, historical daily-baseline, and new stamped paired-LCB bundles; malformed stamped data failed closed
- earlier differential verification covered 20,000 legacy promotion cases with identical behavior and 10,000 stamped decision cases
- changed Python modules compile successfully under Python 3.11
- changed gateway modules import successfully
- protected-workflow identity was regenerated after the rebase and its verifier passes

The first post-rebase CI run reached 3,448 passing tests and found one incomplete synthetic public-card fixture. The fixture claimed `private_holdout_approved` without the required `private_holdout_evaluated` and score commitments. It was corrected to the real stored bundle contract, the affected 276-test group passed locally, and the replacement full CI/Docker run passed.

## Read-only production contract audit

- one active private-model lineage row exists and matches the latest completed baseline manifest
- the latest persisted baseline is complete, passed, and contains 20 numeric per-ICP scores
- all 507 existing score bundles are unversioned; the explicit legacy branch preserves their promotion/reward recovery semantics
- 19 runs are maintenance-paused and 6 are credit-blocked; no run is currently queued or started
- 253 score-calibration rows exist; read-time score-bundle recomputation repairs their planner feedback without a data rewrite
- reimbursement, champion reward, emission allocation, finalized allocation, and attested weight-finalization rows are present and active; their construction/submission code is unchanged and covered by regression tests
- there is no current-day baseline or current tree-authority row, so live activation must first produce the newest daily baseline and immutable dev snapshot

## Deployment boundary

This PR does not deploy, restart workers, unpause maintenance, mutate Supabase, or submit weights.

Gateway/validator runtime parity, worker subprocess environment/import resolution, post-restart PCR0 alignment, the live one-run canary, reward/allocation projection, and on-chain weight submission still require post-merge production verification. The PR intentionally remains draft for operator review and the controlled post-merge activation sequence.
