### PR TITLE
Prevent incomplete fulfillment finalization

### DIFF
--- a/gateway/fulfillment/api.py
+++ b/gateway/fulfillment/api.py
@@ -35,6 +35,9 @@ from gateway.fulfillment.models import (
     FulfillmentScoreResult,
     scrub_company_name,
 )
+from gateway.fulfillment.score_coverage import (
+    missing_lead_data_for_validator,
+)
 from gateway.models.events import EventType
 from gateway.utils.bans import is_hotkey_banned_sync, ban_hotkey
 from gateway.utils.db_executor import run_db
@@ -1507,14 +1510,12 @@ def _collect_scoring_requests_sync(validator_hotkey: str) -> dict:
     supabase = _get_supabase()
 
     # 1. All requests currently in scoring status (paged), PLUS recent
-    #    partially_fulfilled ones.  Consensus can finalize a request while
-    #    some revealed submissions are still un-scored (forced-consensus
-    #    timeout after an interruption); the lifecycle's stale-rescue pass
-    #    re-aggregates whenever late scores land — but that only works if
-    #    the validator is still OFFERED the leftover submissions.  The
-    #    per-submission filter below returns only the un-scored remainder,
-    #    so fully-scored requests in either status drop out of the payload.
-    #    The window matches the stale-rescue score-freshness window.
+    #    partially_fulfilled ones. Historical rows may have finalized under
+    #    the old submission-level coverage gate, and an additional validator
+    #    can also add quorum after the first pass. The lifecycle stale-rescue
+    #    pass re-aggregates those late scores, but only if the validator is
+    #    still offered the exact missing leads. Fully covered requests in
+    #    either status drop out of the payload below.
     rescore_cutoff = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
     scoring_requests: List[dict] = []
     offset = 0
@@ -1537,24 +1538,20 @@ def _collect_scoring_requests_sync(validator_hotkey: str) -> dict:
     print(f"📋 /fulfillment/scoring: {len(scoring_requests)} request(s) in scoring status")
     scoring_ids = [r["request_id"] for r in scoring_requests]
 
-    # 2. Which SUBMISSIONS of these requests has this validator already
-    #    scored?  Tracked per-submission, NOT per-request: excluding a whole
-    #    request the moment one of its submissions has a score strands the
-    #    rest.  When scoring is interrupted mid-request (validator restart,
-    #    gateway outage), the request sits with partial scores, never
-    #    reappears in this feed, and at forced consensus every un-scored
-    #    miner's revealed work is discarded.  Offering only the un-scored
-    #    remainder lets the validator finish the request; re-scores are safe
-    #    regardless (fulfillment_upsert_scores upserts on the same natural
-    #    key).
-    scored_subs_by_req: dict = {}
+    # 2. Which LEADS of these requests has this validator already scored?
+    #    A submission is not complete merely because one score row exists:
+    #    workers can be interrupted after persisting only a prefix of a
+    #    multi-lead submission.  Track exact (request, submission, lead)
+    #    coverage and re-offer only the missing lead subset.  The score RPC
+    #    upserts on this natural key, so a conservative re-offer is safe.
+    scored_leads_by_req_sub: dict = {}
     if validator_hotkey:
         for i in range(0, len(scoring_ids), 100):
             chunk = scoring_ids[i:i + 100]
             offset = 0
-            for _ in range(20):
+            while True:
                 page = supabase.table("fulfillment_scores") \
-                    .select("request_id, submission_id") \
+                    .select("request_id, submission_id, lead_id") \
                     .eq("validator_hotkey", validator_hotkey) \
                     .in_("request_id", chunk) \
                     .range(offset, offset + 999) \
@@ -1562,19 +1559,24 @@ def _collect_scoring_requests_sync(validator_hotkey: str) -> dict:
                 if not page.data:
                     break
                 for row in page.data:
-                    # Rows predating submission_id stamping can't identify
-                    # their submission; leaving them out re-offers the whole
-                    # request, and the upsert makes the re-score harmless.
-                    if row.get("submission_id"):
-                        scored_subs_by_req.setdefault(row["request_id"], set()) \
-                            .add(row["submission_id"])
+                    submission_id = row.get("submission_id")
+                    lead_id = row.get("lead_id")
+                    # Legacy rows missing either identifier cannot prove
+                    # coverage. Leaving them out re-offers the affected lead
+                    # and the idempotent upsert absorbs the retry.
+                    if submission_id and lead_id:
+                        scored_leads_by_req_sub.setdefault(
+                            row["request_id"], {}
+                        ).setdefault(
+                            str(submission_id), set()
+                        ).add(str(lead_id))
                 if len(page.data) < 1000:
                     break
                 offset += 1000
-        if scored_subs_by_req:
+        if scored_leads_by_req_sub:
             print(f"   Validator {validator_hotkey[:8]}... has scores on "
-                  f"{len(scored_subs_by_req)} of {len(scoring_ids)} request(s); "
-                  f"offering un-scored submissions only")
+                  f"{len(scored_leads_by_req_sub)} of {len(scoring_ids)} request(s); "
+                  f"offering missing leads only")
 
     needed_ids = scoring_ids
 
@@ -1606,20 +1608,20 @@ def _collect_scoring_requests_sync(validator_hotkey: str) -> dict:
     out = []
     for rid in needed_ids:
         r = req_by_id[rid]
-        already_scored = scored_subs_by_req.get(rid, set())
+        already_scored = scored_leads_by_req_sub.get(rid, {})
         submissions = []
         for s in subs_by_req.get(rid, []):
-            # Skip submissions this validator already scored — only the
-            # un-scored remainder needs work (see the per-submission
-            # tracking rationale above).
-            if s["submission_id"] in already_scored:
-                continue
             # SAFETY: `leads` and `lead_ids` MUST come from the same
             # `lead_data` list so they stay index-aligned — the validator
             # zips them onto scores, and mismatched lengths silently corrupt
             # consensus / winner selection.  lead_data entries are
             # {"lead_id": ..., "data": ...} so both projections are safe.
-            lead_data = s.get("lead_data") or []
+            lead_data = missing_lead_data_for_validator(
+                s,
+                already_scored.get(str(s["submission_id"]), set()),
+            )
+            if not lead_data:
+                continue
             submissions.append({
                 "submission_id": s["submission_id"],
                 "miner_hotkey": s["miner_hotkey"],
@@ -1711,6 +1713,35 @@ def _submit_scores_impl(request_id: str, validator_hotkey: str, scores: List[dic
     for s in scores:
         if not s.get("request_id"):
             s["request_id"] = request_id
+        elif str(s["request_id"]) != str(request_id):
+            raise HTTPException(
+                422,
+                detail=(
+                    "Every score request_id must match the request_id "
+                    "being submitted"
+                ),
+            )
+
+    # Fast, readable rejection for stale validator work. Migration 117 repeats
+    # this check while holding the request-row lock, which is the actual
+    # finalization race fence; this preflight avoids an opaque RPC error in
+    # the common case where the request is already terminal.
+    request_resp = supabase.table("fulfillment_requests") \
+        .select("status") \
+        .eq("request_id", request_id) \
+        .limit(1) \
+        .execute()
+    if not request_resp.data:
+        raise HTTPException(404, detail="Fulfillment request not found")
+    request_status = request_resp.data[0].get("status")
+    if request_status not in {"scoring", "partially_fulfilled"}:
+        raise HTTPException(
+            409,
+            detail=(
+                "Fulfillment score window is closed "
+                f"(request status: {request_status})"
+            ),
+        )
 
     try:
         supabase.rpc("fulfillment_upsert_scores", {
@@ -1718,6 +1749,11 @@ def _submit_scores_impl(request_id: str, validator_hotkey: str, scores: List[dic
             "p_validator_hotkey": validator_hotkey,
         }).execute()
     except Exception as e:
+        if "FULFILLMENT_SCORE_WINDOW_CLOSED" in str(e):
+            raise HTTPException(
+                409,
+                detail="Fulfillment score window closed during submission",
+            ) from e
         raise HTTPException(500, detail=f"Score submission failed: {e}")
 
     # The fulfillment_upsert_scores RPC was defined before the

--- a/gateway/fulfillment/lifecycle.py
+++ b/gateway/fulfillment/lifecycle.py
@@ -25,6 +25,10 @@ from gateway.fulfillment.config import (
     epochs_to_seconds,
 )
 from gateway.fulfillment.consensus import compute_fulfillment_consensus
+from gateway.fulfillment.score_coverage import (
+    FulfillmentScoreCoverage,
+    summarize_score_coverage,
+)
 from gateway.models.events import EventType
 
 logger = logging.getLogger(__name__)
@@ -115,6 +119,206 @@ def _try_advisory_lock(supabase) -> bool:
 def _release_advisory_lock(supabase) -> None:
     """No-op companion to _try_advisory_lock.  Historical rationale above."""
     return None
+
+
+def _load_score_coverage(
+    supabase,
+    request_id: str,
+) -> FulfillmentScoreCoverage:
+    """Load complete revealed-lead coverage for one request.
+
+    Both tables can exceed PostgREST's 1,000-row default limit, so each scan
+    is explicitly paginated.  The returned summary is the single authority
+    used by the lifecycle finalization gate.
+    """
+
+    revealed_submissions: list[dict] = []
+    offset = 0
+    while True:
+        page = supabase.table("fulfillment_submissions") \
+            .select("submission_id, lead_data") \
+            .eq("request_id", request_id) \
+            .eq("revealed", True) \
+            .range(offset, offset + 999) \
+            .execute()
+        rows = page.data or []
+        if not rows:
+            break
+        revealed_submissions.extend(rows)
+        if len(rows) < 1000:
+            break
+        offset += 1000
+
+    score_rows: list[dict] = []
+    offset = 0
+    while True:
+        page = supabase.table("fulfillment_scores") \
+            .select("submission_id, lead_id, validator_hotkey, scored_at") \
+            .eq("request_id", request_id) \
+            .range(offset, offset + 999) \
+            .execute()
+        rows = page.data or []
+        if not rows:
+            break
+        score_rows.extend(rows)
+        if len(rows) < 1000:
+            break
+        offset += 1000
+
+    return summarize_score_coverage(
+        revealed_submissions,
+        score_rows,
+        required_validators=FULFILLMENT_MIN_VALIDATORS,
+    )
+
+
+def _consensus_readiness(
+    coverage: FulfillmentScoreCoverage,
+    *,
+    timed_out: bool,
+) -> str:
+    """Return the lifecycle action for the current score coverage.
+
+    A partial non-empty score set is never permission to finalize.  Once any
+    validator has begun a request, the request stays in scoring until every
+    revealed lead reaches the configured validator quorum.  Zero-validator
+    requests retain the existing timeout recycle path so an unavailable
+    validator cannot wedge the queue forever.
+    """
+
+    if not coverage.validator_hotkeys:
+        return "no_validators_timeout" if timed_out else "wait_validators"
+    if not coverage.complete:
+        return "wait_score_coverage"
+    return "ready"
+
+
+def _claim_finalization(
+    supabase,
+    request_id: str,
+    coverage: FulfillmentScoreCoverage,
+) -> bool:
+    """Atomically freeze scoring when consensus used the latest score set.
+
+    Migration 117 locks the request row, compares the exact score watermark,
+    and transitions the request to ``finalizing``. Concurrent score RPCs use
+    the same lock. Therefore either a new score lands first (and this returns
+    false) or finalization wins and the stale score is rejected.
+    """
+
+    result = supabase.rpc(
+        "fulfillment_claim_finalization",
+        {
+            "p_request_id": request_id,
+            "p_expected_score_count": coverage.score_row_count,
+            "p_expected_latest_scored_at": coverage.latest_scored_at,
+        },
+    ).execute()
+    data = result.data
+    if isinstance(data, list):
+        return bool(data and data[0])
+    return data is True
+
+
+_RECONCILABLE_SUCCESSOR_STATUSES = {
+    "pending",
+    "open",
+    "continued_open",
+    "commit_closed",
+}
+
+
+def _successor_quota_payload(
+    icp_details: dict,
+    *,
+    remaining_leads: int,
+    held_companies: list[str],
+) -> dict:
+    """Build the two synchronized quota fields for a continuation row."""
+
+    target = max(0, int(remaining_leads))
+    icp = dict(icp_details or {})
+    icp["num_leads"] = target
+
+    prior = list(icp.get("excluded_companies") or [])
+    seen = {
+        str(company).strip().lower()
+        for company in prior
+        if str(company).strip()
+    }
+    for company in held_companies or []:
+        company_text = str(company or "").strip()
+        if company_text and company_text.lower() not in seen:
+            prior.append(company_text)
+            seen.add(company_text.lower())
+    icp["excluded_companies"] = prior
+
+    return {
+        "num_leads": target,
+        "icp_details": icp,
+    }
+
+
+def _reconcile_active_successor(
+    supabase,
+    successor_request_id: str,
+    *,
+    remaining_leads: int,
+    held_companies: list[str],
+) -> bool:
+    """Update a not-yet-scoring successor after late consensus changes.
+
+    Commit/reveal rows may already exist, so the successor is not deleted or
+    recreated. Updating its quota changes future miner caps and dashboard
+    state while chain top-K still safely caps all already-submitted work.
+    Once scoring starts, the ICP is immutable for that cycle to avoid workers
+    evaluating the same batch against different exclusion snapshots.
+    """
+
+    if not successor_request_id:
+        return False
+    current = supabase.table("fulfillment_requests") \
+        .select("request_id, status, num_leads, icp_details") \
+        .eq("request_id", successor_request_id) \
+        .limit(1) \
+        .execute()
+    if not current.data:
+        logger.warning(
+            "FULFILLMENT_SUCCESSOR_RECONCILE_MISSING successor=%s",
+            successor_request_id,
+        )
+        return False
+
+    row = current.data[0]
+    status = row.get("status")
+    if status not in _RECONCILABLE_SUCCESSOR_STATUSES:
+        logger.warning(
+            "FULFILLMENT_SUCCESSOR_RECONCILE_SKIPPED successor=%s status=%s "
+            "remaining=%s",
+            successor_request_id,
+            status,
+            remaining_leads,
+        )
+        return False
+
+    payload = _successor_quota_payload(
+        row.get("icp_details") or {},
+        remaining_leads=remaining_leads,
+        held_companies=held_companies,
+    )
+    current_icp = row.get("icp_details") or {}
+    if (
+        int(row.get("num_leads") or 0) == payload["num_leads"]
+        and current_icp == payload["icp_details"]
+    ):
+        return False
+
+    updated = supabase.table("fulfillment_requests") \
+        .update(payload) \
+        .eq("request_id", successor_request_id) \
+        .eq("status", status) \
+        .execute()
+    return bool(updated.data)
 
 
 async def fulfillment_lifecycle_task() -> None:
@@ -425,7 +629,8 @@ async def _lifecycle_tick_inner(supabase) -> None:
             )
 
     # Step 3: consensus aggregation for scoring requests + recently-transitioned
-    # partially_fulfilled requests (within the consensus timeout window).
+    # partially_fulfilled requests (within the consensus timeout window), plus
+    # crash-recoverable finalizing requests.
     #
     # Why include partially_fulfilled: FULFILLMENT_MIN_VALIDATORS defaults to 1,
     # so the first validator's submission triggers compute_fulfillment_consensus()
@@ -445,9 +650,10 @@ async def _lifecycle_tick_inner(supabase) -> None:
     #     correctly displace lower-scoring held leads.
     #   * Time-bounded to FULFILLMENT_CONSENSUS_TIMEOUT_MINUTES past
     #     reveal_window_end so we don't re-aggregate ancient requests forever.
-    #   * fulfilled and recycled are NOT included — fulfilled would risk
-    #     double-paying via a second _finalize_chain_rewards; recycled is a
-    #     separate (and rarer) failure mode handled in a follow-up.
+    #   * fulfilled and recycled are NOT included. Migration 117 makes
+    #     fulfilled immutable by rejecting late score writes; `finalizing`
+    #     is the retryable pre-fulfilled state used to finish reward writes
+    #     safely after a process interruption.
     # The time-bound on `reveal_window_end` exists to prevent infinite
     # re-aggregation of `partially_fulfilled` requests when late validator
     # scores trickle in.  It must NOT apply to `scoring` — that status
@@ -459,12 +665,14 @@ async def _lifecycle_tick_inner(supabase) -> None:
     rerun_window_start = (
         now - timedelta(minutes=FULFILLMENT_CONSENSUS_TIMEOUT_MINUTES)
     ).isoformat()
-    # Standard window: scoring (any age) + fresh partially_fulfilled.
+    # Standard window: scoring/finalizing (any age) + fresh
+    # partially_fulfilled.
     scoring_requests = supabase.table("fulfillment_requests") \
         .select("request_id, reveal_window_end, icp_details, num_leads, internal_label, company, required_attributes, status, successor_request_id") \
-        .in_("status", ["scoring", "partially_fulfilled"]) \
+        .in_("status", ["scoring", "partially_fulfilled", "finalizing"]) \
         .or_(
-            f"status.eq.scoring,reveal_window_end.gte.{rerun_window_start}"
+            f"status.eq.scoring,status.eq.finalizing,"
+            f"reveal_window_end.gte.{rerun_window_start}"
         ) \
         .execute()
 
@@ -531,60 +739,33 @@ async def _lifecycle_tick_inner(supabase) -> None:
     for r in (scoring_requests.data or []):
         rid = r["request_id"]
         try:
-            validator_count_resp = supabase.table("fulfillment_scores") \
-                .select("validator_hotkey") \
-                .eq("request_id", rid) \
-                .execute()
-            unique_validators = {s["validator_hotkey"] for s in (validator_count_resp.data or [])}
-
             reveal_end = _isoparse(r["reveal_window_end"])
             timeout = reveal_end + timedelta(minutes=FULFILLMENT_CONSENSUS_TIMEOUT_MINUTES)
+            timed_out = now >= timeout
+            coverage = await asyncio.to_thread(
+                _load_score_coverage,
+                supabase,
+                rid,
+            )
+            unique_validators = set(coverage.validator_hotkeys)
+            readiness = _consensus_readiness(
+                coverage,
+                timed_out=timed_out,
+            )
 
-            if len(unique_validators) < FULFILLMENT_MIN_VALIDATORS and now < timeout:
-                mins_left = (timeout - now).total_seconds() / 60
-                print(f"   {rid[:8]}... waiting for validators: {len(unique_validators)}/{FULFILLMENT_MIN_VALIDATORS} ({mins_left:.1f}min until timeout)")
-                continue
-
-            # ─── Guard: don't run consensus while revealed submissions are still un-scored ─────
-            # Observed 2026-06-01 on request fbeed690-edbb-...: 6 miners had
-            # revealed submissions (3 with 41 leads each + 3 with 9 leads each),
-            # but only 2 of 6 were scored before consensus fired. The other 4
-            # miners' work was discarded when the request transitioned to
-            # `recycled`. Miners (5GpzK4Rm, 5H17R1Za, 5HGP4yPa, 5DcJwmjL)
-            # rightly complained that their submissions "weren't scored".
-            #
-            # Root cause: this loop's gate counts unique VALIDATORS (currently
-            # MIN=1). The moment one validator submits a score for ONE miner's
-            # submission, the gate opens and consensus runs — even if other
-            # miners' revealed submissions are still queued for scoring.
-            #
-            # Fix: count distinct revealed submissions for this request and
-            # distinct submission_ids in fulfillment_scores. If revealed >
-            # scored AND we're inside the consensus grace window, defer.
-            # Once we hit the timeout, fall through to consensus anyway so a
-            # dead validator can't wedge the request forever.
-            revealed_subs_resp = supabase.table("fulfillment_submissions") \
-                .select("submission_id") \
-                .eq("request_id", rid) \
-                .eq("revealed", True) \
-                .execute()
-            revealed_subs = {s["submission_id"] for s in (revealed_subs_resp.data or [])}
-            scored_subs_resp = supabase.table("fulfillment_scores") \
-                .select("submission_id") \
-                .eq("request_id", rid) \
-                .execute()
-            scored_subs = {s.get("submission_id") for s in (scored_subs_resp.data or []) if s.get("submission_id")}
-            unscored_subs = revealed_subs - scored_subs
-            if unscored_subs and now < timeout:
-                mins_left = (timeout - now).total_seconds() / 60
+            if readiness == "wait_validators":
+                mins_left = max(
+                    0.0,
+                    (timeout - now).total_seconds() / 60,
+                )
                 print(
-                    f"   {rid[:8]}... deferring consensus: "
-                    f"{len(unscored_subs)}/{len(revealed_subs)} revealed submissions "
-                    f"still un-scored ({mins_left:.1f}min until forced consensus)"
+                    f"   {rid[:8]}... waiting for validators: "
+                    f"0/{FULFILLMENT_MIN_VALIDATORS} "
+                    f"({mins_left:.1f}min until timeout)"
                 )
                 continue
 
-            if len(unique_validators) == 0 and now >= timeout:
+            if readiness == "no_validators_timeout":
                 print(
                     f"   ⚠️  {rid[:8]}... has 0 validators after timeout — "
                     f"expiring and recycling"
@@ -614,11 +795,32 @@ async def _lifecycle_tick_inner(supabase) -> None:
                 )
                 continue
 
-            if len(unique_validators) < FULFILLMENT_MIN_VALIDATORS:
-                print(
-                    f"   ⚠️  {rid[:8]}... consensus timeout: "
-                    f"{len(unique_validators)}/{FULFILLMENT_MIN_VALIDATORS} validators — proceeding"
+            if readiness == "wait_score_coverage":
+                timing = "after timeout" if timed_out else "before timeout"
+                logger.warning(
+                    "FULFILLMENT_SCORE_COVERAGE_INCOMPLETE request=%s "
+                    "coverage=%s/%s incomplete_submissions=%s "
+                    "missing_score_slots=%s validators=%s timing=%s",
+                    rid,
+                    coverage.covered_leads,
+                    coverage.expected_leads,
+                    coverage.incomplete_submissions,
+                    coverage.missing_score_slots,
+                    len(unique_validators),
+                    timing,
                 )
+                print(
+                    f"   {rid[:8]}... deferring consensus: "
+                    f"{coverage.covered_leads}/{coverage.expected_leads} "
+                    f"revealed leads have "
+                    f"{FULFILLMENT_MIN_VALIDATORS}-validator coverage; "
+                    f"{coverage.incomplete_submissions} submission(s) "
+                    f"incomplete ({timing})"
+                )
+                # Never finalize a non-empty partial score set. The validator
+                # feed re-offers missing leads, and the request deliberately
+                # stays in scoring until every revealed lead reaches quorum.
+                continue
 
             # Skip re-aggregation when no new validator scores have arrived
             # since the last consensus pass.  Heavy work (compute_consensus +
@@ -736,7 +938,43 @@ async def _lifecycle_tick_inner(supabase) -> None:
             # recycle branch when nothing materially changed — otherwise the
             # existing recycle would insert + claim-loss + delete an orphan
             # successor every tick.
-            was_partially_fulfilled = r.get("status") == "partially_fulfilled"
+            was_partially_fulfilled = (
+                r.get("status") == "partially_fulfilled"
+                or (
+                    r.get("status") == "finalizing"
+                    and bool(r.get("successor_request_id"))
+                )
+            )
+
+            # Late scores can change the held set after a continuation was
+            # created. Keep the active successor's remaining quota and miner-
+            # visible ICP synchronized with the authoritative chain top-K.
+            # This is safe through commit_closed; once successor scoring starts
+            # its ICP is frozen for that cycle.
+            if was_partially_fulfilled and held_count < chain_target:
+                remaining = chain_target - held_count
+                try:
+                    reconciled = await asyncio.to_thread(
+                        _reconcile_active_successor,
+                        supabase,
+                        r.get("successor_request_id"),
+                        remaining_leads=remaining,
+                        held_companies=topk_companies,
+                    )
+                    if reconciled:
+                        print(
+                            f"   🔄 reconciled successor "
+                            f"{str(r.get('successor_request_id'))[:8]}... "
+                            f"to remaining quota {remaining}"
+                        )
+                except Exception as e:
+                    logger.warning(
+                        "FULFILLMENT_SUCCESSOR_RECONCILE_FAILED "
+                        "request=%s successor=%s error=%s",
+                        rid,
+                        r.get("successor_request_id"),
+                        e,
+                    )
 
             if held_count >= chain_target:
                 # ────────────────────────────────────────────────────────
@@ -755,12 +993,38 @@ async def _lifecycle_tick_inner(supabase) -> None:
                 # cycle runs (chain top-K sees the chain quota already met
                 # via the predecessor's held leads).
                 # ────────────────────────────────────────────────────────
+                claimed = await asyncio.to_thread(
+                    _claim_finalization,
+                    supabase,
+                    rid,
+                    coverage,
+                )
+                if not claimed:
+                    logger.warning(
+                        "FULFILLMENT_FINALIZATION_WATERMARK_CHANGED "
+                        "request=%s expected_score_count=%s "
+                        "expected_latest_scored_at=%s",
+                        rid,
+                        coverage.score_row_count,
+                        coverage.latest_scored_at,
+                    )
+                    # A score committed after coverage/consensus was loaded.
+                    # Leave the request non-terminal and recompute next tick.
+                    continue
+
                 winner_lead_ids = await _finalize_chain_rewards(
                     rid, topk, chain["tied_groups"],
                 )
-                supabase.table("fulfillment_requests").update({
+                finalized = supabase.table("fulfillment_requests").update({
                     "status": "fulfilled",
-                }).eq("request_id", rid).execute()
+                }).eq("request_id", rid) \
+                  .eq("status", "finalizing") \
+                  .execute()
+                if not finalized.data:
+                    raise RuntimeError(
+                        "FULFILLMENT_FINAL_STATUS_WRITE_FAILED "
+                        f"request={rid}"
+                    )
                 print(
                     f"   ✅ {rid[:8]}... -> fulfilled "
                     f"({len(winner_lead_ids)}/{chain_target} winners; "
@@ -852,7 +1116,7 @@ async def _lifecycle_tick_inner(supabase) -> None:
                     print(
                         f"   🔄 {rid[:8]}... re-aggregated "
                         f"({held_count}/{chain_target} held, "
-                        f"still partially_fulfilled; successor unchanged)"
+                        f"still partially_fulfilled; successor reconciled)"
                     )
                 else:
                     # ────────────────────────────────────────────────────
@@ -2008,6 +2272,13 @@ def _recycle_request(
             if successor_num_leads is not None
             else original_request["num_leads"]
         )
+        quota_payload = _successor_quota_payload(
+            successor_icp,
+            remaining_leads=target_num_leads,
+            held_companies=held_companies or [],
+        )
+        target_num_leads = quota_payload["num_leads"]
+        successor_icp = quota_payload["icp_details"]
 
         successor_row = {
             "request_id": new_id,

--- a/gateway/fulfillment/rewards.py
+++ b/gateway/fulfillment/rewards.py
@@ -34,11 +34,12 @@ def calculate_lead_rewards(
     supabase = _get_supabase()
     expires_epoch = current_epoch + l_epochs
 
+    failures: list[str] = []
     for w in winners:
         pct = z_pct / w.get("tie_count", 1)
 
         try:
-            supabase.table("fulfillment_score_consensus").update({
+            response = supabase.table("fulfillment_score_consensus").update({
                 "is_winner": True,
                 "reward_pct": pct,
                 "reward_expires_epoch": expires_epoch,
@@ -46,5 +47,15 @@ def calculate_lead_rewards(
               .eq("submission_id", w["submission_id"]) \
               .eq("lead_id", w["lead_id"]) \
               .execute()
+            if not response.data:
+                raise RuntimeError("no consensus row matched the winner key")
         except Exception as e:
-            logger.error(f"Failed to assign reward for lead {w.get('lead_id')}: {e}")
+            lead_id = str(w.get("lead_id") or "")
+            failures.append(lead_id)
+            logger.error(f"Failed to assign reward for lead {lead_id}: {e}")
+
+    if failures:
+        raise RuntimeError(
+            "FULFILLMENT_REWARD_WRITE_INCOMPLETE "
+            f"request={request_id} failed_leads={failures}"
+        )

--- a/gateway/fulfillment/score_coverage.py
+++ b/gateway/fulfillment/score_coverage.py
@@ -1,0 +1,153 @@
+"""Shared score-coverage accounting for fulfillment submissions.
+
+The validator feed and lifecycle finalizer must agree on what "scored" means.
+A submission is complete only when every revealed lead has the required
+validator coverage; one score row for a multi-lead submission is not enough.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class FulfillmentScoreCoverage:
+    """Coverage summary for one fulfillment request."""
+
+    expected_leads: int
+    covered_leads: int
+    incomplete_submissions: int
+    missing_score_slots: int
+    malformed_revealed_leads: int
+    validator_hotkeys: frozenset[str]
+    score_row_count: int = 0
+    latest_scored_at: str | None = None
+
+    @property
+    def complete(self) -> bool:
+        return (
+            self.expected_leads > 0
+            and self.covered_leads == self.expected_leads
+            and self.incomplete_submissions == 0
+            and self.malformed_revealed_leads == 0
+        )
+
+
+def _lead_id(entry: Mapping) -> str:
+    return str(entry.get("lead_id") or "").strip()
+
+
+def summarize_score_coverage(
+    revealed_submissions: Sequence[Mapping],
+    score_rows: Iterable[Mapping],
+    *,
+    required_validators: int,
+) -> FulfillmentScoreCoverage:
+    """Return per-lead validator coverage for revealed submissions.
+
+    Scores only count when their ``(submission_id, lead_id)`` pair exists in
+    the revealed payload. Duplicate rows from one validator count once.
+    Missing or duplicate revealed lead IDs fail closed because the scorer
+    cannot correlate them unambiguously.
+    """
+
+    quorum = max(1, int(required_validators))
+    validators_by_lead: dict[tuple[str, str], set[str]] = {}
+    all_validator_hotkeys: set[str] = set()
+    score_row_count = 0
+    latest_scored_at: str | None = None
+    latest_scored_at_value: datetime | None = None
+
+    for row in score_rows:
+        score_row_count += 1
+        scored_at = str(row.get("scored_at") or "").strip()
+        if scored_at:
+            try:
+                scored_at_value = datetime.fromisoformat(
+                    scored_at.replace("Z", "+00:00")
+                )
+            except ValueError:
+                scored_at_value = None
+            if scored_at_value is not None and (
+                latest_scored_at_value is None
+                or scored_at_value > latest_scored_at_value
+            ):
+                latest_scored_at = scored_at
+                latest_scored_at_value = scored_at_value
+        submission_id = str(row.get("submission_id") or "").strip()
+        lead_id = str(row.get("lead_id") or "").strip()
+        validator_hotkey = str(row.get("validator_hotkey") or "").strip()
+        if not submission_id or not lead_id or not validator_hotkey:
+            continue
+        validators_by_lead.setdefault((submission_id, lead_id), set()).add(
+            validator_hotkey
+        )
+
+    expected_leads = 0
+    covered_leads = 0
+    incomplete_submissions = 0
+    missing_score_slots = 0
+    malformed_revealed_leads = 0
+
+    for submission in revealed_submissions:
+        submission_id = str(submission.get("submission_id") or "").strip()
+        lead_data = submission.get("lead_data") or []
+        submission_incomplete = False
+        seen_lead_ids: set[str] = set()
+
+        for entry in lead_data:
+            expected_leads += 1
+            lead_id = _lead_id(entry) if isinstance(entry, Mapping) else ""
+            if not submission_id or not lead_id or lead_id in seen_lead_ids:
+                malformed_revealed_leads += 1
+                missing_score_slots += quorum
+                submission_incomplete = True
+                continue
+
+            seen_lead_ids.add(lead_id)
+            validators = validators_by_lead.get((submission_id, lead_id), set())
+            all_validator_hotkeys.update(validators)
+            validator_count = len(validators)
+            if validator_count >= quorum:
+                covered_leads += 1
+            else:
+                missing_score_slots += quorum - validator_count
+                submission_incomplete = True
+
+        if not lead_data:
+            submission_incomplete = True
+        if submission_incomplete:
+            incomplete_submissions += 1
+
+    return FulfillmentScoreCoverage(
+        expected_leads=expected_leads,
+        covered_leads=covered_leads,
+        incomplete_submissions=incomplete_submissions,
+        missing_score_slots=missing_score_slots,
+        malformed_revealed_leads=malformed_revealed_leads,
+        validator_hotkeys=frozenset(all_validator_hotkeys),
+        score_row_count=score_row_count,
+        latest_scored_at=latest_scored_at,
+    )
+
+
+def missing_lead_data_for_validator(
+    submission: Mapping,
+    scored_lead_ids: Iterable[str],
+) -> list[Mapping]:
+    """Return only the revealed leads the validator has not scored yet."""
+
+    scored = {
+        str(lead_id or "").strip()
+        for lead_id in scored_lead_ids
+        if str(lead_id or "").strip()
+    }
+    missing: list[Mapping] = []
+    for entry in submission.get("lead_data") or []:
+        if not isinstance(entry, Mapping):
+            missing.append(entry)
+            continue
+        lead_id = _lead_id(entry)
+        if not lead_id or lead_id not in scored:
+            missing.append(entry)
+    return missing

--- a/scripts/117-fulfillment-finalization-fence.sql
+++ b/scripts/117-fulfillment-finalization-fence.sql
@@ -1,0 +1,225 @@
+-- Fulfillment finalization correctness fence.
+--
+-- 1. Score writes lock the request row and reject terminal/finalizing states.
+-- 2. Finalization locks the same row and succeeds only when the score count
+--    and latest score timestamp still match the set used for consensus.
+-- 3. Newly-added score detail columns are persisted inside the score RPC
+--    transaction instead of relying only on the gateway's compatibility
+--    patch after the RPC commits.
+
+BEGIN;
+
+ALTER TABLE public.fulfillment_requests
+    DROP CONSTRAINT IF EXISTS fulfillment_requests_status_check;
+
+ALTER TABLE public.fulfillment_requests
+    ADD CONSTRAINT fulfillment_requests_status_check
+    CHECK (
+        status IN (
+            'pending',
+            'open',
+            'continued_open',
+            'commit_closed',
+            'scoring',
+            'finalizing',
+            'fulfilled',
+            'partially_fulfilled',
+            'recycled',
+            'expired'
+        )
+    );
+
+CREATE OR REPLACE FUNCTION public.fulfillment_upsert_scores(
+    p_scores jsonb,
+    p_validator_hotkey text
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+    v_score jsonb;
+    v_request_id uuid;
+    v_score_request_id uuid;
+    v_request_status text;
+BEGIN
+    IF jsonb_typeof(p_scores) IS DISTINCT FROM 'array'
+       OR jsonb_array_length(p_scores) = 0 THEN
+        RETURN;
+    END IF;
+
+    v_request_id := (p_scores->0->>'request_id')::uuid;
+
+    SELECT status
+      INTO v_request_status
+      FROM public.fulfillment_requests
+     WHERE request_id = v_request_id
+     FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'FULFILLMENT_REQUEST_NOT_FOUND request=%',
+            v_request_id;
+    END IF;
+
+    IF v_request_status NOT IN ('scoring', 'partially_fulfilled') THEN
+        RAISE EXCEPTION
+            'FULFILLMENT_SCORE_WINDOW_CLOSED request=% status=%',
+            v_request_id,
+            v_request_status;
+    END IF;
+
+    FOR v_score IN SELECT * FROM jsonb_array_elements(p_scores) LOOP
+        v_score_request_id := (v_score->>'request_id')::uuid;
+        IF v_score_request_id IS DISTINCT FROM v_request_id THEN
+            RAISE EXCEPTION
+                'FULFILLMENT_SCORE_REQUEST_MISMATCH expected=% actual=%',
+                v_request_id,
+                v_score_request_id;
+        END IF;
+
+        INSERT INTO public.fulfillment_scores (
+            score_id,
+            request_id,
+            submission_id,
+            miner_hotkey,
+            validator_hotkey,
+            lead_id,
+            icp_fit,
+            decision_maker,
+            intent_signal_raw,
+            intent_signal_final,
+            intent_decay_multiplier,
+            final_score,
+            tier1_passed,
+            tier2_passed,
+            email_verified,
+            person_verified,
+            company_verified,
+            rep_score,
+            failure_reason,
+            failure_detail,
+            intent_signals_detail,
+            attribute_verification,
+            scored_at,
+            all_fabricated
+        ) VALUES (
+            gen_random_uuid(),
+            v_score_request_id,
+            (v_score->>'submission_id')::uuid,
+            v_score->>'miner_hotkey',
+            p_validator_hotkey,
+            v_score->>'lead_id',
+            NULL,
+            NULL,
+            (v_score->>'intent_signal_raw')::double precision,
+            (v_score->>'intent_signal_final')::double precision,
+            (v_score->>'intent_decay_multiplier')::double precision,
+            (v_score->>'final_score')::double precision,
+            COALESCE((v_score->>'tier1_passed')::boolean, false),
+            COALESCE((v_score->>'tier2_passed')::boolean, false),
+            COALESCE((v_score->>'email_verified')::boolean, false),
+            COALESCE((v_score->>'person_verified')::boolean, false),
+            COALESCE((v_score->>'company_verified')::boolean, false),
+            COALESCE((v_score->>'rep_score')::double precision, 0.0),
+            v_score->>'failure_reason',
+            v_score->>'failure_detail',
+            NULLIF(v_score->'intent_signals_detail', 'null'::jsonb),
+            NULLIF(v_score->'attribute_verification', 'null'::jsonb),
+            clock_timestamp(),
+            COALESCE((v_score->>'all_fabricated')::boolean, false)
+        )
+        ON CONFLICT (
+            request_id,
+            submission_id,
+            lead_id,
+            validator_hotkey
+        ) DO UPDATE SET
+            intent_signal_raw = EXCLUDED.intent_signal_raw,
+            intent_signal_final = EXCLUDED.intent_signal_final,
+            intent_decay_multiplier = EXCLUDED.intent_decay_multiplier,
+            final_score = EXCLUDED.final_score,
+            tier1_passed = EXCLUDED.tier1_passed,
+            tier2_passed = EXCLUDED.tier2_passed,
+            email_verified = EXCLUDED.email_verified,
+            person_verified = EXCLUDED.person_verified,
+            company_verified = EXCLUDED.company_verified,
+            rep_score = EXCLUDED.rep_score,
+            failure_reason = EXCLUDED.failure_reason,
+            failure_detail = COALESCE(
+                EXCLUDED.failure_detail,
+                fulfillment_scores.failure_detail
+            ),
+            intent_signals_detail = COALESCE(
+                EXCLUDED.intent_signals_detail,
+                fulfillment_scores.intent_signals_detail
+            ),
+            attribute_verification = COALESCE(
+                EXCLUDED.attribute_verification,
+                fulfillment_scores.attribute_verification
+            ),
+            scored_at = EXCLUDED.scored_at,
+            all_fabricated = EXCLUDED.all_fabricated;
+    END LOOP;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.fulfillment_claim_finalization(
+    p_request_id uuid,
+    p_expected_score_count bigint,
+    p_expected_latest_scored_at timestamptz
+)
+RETURNS boolean
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+    v_request_status text;
+    v_score_count bigint;
+    v_latest_scored_at timestamptz;
+BEGIN
+    SELECT status
+      INTO v_request_status
+      FROM public.fulfillment_requests
+     WHERE request_id = p_request_id
+     FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN false;
+    END IF;
+
+    IF v_request_status = 'finalizing' THEN
+        RETURN true;
+    END IF;
+
+    IF v_request_status NOT IN ('scoring', 'partially_fulfilled') THEN
+        RETURN false;
+    END IF;
+
+    SELECT count(*), max(scored_at)
+      INTO v_score_count, v_latest_scored_at
+      FROM public.fulfillment_scores
+     WHERE request_id = p_request_id;
+
+    IF v_score_count IS DISTINCT FROM p_expected_score_count
+       OR v_latest_scored_at IS DISTINCT FROM p_expected_latest_scored_at THEN
+        RETURN false;
+    END IF;
+
+    UPDATE public.fulfillment_requests
+       SET status = 'finalizing'
+     WHERE request_id = p_request_id;
+
+    RETURN true;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.fulfillment_claim_finalization(
+    uuid,
+    bigint,
+    timestamptz
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.fulfillment_claim_finalization(
+    uuid,
+    bigint,
+    timestamptz
+) TO service_role;
+
+COMMIT;

--- a/tests/test_fulfillment_finalization_sql.py
+++ b/tests/test_fulfillment_finalization_sql.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SQL = ROOT / "scripts" / "117-fulfillment-finalization-fence.sql"
+
+
+def test_score_rpc_and_finalization_use_same_request_row_lock() -> None:
+    text = SQL.read_text(encoding="utf-8")
+
+    assert "CREATE OR REPLACE FUNCTION public.fulfillment_upsert_scores" in text
+    assert "CREATE OR REPLACE FUNCTION public.fulfillment_claim_finalization" in text
+    assert text.count("FOR UPDATE;") == 2
+    assert "FULFILLMENT_SCORE_WINDOW_CLOSED" in text
+    assert "v_request_status NOT IN ('scoring', 'partially_fulfilled')" in text
+    assert "SET status = 'finalizing'" in text
+
+
+def test_request_status_constraint_allows_retryable_finalization() -> None:
+    text = SQL.read_text(encoding="utf-8")
+
+    assert "DROP CONSTRAINT IF EXISTS fulfillment_requests_status_check" in text
+    assert "ADD CONSTRAINT fulfillment_requests_status_check" in text
+    assert "'finalizing'" in text
+
+
+def test_finalization_claim_is_service_role_only() -> None:
+    text = SQL.read_text(encoding="utf-8")
+
+    assert "FROM PUBLIC, anon, authenticated;" in text and "TO service_role;" in text
+
+
+def test_finalization_claim_checks_count_and_latest_score_timestamp() -> None:
+    text = SQL.read_text(encoding="utf-8")
+
+    assert "p_expected_score_count bigint" in text
+    assert "p_expected_latest_scored_at timestamptz" in text
+    assert "SELECT count(*), max(scored_at)" in text
+    assert "v_score_count IS DISTINCT FROM p_expected_score_count" in text
+    assert "v_latest_scored_at IS DISTINCT FROM p_expected_latest_scored_at" in text
+
+
+def test_score_rpc_persists_all_post_rpc_compatibility_fields() -> None:
+    text = SQL.read_text(encoding="utf-8")
+
+    for column in (
+        "failure_detail",
+        "intent_signals_detail",
+        "attribute_verification",
+    ):
+        assert f"EXCLUDED.{column}" in text
+
+    assert "clock_timestamp()" in text
+    assert "COALESCE(" in text

--- a/tests/test_fulfillment_lifecycle_correctness.py
+++ b/tests/test_fulfillment_lifecycle_correctness.py
@@ -1,0 +1,573 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from fastapi import HTTPException
+
+from gateway.fulfillment import api, lifecycle, rewards
+from gateway.fulfillment.score_coverage import (
+    FulfillmentScoreCoverage,
+    summarize_score_coverage,
+)
+
+
+class _MemoryQuery:
+    def __init__(self, client: "_MemorySupabase", table_name: str) -> None:
+        self.client = client
+        self.table_name = table_name
+        self.filters: list[tuple[str, str, object]] = []
+        self.range_bounds: tuple[int, int] | None = None
+        self.limit_count: int | None = None
+        self.order_field: str | None = None
+        self.order_desc = False
+        self.update_payload: dict | None = None
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, field: str, value):
+        self.filters.append(("eq", field, value))
+        return self
+
+    def in_(self, field: str, values):
+        self.filters.append(("in", field, set(values)))
+        return self
+
+    def gte(self, field: str, value):
+        self.filters.append(("gte", field, value))
+        return self
+
+    def or_(self, _expression: str):
+        # Tests use scoring rows, which satisfy the production OR predicate.
+        return self
+
+    def range(self, start: int, end: int):
+        self.range_bounds = (start, end)
+        return self
+
+    def order(self, field: str, desc: bool = False):
+        self.order_field = field
+        self.order_desc = desc
+        return self
+
+    def limit(self, count: int):
+        self.limit_count = count
+        return self
+
+    def update(self, payload: dict):
+        self.update_payload = deepcopy(payload)
+        return self
+
+    def _matches(self, row: dict) -> bool:
+        for operation, field, expected in self.filters:
+            actual = row.get(field)
+            if operation == "eq" and actual != expected:
+                return False
+            if operation == "in" and actual not in expected:
+                return False
+            if operation == "gte" and actual < expected:
+                return False
+        return True
+
+    def execute(self):
+        source = self.client.tables.setdefault(self.table_name, [])
+        matched = [row for row in source if self._matches(row)]
+
+        if self.update_payload is not None:
+            for row in matched:
+                row.update(deepcopy(self.update_payload))
+            return SimpleNamespace(data=deepcopy(matched), count=len(matched))
+
+        if self.order_field:
+            matched.sort(
+                key=lambda row: row.get(self.order_field),
+                reverse=self.order_desc,
+            )
+        if self.range_bounds:
+            start, end = self.range_bounds
+            matched = matched[start : end + 1]
+        if self.limit_count is not None:
+            matched = matched[: self.limit_count]
+        return SimpleNamespace(data=deepcopy(matched), count=len(matched))
+
+
+class _MemorySupabase:
+    def __init__(
+        self,
+        tables: dict[str, list[dict]],
+        *,
+        rpc_results: dict[str, object] | None = None,
+    ) -> None:
+        self.tables = deepcopy(tables)
+        self.rpc_results = rpc_results or {}
+        self.rpc_calls: list[tuple[str, dict]] = []
+
+    def table(self, table_name: str) -> _MemoryQuery:
+        return _MemoryQuery(self, table_name)
+
+    def rpc(self, function_name: str, payload: dict):
+        self.rpc_calls.append((function_name, deepcopy(payload)))
+        result = self.rpc_results.get(function_name)
+        return SimpleNamespace(execute=lambda: SimpleNamespace(data=deepcopy(result)))
+
+
+def _lead(lead_id: str, business: str = "Example") -> dict:
+    return {
+        "lead_id": lead_id,
+        "data": {"business": business},
+    }
+
+
+def _score(
+    submission_id: str,
+    lead_id: str,
+    validator_hotkey: str = "validator-a",
+) -> dict:
+    return {
+        "request_id": "request-1",
+        "submission_id": submission_id,
+        "lead_id": lead_id,
+        "validator_hotkey": validator_hotkey,
+    }
+
+
+def test_score_coverage_requires_every_revealed_lead() -> None:
+    submissions = [
+        {
+            "submission_id": "submission-1",
+            "lead_data": [_lead("lead-1"), _lead("lead-2"), _lead("lead-3")],
+        },
+        {
+            "submission_id": "submission-2",
+            "lead_data": [_lead("lead-4"), _lead("lead-5")],
+        },
+    ]
+    partial = summarize_score_coverage(
+        submissions,
+        [
+            _score("submission-1", "lead-1"),
+            _score("submission-1", "lead-2"),
+            _score("submission-2", "lead-4"),
+        ],
+        required_validators=1,
+    )
+
+    assert partial.expected_leads == 5
+    assert partial.covered_leads == 3
+    assert partial.incomplete_submissions == 2
+    assert partial.missing_score_slots == 2
+    assert not partial.complete
+
+    complete = summarize_score_coverage(
+        submissions,
+        [
+            _score("submission-1", "lead-1"),
+            _score("submission-1", "lead-2"),
+            _score("submission-1", "lead-3"),
+            _score("submission-2", "lead-4"),
+            _score("submission-2", "lead-5"),
+        ],
+        required_validators=1,
+    )
+    assert complete.complete
+
+
+def test_score_coverage_requires_distinct_validator_quorum_per_lead() -> None:
+    submissions = [
+        {
+            "submission_id": "submission-1",
+            "lead_data": [_lead("lead-1")],
+        }
+    ]
+    duplicate_validator_rows = [
+        _score("submission-1", "lead-1", "validator-a"),
+        _score("submission-1", "lead-1", "validator-a"),
+    ]
+
+    one_of_two = summarize_score_coverage(
+        submissions,
+        duplicate_validator_rows,
+        required_validators=2,
+    )
+    assert not one_of_two.complete
+    assert one_of_two.missing_score_slots == 1
+
+    two_of_two = summarize_score_coverage(
+        submissions,
+        [
+            *duplicate_validator_rows,
+            _score("submission-1", "lead-1", "validator-b"),
+        ],
+        required_validators=2,
+    )
+    assert two_of_two.complete
+
+
+def test_score_coverage_records_exact_finalization_watermark() -> None:
+    coverage = summarize_score_coverage(
+        [
+            {
+                "submission_id": "submission-1",
+                "lead_data": [_lead("lead-1")],
+            }
+        ],
+        [
+            {
+                **_score("submission-1", "lead-1"),
+                "scored_at": "2026-07-23T21:40:00+00:00",
+            },
+            {
+                # A stray row still belongs in the database watermark even
+                # though it cannot prove revealed-lead coverage.
+                **_score("unknown-submission", "unknown-lead"),
+                # Use Z notation to ensure timestamp order is chronological,
+                # not a lexical comparison of differently formatted strings.
+                "scored_at": "2026-07-23T21:41:00Z",
+            },
+        ],
+        required_validators=1,
+    )
+
+    assert coverage.complete
+    assert coverage.score_row_count == 2
+    assert coverage.latest_scored_at == "2026-07-23T21:41:00Z"
+
+
+@pytest.mark.parametrize(
+    ("coverage", "timed_out", "expected"),
+    [
+        (
+            FulfillmentScoreCoverage(
+                expected_leads=3,
+                covered_leads=2,
+                incomplete_submissions=1,
+                missing_score_slots=1,
+                malformed_revealed_leads=0,
+                validator_hotkeys=frozenset({"validator-a"}),
+            ),
+            True,
+            "wait_score_coverage",
+        ),
+        (
+            FulfillmentScoreCoverage(
+                expected_leads=3,
+                covered_leads=0,
+                incomplete_submissions=1,
+                missing_score_slots=3,
+                malformed_revealed_leads=0,
+                validator_hotkeys=frozenset(),
+            ),
+            False,
+            "wait_validators",
+        ),
+        (
+            FulfillmentScoreCoverage(
+                expected_leads=3,
+                covered_leads=0,
+                incomplete_submissions=1,
+                missing_score_slots=3,
+                malformed_revealed_leads=0,
+                validator_hotkeys=frozenset(),
+            ),
+            True,
+            "no_validators_timeout",
+        ),
+        (
+            FulfillmentScoreCoverage(
+                expected_leads=3,
+                covered_leads=3,
+                incomplete_submissions=0,
+                missing_score_slots=0,
+                malformed_revealed_leads=0,
+                validator_hotkeys=frozenset({"validator-a"}),
+            ),
+            False,
+            "ready",
+        ),
+    ],
+)
+def test_consensus_readiness_never_forces_partial_coverage(
+    coverage: FulfillmentScoreCoverage,
+    timed_out: bool,
+    expected: str,
+) -> None:
+    assert (
+        lifecycle._consensus_readiness(
+            coverage,
+            timed_out=timed_out,
+        )
+        == expected
+    )
+
+
+def test_scoring_feed_reoffers_only_missing_leads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _MemorySupabase(
+        {
+            "fulfillment_requests": [
+                {
+                    "request_id": "request-1",
+                    "status": "scoring",
+                    "reveal_window_end": "2099-01-01T00:00:00+00:00",
+                    "icp_details": {"num_leads": 4},
+                    "required_attributes": None,
+                }
+            ],
+            "fulfillment_submissions": [
+                {
+                    "request_id": "request-1",
+                    "submission_id": "submission-1",
+                    "miner_hotkey": "miner-1",
+                    "revealed": True,
+                    "lead_data": [
+                        _lead("lead-1"),
+                        _lead("lead-2"),
+                        _lead("lead-3"),
+                    ],
+                },
+                {
+                    "request_id": "request-1",
+                    "submission_id": "submission-2",
+                    "miner_hotkey": "miner-2",
+                    "revealed": True,
+                    "lead_data": [_lead("lead-4")],
+                },
+            ],
+            "fulfillment_scores": [
+                _score("submission-1", "lead-1"),
+                _score("submission-1", "lead-2"),
+                _score("submission-2", "lead-4"),
+            ],
+        }
+    )
+    monkeypatch.setattr(api, "_get_supabase", lambda: supabase)
+
+    payload = api._collect_scoring_requests_sync("validator-a")
+
+    assert len(payload["requests"]) == 1
+    submissions = payload["requests"][0]["submissions"]
+    assert submissions == [
+        {
+            "submission_id": "submission-1",
+            "miner_hotkey": "miner-1",
+            "leads": [{"business": "Example"}],
+            "lead_ids": ["lead-3"],
+        }
+    ]
+
+    other_validator_payload = api._collect_scoring_requests_sync("validator-b")
+    other_submissions = other_validator_payload["requests"][0]["submissions"]
+    assert [row["lead_ids"] for row in other_submissions] == [
+        ["lead-1", "lead-2", "lead-3"],
+        ["lead-4"],
+    ]
+
+
+def test_load_score_coverage_paginates_past_postgrest_default_limit() -> None:
+    leads = [_lead(f"lead-{index}") for index in range(1001)]
+    scores = [_score("submission-1", f"lead-{index}") for index in range(1001)]
+    supabase = _MemorySupabase(
+        {
+            "fulfillment_submissions": [
+                {
+                    "request_id": "request-1",
+                    "submission_id": "submission-1",
+                    "revealed": True,
+                    "lead_data": leads,
+                }
+            ],
+            "fulfillment_scores": scores,
+        }
+    )
+
+    coverage = lifecycle._load_score_coverage(supabase, "request-1")
+
+    assert coverage.expected_leads == 1001
+    assert coverage.covered_leads == 1001
+    assert coverage.complete
+
+
+def test_claim_finalization_passes_exact_score_watermark() -> None:
+    supabase = _MemorySupabase(
+        {},
+        rpc_results={"fulfillment_claim_finalization": True},
+    )
+    coverage = FulfillmentScoreCoverage(
+        expected_leads=2,
+        covered_leads=2,
+        incomplete_submissions=0,
+        missing_score_slots=0,
+        malformed_revealed_leads=0,
+        validator_hotkeys=frozenset({"validator-a"}),
+        score_row_count=2,
+        latest_scored_at="2026-07-23T21:40:00+00:00",
+    )
+
+    assert lifecycle._claim_finalization(supabase, "request-1", coverage)
+    assert supabase.rpc_calls == [
+        (
+            "fulfillment_claim_finalization",
+            {
+                "p_request_id": "request-1",
+                "p_expected_score_count": 2,
+                "p_expected_latest_scored_at": "2026-07-23T21:40:00+00:00",
+            },
+        )
+    ]
+
+
+def test_terminal_request_rejects_late_score_submission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _MemorySupabase(
+        {
+            "fulfillment_requests": [
+                {
+                    "request_id": "request-1",
+                    "status": "fulfilled",
+                }
+            ]
+        }
+    )
+    monkeypatch.setattr(api, "_get_supabase", lambda: supabase)
+
+    with pytest.raises(HTTPException) as exc_info:
+        api._submit_scores_impl(
+            "request-1",
+            "validator-a",
+            [_score("submission-1", "lead-1")],
+        )
+
+    assert exc_info.value.status_code == 409
+    assert not supabase.rpc_calls
+
+
+def test_score_submission_rejects_cross_request_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _MemorySupabase({})
+    monkeypatch.setattr(api, "_get_supabase", lambda: supabase)
+
+    with pytest.raises(HTTPException) as exc_info:
+        api._submit_scores_impl(
+            "request-1",
+            "validator-a",
+            [
+                {
+                    **_score("submission-1", "lead-1"),
+                    "request_id": "request-2",
+                }
+            ],
+        )
+
+    assert exc_info.value.status_code == 422
+    assert not supabase.rpc_calls
+
+
+def test_reward_write_failure_prevents_false_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supabase = _MemorySupabase(
+        {
+            # No matching row: the update returns an empty representation.
+            "fulfillment_score_consensus": [],
+        }
+    )
+    monkeypatch.setattr(rewards, "_get_supabase", lambda: supabase)
+
+    with pytest.raises(RuntimeError, match="FULFILLMENT_REWARD_WRITE_INCOMPLETE"):
+        rewards.calculate_lead_rewards(
+            "request-1",
+            [
+                {
+                    "request_id": "request-1",
+                    "submission_id": "submission-1",
+                    "lead_id": "lead-1",
+                    "tie_count": 1,
+                }
+            ],
+            0.5,
+            100,
+            10,
+        )
+
+
+def test_active_successor_quota_and_icp_are_reconciled_together() -> None:
+    supabase = _MemorySupabase(
+        {
+            "fulfillment_requests": [
+                {
+                    "request_id": "successor-1",
+                    "status": "continued_open",
+                    "num_leads": 28,
+                    "icp_details": {
+                        "num_leads": 28,
+                        "excluded_companies": ["Original exclusion"],
+                    },
+                }
+            ],
+        }
+    )
+
+    changed = lifecycle._reconcile_active_successor(
+        supabase,
+        "successor-1",
+        remaining_leads=18,
+        held_companies=["New held company", "Original exclusion"],
+    )
+
+    assert changed
+    row = supabase.tables["fulfillment_requests"][0]
+    assert row["num_leads"] == 18
+    assert row["icp_details"]["num_leads"] == 18
+    assert row["icp_details"]["excluded_companies"] == [
+        "Original exclusion",
+        "New held company",
+    ]
+
+
+def test_scoring_successor_is_not_mutated_mid_cycle() -> None:
+    original = {
+        "request_id": "successor-1",
+        "status": "scoring",
+        "num_leads": 28,
+        "icp_details": {"num_leads": 28},
+    }
+    supabase = _MemorySupabase(
+        {
+            "fulfillment_requests": [original],
+        }
+    )
+
+    changed = lifecycle._reconcile_active_successor(
+        supabase,
+        "successor-1",
+        remaining_leads=18,
+        held_companies=["New held company"],
+    )
+
+    assert not changed
+    assert supabase.tables["fulfillment_requests"][0] == original
+
+
+def test_initial_successor_payload_updates_nested_num_leads() -> None:
+    payload = lifecycle._successor_quota_payload(
+        {
+            "num_leads": 30,
+            "excluded_companies": ["Existing"],
+        },
+        remaining_leads=18,
+        held_companies=["Held"],
+    )
+
+    assert payload == {
+        "num_leads": 18,
+        "icp_details": {
+            "num_leads": 18,
+            "excluded_companies": ["Existing", "Held"],
+        },
+    }


### PR DESCRIPTION
## Summary

Fixes the three fulfillment correctness gaps observed in production:

- require configured validator quorum for every revealed lead before consensus/finalization (not merely one score row per submission)
- re-offer only the exact missing leads after interrupted validator scoring
- synchronize continuation row quota and nested miner-visible `icp_details.num_leads`
- fence score writes against finalization with a shared PostgreSQL request-row lock and exact `(score_count, latest_scored_at)` watermark
- make fulfilled results immutable by rejecting late score writes, while using a retryable `finalizing` state for reward completion
- fail closed when a winner reward update does not match a consensus row

## Production evidence

Read-only Supabase checks on July 23 found current scoring coverage at 182/224, 43/315, and 8/133 revealed leads. The old timeout branch could finalize these partial sets. The Dropbox chain showed row quota 28, nested ICP quota 30, and authoritative remaining quota 18. A fulfilled request had 932 score rows but only 88 original consensus rows, with 63 scores arriving after consensus.

This PR prevents recurrence. It intentionally does not rewrite historical fulfilled rewards or mutate a continuation that is already in `scoring`; those require an operator-reviewed repair/backfill rather than an automatic deploy-time data rewrite.

## Database migration

Apply `scripts/117-fulfillment-finalization-fence.sql` before deploying/restarting the gateway. It:

- extends the existing request status constraint with `finalizing`
- updates `fulfillment_upsert_scores` to lock the request, reject closed windows atomically, validate a single request id, and persist score-detail columns in the same transaction
- adds a service-role-only `fulfillment_claim_finalization` RPC that wins or loses deterministically against concurrent score writers

## Verification

- 58 focused fulfillment, migration, runtime-recovery, qualification, and reward/weight tests passed
- clean pinned environment uses Bittensor 10.5.0
- `gateway.main` and changed modules import successfully under the supported gateway package parent
- formatting, `git diff --check`, and package compilation passed
- migration executed against isolated PostgreSQL with the production status constraint shape; stale watermark rejected, current watermark accepted, detail JSON persisted, `finalizing` allowed, and anon RPC execution denied
- both database lock-order races exercised: scorer-first rejects stale finalization; finalizer-first makes the late scorer wait and then reject
- broad suite reached 1,288 passed before interruption; its three failures were environment-only (sandbox loopback binds and local `NETUID=48`) and all three passed when rerun with loopback permission and `NETUID=71`

## Deployment note

No production write, deploy, rsync, restart, or historical backfill is performed by this PR.
