### PR TITLE
Prune ancestry transport detail from the allocation enclave payload

### DIFF
--- a/gateway/research_lab/v2_authority.py
+++ b/gateway/research_lab/v2_authority.py
@@ -1349,6 +1349,31 @@ async def compare_promotion_decision_v2(
     return {**dict(outcome), "status": "matched", "artifact_link_status": link}
 
 
+def _prune_ancestry_transport_detail(
+    graph: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Drop per-attempt transport/host detail from a historical ancestry graph.
+
+    The coordinator enclave consumes allocation parent graphs by their root
+    receipt authority only (root hash, purpose, role); it does not
+    re-validate a parent graph's transport_root against its terminal
+    transport attempts. Those attempt records are the unbounded-growth
+    component of a champion graph — ~2,600 per epoch, ~5MB — so shipping the
+    full reimbursement-window history every epoch pushed the scoring job
+    payload past the enclave's 64MB MAX_INPUT_BYTES limit (observed at epoch
+    24116). Prune the transport and host-operation detail while preserving
+    the receipts, boot identities, root, and schema the enclave actually
+    verifies. Each full graph is still validated by the gateway (including
+    transport reconstruction) before this prune, so integrity is unchanged;
+    only the redundant historical detail is withheld from the enclave.
+    """
+
+    pruned = dict(graph)
+    pruned["transport_attempts"] = []
+    pruned["host_operations"] = []
+    return pruned
+
+
 async def build_allocation_v2(
     *,
     epoch_id: int,
@@ -1430,13 +1455,16 @@ async def build_allocation_v2(
                 "receipt_role": str(root.get("role") or ""),
             }
         )
+    # The full graphs were validated and bound above; the enclave only needs
+    # each parent graph's root authority, so ship them without the per-attempt
+    # transport/host history that would otherwise exceed the 64MB input limit.
     outcome = await execute(
         operation=OP_RESEARCH_LAB_ALLOCATION,
         purpose="research_lab.allocation.v2",
         epoch_id=int(epoch_id),
         sequence=0,
         payload={"epoch": int(epoch_id), "netuid": int(netuid)},
-        parent_graphs=graphs,
+        parent_graphs=[_prune_ancestry_transport_detail(g) for g in graphs],
     )
     authority_result = outcome.get("result")
     if not isinstance(authority_result, Mapping):

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -437,7 +437,7 @@
       "symbol": "attest_historical_source_add_reward_v2"
     },
     {
-      "ast_sha256": "sha256:8c89ac2cce14b4393cecc91e63eb64eef44816a332ed0b095d4924d592a4183e",
+      "ast_sha256": "sha256:54ef531419a396c724010f0d419493c5aeff881677a1f4e437ac467bc2d7f6fb",
       "path": "gateway/research_lab/v2_authority.py",
       "symbol": "build_allocation_v2"
     },
@@ -1087,7 +1087,7 @@
       "symbol": "validate_source_add_reward_record"
     }
   ],
-  "manifest_hash": "sha256:8ba6f766b587cdb4362ddcdca287aaaf97500fc4c54723ceb5a454847e2c8678",
+  "manifest_hash": "sha256:eca5528cf4b697c9958a04b4afd24d4289d248bce5fd5f60b46702f05201ae37",
   "protected_source_commit": "b454e973a06cbb74431a890e739e513abb541362",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_allocation_ancestry_prune.py
+++ b/tests/test_allocation_ancestry_prune.py
@@ -1,0 +1,89 @@
+"""Allocation ancestry graphs are pruned of transport detail before the enclave.
+
+Historical champion/reimbursement parent graphs accumulate ~2,600 transport
+attempts per epoch (~5MB each). Shipping the full reimbursement-window history
+every epoch pushed the coordinator scoring payload past the enclave's 64MB
+MAX_INPUT_BYTES limit (epoch 24116, whole-subnet weight miss). The coordinator
+enclave consumes these graphs by root receipt authority only, so the per-attempt
+transport/host detail is dropped before send while the receipts, boots, and root
+the enclave verifies are preserved.
+"""
+
+from __future__ import annotations
+
+import json
+
+from gateway.research_lab.v2_authority import _prune_ancestry_transport_detail
+
+
+def _sample_graph() -> dict:
+    root = "sha256:" + "a" * 64
+    return {
+        "schema_version": "leadpoet.attested_execution_receipt_graph.v2",
+        "root_receipt_hash": root,
+        "receipts": [
+            {
+                "receipt_hash": root,
+                "role": "gateway_coordinator",
+                "purpose": "research_lab.promotion_decision.v2",
+                "transport_root": "sha256:" + "b" * 64,
+            },
+            {
+                "receipt_hash": "sha256:" + "c" * 64,
+                "role": "gateway_scoring",
+                "purpose": "research_lab.candidate_evaluation.v2",
+                "transport_root": "sha256:" + "d" * 64,
+            },
+        ],
+        "boot_identities": [
+            {"boot_identity_hash": "sha256:" + "e" * 64, "physical_role": "gateway_coordinator"},
+        ],
+        "transport_attempts": [
+            {"attempt_hash": "sha256:%064x" % i, "job_id": "j", "purpose": "p"}
+            for i in range(2600)
+        ],
+        "host_operations": [
+            {"request": {"request_hash": "sha256:%064x" % i}} for i in range(40)
+        ],
+    }
+
+
+def test_prune_empties_transport_and_host_only():
+    graph = _sample_graph()
+    pruned = _prune_ancestry_transport_detail(graph)
+
+    assert pruned["transport_attempts"] == []
+    assert pruned["host_operations"] == []
+    # Everything the enclave verifies is preserved byte-for-byte.
+    assert pruned["root_receipt_hash"] == graph["root_receipt_hash"]
+    assert pruned["receipts"] == graph["receipts"]
+    assert pruned["boot_identities"] == graph["boot_identities"]
+    assert pruned["schema_version"] == graph["schema_version"]
+
+
+def test_prune_does_not_mutate_the_validated_original():
+    graph = _sample_graph()
+    _prune_ancestry_transport_detail(graph)
+    # The gateway still holds the full, already-validated graph for its own
+    # binding extraction; pruning must not reach back into it.
+    assert len(graph["transport_attempts"]) == 2600
+    assert len(graph["host_operations"]) == 40
+
+
+def test_prune_root_receipt_authority_survives():
+    graph = _sample_graph()
+    pruned = _prune_ancestry_transport_detail(graph)
+    root = {r["receipt_hash"]: r for r in pruned["receipts"]}[
+        pruned["root_receipt_hash"]
+    ]
+    # The reward-ancestry check reads root purpose/role/hash — all intact.
+    assert root["purpose"] == "research_lab.promotion_decision.v2"
+    assert root["role"] == "gateway_coordinator"
+
+
+def test_prune_shrinks_payload_below_enclave_pressure():
+    graph = _sample_graph()
+    full = len(json.dumps(graph))
+    pruned = len(json.dumps(_prune_ancestry_transport_detail(graph)))
+    # The transport/host detail is the dominant, unbounded-growth component.
+    assert pruned < full * 0.25


### PR DESCRIPTION
## P0 root cause

The whole-subnet weight miss (epoch 24116, ~19:00 UTC) was the allocation endpoint returning:
```
RPC failed: Enclave error: payload size is outside limit
```
The primary's `authoritative_v2_allocation_unavailable` pre-submission guard then fail-closed blocked it — and every mirroring auditor with it.

**Why:** the allocation scoring job ships historical champion/reimbursement **parent graphs** to the coordinator enclave. Measured live on epoch 24115: a single such graph is **5.80 MB, dominated by 2,662 transport attempts** (377 receipts, 0 host-ops). The reimbursement-window history accumulates one graph per epoch (34,066 transport attempts table-wide and growing ~5.8 MB/epoch), so the job payload grew unbounded and finally crossed the enclave's `MAX_INPUT_BYTES = 64 MB` around epoch 24116. 24115 (17:52) built fine; 24116 didn't. This is a time-bomb, not a deployment/auto-pull issue.

## Fix

The enclave consumes parent graphs by **root receipt authority only** — the reward-ancestry check (`coordinator_executor_v2.py`) reads root hash/purpose/role, and `add_external_receipt_graph` does not re-validate their `transport_root` against terminal attempts. So the per-attempt transport/host detail of *historical* graphs is dead payload weight.

Ship the parent graphs to the enclave **without** `transport_attempts`/`host_operations`:
- **~86% smaller per graph** (5.80 MB → 0.81 MB), removing the unbounded-growth component and keeping the payload well under 64 MB.
- The gateway still validates each **full** graph (including transport reconstruction) before the prune, and keeps the validated originals for its own binding extraction — integrity unchanged.
- Receipts, boot identities, root, and schema the enclave verifies are preserved byte-for-byte.

## Verification

- `tests/test_allocation_ancestry_prune.py` (4): empties transport/host only, preserves root authority + receipts + boots, does not mutate the validated original, and shrinks the payload >4×.
- Protected-workflow manifest refreshed for the `build_allocation_v2` change; `tests/test_protected_workflows.py` green.

## Scope / reviewer note

Gateway-side only — deployable with a gateway restart, **no enclave rebuild** required, since the pruned graphs are exactly what the enclave already uses (roots). This assumes no enclave path re-validates external-graph transport; I traced the executor and job-manager receive paths and found none, but this is @Pranav-create's enclave-authority area — please confirm the enclave receive path so we can rule out a hidden completeness check. If one exists, the enclave needs the matching relaxation (and then a rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)