### PR TITLE
Corrective fixes for the PR-28 verifier integration audit

### DIFF
--- a/gateway/qualification/models.py
+++ b/gateway/qualification/models.py
@@ -801,6 +801,15 @@ class LeadScoreBreakdown(BaseModel):
         default=None,
         description="Per-signal scoring detail (autoresearch benchmark); None for lead-mode",
     )
+    # Durable verifier-gate receipts (PR-28 audit): audit documents from the
+    # deterministic/semantic industry gate — modes, deterministic detail,
+    # semantic model/input-hash/source-hashes/judgment, and the final scoring
+    # effect. Optional and None by default so legacy callers and persisted
+    # breakdown readers are unaffected.
+    verifier_gate_receipts: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description="Durable industry-gate audit receipts (taxonomy/semantic); None when gates disabled",
+    )
 
     @model_validator(mode='after')
     def validate_score_consistency(self) -> 'LeadScoreBreakdown':

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -612,7 +612,7 @@
       "symbol": "rpc_method_allowed"
     },
     {
-      "ast_sha256": "sha256:a88aaa014d07c114351c9eb4a92a3fd546c290a09ee03f6df1c36b6c70093534",
+      "ast_sha256": "sha256:e2be987b9c8bab274330bd873a5dc1c008d8e09dc7e5c16fec718b6ffc01f252",
       "path": "gateway/tee/scoring_executor_v2.py",
       "symbol": "ScoringExecutorV2"
     },
@@ -1107,7 +1107,7 @@
       "symbol": "validate_source_add_reward_record"
     }
   ],
-  "manifest_hash": "sha256:f4f022b23a3c406d3d59d140681d2043b76ce0154ede436b237429524894dbc3",
-  "protected_source_commit": "4e7fc7aa40ef6f3f6dee3b269c932410981e18c5",
+  "manifest_hash": "sha256:cafd49bc6a0793e729730eb3dd44c06de33e2916614ce35accd55a6b97b372c7",
+  "protected_source_commit": "b934d62b9e4a84bc4081cc1f42dae2a17bcee43b",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -612,7 +612,7 @@
       "symbol": "rpc_method_allowed"
     },
     {
-      "ast_sha256": "sha256:a88aaa014d07c114351c9eb4a92a3fd546c290a09ee03f6df1c36b6c70093534",
+      "ast_sha256": "sha256:e2be987b9c8bab274330bd873a5dc1c008d8e09dc7e5c16fec718b6ffc01f252",
       "path": "gateway/tee/scoring_executor_v2.py",
       "symbol": "ScoringExecutorV2"
     },
@@ -1107,7 +1107,7 @@
       "symbol": "validate_source_add_reward_record"
     }
   ],
-  "manifest_hash": "sha256:c5acd5461998b9d04309e3ba4030f566630df200675d987fd029bed547d77055",
-  "protected_source_commit": "cba7c648296539c2dfab38b06bafc23f555a18e5",
+  "manifest_hash": "sha256:ff7a51412c65c66cd40ecac134eb21621303f34b290fa787a5b9d6645edf05b8",
+  "protected_source_commit": "c0dd9a72fe11a487c1383acf6386f2002cba4aa1",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1107,7 +1107,7 @@
       "symbol": "validate_source_add_reward_record"
     }
   ],
-  "manifest_hash": "sha256:ff7a51412c65c66cd40ecac134eb21621303f34b290fa787a5b9d6645edf05b8",
-  "protected_source_commit": "c0dd9a72fe11a487c1383acf6386f2002cba4aa1",
+  "manifest_hash": "sha256:ae10b44570c7f37e9f5772932b2a6940c0c6e5da3464c3aab114def74404237a",
+  "protected_source_commit": "a8ab628e1e478ee3387cdf785589b795dc7f5107",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -612,7 +612,7 @@
       "symbol": "rpc_method_allowed"
     },
     {
-      "ast_sha256": "sha256:a88aaa014d07c114351c9eb4a92a3fd546c290a09ee03f6df1c36b6c70093534",
+      "ast_sha256": "sha256:e2be987b9c8bab274330bd873a5dc1c008d8e09dc7e5c16fec718b6ffc01f252",
       "path": "gateway/tee/scoring_executor_v2.py",
       "symbol": "ScoringExecutorV2"
     },
@@ -1107,7 +1107,7 @@
       "symbol": "validate_source_add_reward_record"
     }
   ],
-  "manifest_hash": "sha256:dd25db703980a63fe558933b81c964e51e5e87b90628074467554c59684f1c19",
-  "protected_source_commit": "f34b252927526d43c91ca8e8d418d431bf5e24c0",
+  "manifest_hash": "sha256:1004e6df913cc8288cce992aada3bd2a2e3108d92ee8b92ee1b18d5205c4a9d1",
+  "protected_source_commit": "0c25d28b540c87d86ab15eec9ec58309799ebdb2",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/scoring_executor_v2.py
+++ b/gateway/tee/scoring_executor_v2.py
@@ -170,15 +170,24 @@ class ScoringExecutorV2:
             )
         )
         self._transport.install()
-        self._qualification_executor = qualification_executor or QualificationExecutorV2(
-            epoch_checker=QualificationEpochGuardV2(
-                self._transport,
-                epoch_authority=self._execution_config["epoch_authority"],
-                netuid=self._execution_config["deployment"]["netuid"],
+        try:
+            self._qualification_executor = (
+                qualification_executor or QualificationExecutorV2(
+                    epoch_checker=QualificationEpochGuardV2(
+                        self._transport,
+                        epoch_authority=self._execution_config["epoch_authority"],
+                        netuid=self._execution_config["deployment"]["netuid"],
+                    )
+                )
             )
-        )
-        self._qualification_network = SecureQualificationNetworkV2()
-        self._qualification_network.install()
+            self._qualification_network = SecureQualificationNetworkV2()
+            self._qualification_network.install()
+        except BaseException:
+            # A failed construction must never leak the process-wide transport
+            # interception (httpx/requests/urllib send hooks): every later HTTP
+            # call in the process would be silently swallowed or rejected.
+            self._transport.restore()
+            raise
         self._preflight_lock = threading.Lock()
         self._preflight_by_scope: Dict[str, ProviderPreflight] = {}
         os.environ["EXA_API_KEY"] = "leadpoet-v2-brokered-credential"

--- a/leadpoet_verifier/contracts.py
+++ b/leadpoet_verifier/contracts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -32,7 +32,7 @@ class SignalDecision(BaseModel):
     input_index: int = Field(ge=0, le=4)
     accepted: bool
     verifier_score: float = Field(ge=0, le=100)
-    failure_reason: Optional[str] = Field(default=None, max_length=500)
+    failure_reason: str | None = Field(default=None, max_length=500)
     detail: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -43,7 +43,7 @@ class VerificationDecision(BaseModel):
     reason_code: str = Field(min_length=1, max_length=120)
     reason_message: str = Field(max_length=2_000)
     verifier_score: float = Field(ge=0, le=100)
-    verified_payload: Optional[dict[str, Any]] = None
+    verified_payload: dict[str, Any] | None = None
     signal_decisions: list[SignalDecision] = Field(default_factory=list, max_length=5)
     metadata: dict[str, Any] = Field(default_factory=dict)
 

--- a/leadpoet_verifier/deepline_repair.py
+++ b/leadpoet_verifier/deepline_repair.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import quote
 
 import httpx
@@ -22,8 +22,8 @@ class DeeplineEvidenceRepairUnavailable(RuntimeError):
         self,
         code: str,
         *,
-        status_code: Optional[int] = None,
-        endpoint: Optional[str] = None,
+        status_code: int | None = None,
+        endpoint: str | None = None,
         retryable: bool = False,
     ) -> None:
         super().__init__(code)
@@ -42,12 +42,12 @@ class DeeplineEvidenceRepairUnavailable(RuntimeError):
 
 
 Transport = Callable[
-    [str, str, Optional[dict[str, Any]]],
+    [str, str, dict[str, Any] | None],
     Awaitable[dict[str, Any]],
 ]
 
 
-def _first_text(value: Any, keys: tuple[str, ...]) -> Optional[str]:
+def _first_text(value: Any, keys: tuple[str, ...]) -> str | None:
     if not isinstance(value, dict):
         return None
     for key in keys:
@@ -57,7 +57,7 @@ def _first_text(value: Any, keys: tuple[str, ...]) -> Optional[str]:
     return None
 
 
-def _run_id(value: dict[str, Any]) -> Optional[str]:
+def _run_id(value: dict[str, Any]) -> str | None:
     return _first_text(value, ("workflowId", "workflow_id", "runId", "run_id", "id"))
 
 
@@ -94,7 +94,7 @@ class DeeplineEvidenceRepairClient:
         host_url: str = "https://code.deepline.com",
         timeout_seconds: float = 90,
         poll_seconds: float = 2,
-        transport: Optional[Transport] = None,
+        transport: Transport | None = None,
     ) -> None:
         self._api_key = api_key.strip()
         self._host_url = host_url.rstrip("/")
@@ -103,7 +103,7 @@ class DeeplineEvidenceRepairClient:
         self._transport = transport or self._request
 
     @classmethod
-    def from_env(cls) -> Optional["DeeplineEvidenceRepairClient"]:
+    def from_env(cls) -> "DeeplineEvidenceRepairClient | None":
         enabled = os.getenv(
             "VERIFIER_DEEPLINE_EVIDENCE_REPAIR_ENABLED", "false"
         ).strip().casefold() in {"1", "true", "yes", "on"}
@@ -129,7 +129,7 @@ class DeeplineEvidenceRepairClient:
         self,
         method: str,
         url: str,
-        body: Optional[dict[str, Any]],
+        body: dict[str, Any] | None,
     ) -> dict[str, Any]:
         headers = {
             "Authorization": f"Bearer {self._api_key}",
@@ -154,7 +154,7 @@ class DeeplineEvidenceRepairClient:
         self,
         method: str,
         url: str,
-        body: Optional[dict[str, Any]],
+        body: dict[str, Any] | None,
         *,
         endpoint: str,
     ) -> dict[str, Any]:
@@ -205,7 +205,7 @@ class DeeplineEvidenceRepairClient:
         company_domain: str,
         requested_criterion: str,
         evidence_kind: str,
-        existing_url: Optional[str],
+        existing_url: str | None,
     ) -> list[dict[str, Any]]:
         if evidence_kind not in {"industry", "required_attribute", "intent"}:
             raise ValueError("unsupported evidence repair kind")

--- a/leadpoet_verifier/exa_repair.py
+++ b/leadpoet_verifier/exa_repair.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import ipaddress
+import os
+import re
+from collections.abc import Awaitable, Callable
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+
+EXA_SEARCH_URL = "https://api.exa.ai/search"
+MAX_RESULTS = 6
+MAX_QUERY_CHARS = 2_000
+POLICY_VERSION = "direct-exa-evidence-repair-v1"
+_PROVIDER_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,199}$")
+
+
+def _provider_token(value: Any, *, limit: int = 200) -> str | None:
+    token = str(value or "").strip()[:limit]
+    return token if token and _PROVIDER_TOKEN_RE.fullmatch(token) else None
+
+
+class ExaEvidenceRepairUnavailable(RuntimeError):
+    """A bounded, sanitized Exa failure safe to persist in receipts."""
+
+    def __init__(
+        self,
+        code: str,
+        *,
+        status_code: int | None = None,
+        endpoint: str = "exa_search",
+        retryable: bool = False,
+        request_id: str | None = None,
+    ) -> None:
+        super().__init__(code)
+        self.code = _provider_token(code, limit=120) or "exa_provider_error"
+        self.status_code = status_code
+        self.endpoint = endpoint
+        self.retryable = retryable
+        self.request_id = _provider_token(request_id)
+
+
+Transport = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
+
+
+def _public_result_url(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.startswith(("https://", "http://")):
+        return None
+    if len(value) > 2_000:
+        return None
+    try:
+        parsed = urlparse(value)
+    except ValueError:
+        return None
+    host = (parsed.hostname or "").casefold()
+    if (
+        not host
+        or "." not in host
+        or parsed.username is not None
+        or parsed.password is not None
+        or host in {"localhost", "127.0.0.1", "::1"}
+        or host.endswith((".local", ".internal"))
+    ):
+        return None
+    try:
+        if not ipaddress.ip_address(host).is_global:
+            return None
+    except ValueError:
+        pass
+    return value
+
+
+def _bounded_cost_usd(payload: dict[str, Any]) -> float | None:
+    raw = payload.get("costDollars")
+    if isinstance(raw, dict):
+        raw = raw.get("total")
+    if (
+        isinstance(raw, (int, float))
+        and not isinstance(raw, bool)
+        and 0 <= float(raw) <= 100
+    ):
+        return round(float(raw), 6)
+    return None
+
+
+class ExaEvidenceRepairClient:
+    """One direct, bounded Exa discovery call; returned URLs remain untrusted."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        timeout_seconds: float = 30,
+        transport: Transport | None = None,
+    ) -> None:
+        self._api_key = api_key.strip()
+        self._timeout_seconds = max(5.0, min(float(timeout_seconds), 60.0))
+        self._transport = transport or self._request
+
+    @classmethod
+    def from_env(cls) -> "ExaEvidenceRepairClient | None":
+        # The legacy flag is an intentional migration alias: existing
+        # production configuration switches to direct Exa without retaining a
+        # verifier -> Deepline -> Exa dependency.
+        raw_enabled = os.getenv(
+            "VERIFIER_EXA_EVIDENCE_REPAIR_ENABLED",
+            os.getenv("VERIFIER_DEEPLINE_EVIDENCE_REPAIR_ENABLED", "false"),
+        )
+        enabled = raw_enabled.strip().casefold() in {"1", "true", "yes", "on"}
+        if not enabled:
+            return None
+        api_key = os.getenv("EXA_API_KEY", "").strip()
+        if not api_key:
+            raise RuntimeError(
+                "VERIFIER_EXA_EVIDENCE_REPAIR_ENABLED requires EXA_API_KEY"
+            )
+        timeout = os.getenv(
+            "VERIFIER_EXA_EVIDENCE_REPAIR_TIMEOUT_SECONDS",
+            os.getenv("VERIFIER_DEEPLINE_EVIDENCE_REPAIR_TIMEOUT_SECONDS", "30"),
+        )
+        return cls(api_key=api_key, timeout_seconds=float(timeout))
+
+    async def _request(self, payload: dict[str, Any]) -> dict[str, Any]:
+        headers = {
+            "x-api-key": self._api_key,
+            "Content-Type": "application/json",
+        }
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(self._timeout_seconds),
+                follow_redirects=False,
+            ) as client:
+                response = await client.post(
+                    EXA_SEARCH_URL,
+                    headers=headers,
+                    json=payload,
+                )
+        except (httpx.TimeoutException, httpx.NetworkError) as exc:
+            raise ExaEvidenceRepairUnavailable(
+                "exa_transport_error",
+                retryable=True,
+            ) from exc
+        request_id = (
+            response.headers.get("x-request-id")
+            or response.headers.get("x-correlation-id")
+        )
+        if response.status_code != 200:
+            raise ExaEvidenceRepairUnavailable(
+                f"exa_http_{response.status_code}",
+                status_code=response.status_code,
+                retryable=(
+                    response.status_code in {408, 425, 429}
+                    or response.status_code >= 500
+                ),
+                request_id=request_id,
+            )
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise ExaEvidenceRepairUnavailable(
+                "invalid_exa_response",
+                request_id=request_id,
+            ) from exc
+        if not isinstance(data, dict):
+            raise ExaEvidenceRepairUnavailable(
+                "invalid_exa_response",
+                request_id=request_id,
+            )
+        data["_leadpoet_request_id"] = _provider_token(request_id)
+        return data
+
+    async def repair(
+        self,
+        *,
+        company_name: str,
+        company_domain: str,
+        requested_criterion: str,
+        evidence_kind: str,
+        existing_url: str | None,
+    ) -> list[dict[str, Any]]:
+        del existing_url
+        if evidence_kind not in {"industry", "required_attribute", "intent"}:
+            raise ValueError("unsupported evidence repair kind")
+        name = " ".join(str(company_name or "").split())[:200]
+        company_url = _public_result_url(f"https://{company_domain}")
+        domain = (
+            (urlparse(company_url).hostname or "").casefold()
+            if company_url
+            else ""
+        )
+        criterion = " ".join(str(requested_criterion or "").split())[:1_500]
+        if not name or not domain or "." not in domain or not criterion:
+            raise ValueError(
+                "company_name, public company_domain, and requested_criterion are required"
+            )
+        query = f'"{name}" {domain} {criterion}'[:MAX_QUERY_CHARS]
+        payload = {
+            "query": query,
+            "type": "auto",
+            "numResults": MAX_RESULTS,
+            "moderation": True,
+        }
+        result = await self._transport(payload)
+        if not isinstance(result, dict):
+            raise ExaEvidenceRepairUnavailable("invalid_exa_response")
+        request_id = _provider_token(result.get("_leadpoet_request_id"))
+        cost_usd = _bounded_cost_usd(result)
+        rows = result.get("results")
+        if not isinstance(rows, list):
+            return []
+        result_count = min(len(rows), MAX_RESULTS)
+        seen: set[str] = set()
+        sources: list[dict[str, Any]] = []
+        for raw in rows[:MAX_RESULTS]:
+            url = _public_result_url(raw.get("url") if isinstance(raw, dict) else None)
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            sources.append({
+                "url": url,
+                "provider": "exa",
+                "policy_version": POLICY_VERSION,
+                "provider_request_id": request_id,
+                "provider_cost_usd": cost_usd,
+                "result_count": result_count,
+            })
+        return sources or [{
+            "url": None,
+            "provider": "exa",
+            "policy_version": POLICY_VERSION,
+            "provider_request_id": request_id,
+            "provider_cost_usd": cost_usd,
+            "result_count": result_count,
+        }]

--- a/leadpoet_verifier/identity/__init__.py
+++ b/leadpoet_verifier/identity/__init__.py
@@ -1,4 +1,16 @@
-"""Private, versioned company-identity resolution contracts."""
+"""Private, versioned company-identity resolution contracts.
+
+DEFERRED PRIMITIVES (explicit, per the PR-28 audit): this package ports the
+site verifier's identity-resolution building blocks — PSL-pinned host
+normalization, float-forbidding canonical hashing, the SSRF-hardened fetcher,
+the closed-allowlist resolution policy, observation parsing, and evidence
+binding — with their full test suites, but NO lab runtime calls them yet.
+The site runs identity resolution as its own queue worker with a Postgres
+run-store; the lab equivalent (wiring resolve_identity into
+qualification/scoring/company_verification.py behind a mode flag, with its
+own durable receipts) is a follow-up integration, not part of this port.
+Until then these are library primitives: importable, tested, unwired.
+"""
 
 from .models import (
     AnchorSet,

--- a/leadpoet_verifier/semantic_gates.py
+++ b/leadpoet_verifier/semantic_gates.py
@@ -9,7 +9,7 @@ import os
 import re
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 import httpx
@@ -86,12 +86,7 @@ _SHORT_HOST_SUFFIXES = {
 class SemanticGateUnavailable(RuntimeError):
     """The semantic provider path could not reach a trustworthy decision."""
 
-    def __init__(
-        self,
-        code: str,
-        *,
-        receipt: Optional[dict[str, Any]] = None,
-    ) -> None:
+    def __init__(self, code: str, *, receipt: dict[str, Any] | None = None) -> None:
         super().__init__(code)
         self.code = code
         self.receipt = receipt or {}
@@ -190,15 +185,16 @@ class SemanticGateResult(BaseModel):
 
     outcome: GateOutcome
     reason_code: str = Field(min_length=1, max_length=120)
-    judgment: Optional[SemanticJudgment] = None
-    model: Optional[str] = Field(default=None, max_length=160)
+    judgment: SemanticJudgment | None = None
+    model: str | None = Field(default=None, max_length=160)
     input_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
     duration_ms: int = Field(ge=0)
     policy_version: str = POLICY_VERSION
     sources: list[dict[str, Any]] = Field(default_factory=list, max_length=3)
-    prompt_tokens: Optional[int] = Field(default=None, ge=0)
-    completion_tokens: Optional[int] = Field(default=None, ge=0)
-    submitted_quote_found: Optional[bool] = None
+    prompt_tokens: int | None = Field(default=None, ge=0)
+    completion_tokens: int | None = Field(default=None, ge=0)
+    submitted_quote_found: bool | None = None
+    repair_attempts: list[dict[str, Any]] = Field(default_factory=list, max_length=8)
 
     def receipt(self) -> dict[str, Any]:
         payload = self.model_dump(mode="json", exclude_none=True)
@@ -214,14 +210,46 @@ class SemanticGateResult(BaseModel):
 Fetcher = Callable[[str], Awaitable[RawFetchResult]]
 Judge = Callable[
     [GateKind, dict[str, Any], list[EvidenceSource]],
-    Awaitable[
-        tuple[SemanticJudgment, str, Optional[int], Optional[int]]
-    ],
+    Awaitable[tuple[SemanticJudgment, str, int | None, int | None]],
 ]
 Repairer = Callable[..., Awaitable[list[dict[str, Any]]]]
 
 
-def semantic_gate_mode(value: Optional[str] = None) -> SemanticGateMode:
+def _repair_receipts(attempts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Persist only bounded operational metadata from the repair path."""
+
+    allowed = {
+        "url",
+        "stage",
+        "reason_code",
+        "status_code",
+        "endpoint",
+        "retryable",
+        "provider",
+        "provider_request_id",
+        "provider_cost_usd",
+        "result_count",
+    }
+    receipts: list[dict[str, Any]] = []
+    for attempt in attempts:
+        if not str(attempt.get("stage") or "").startswith(("repair_", "exa_")):
+            continue
+        receipt: dict[str, Any] = {}
+        for key in allowed:
+            value = attempt.get(key)
+            if isinstance(value, str):
+                receipt[key] = value[:2_000] if key == "url" else value[:200]
+            elif isinstance(value, bool) or value is None:
+                receipt[key] = value
+            elif isinstance(value, (int, float)):
+                receipt[key] = value
+        receipts.append(receipt)
+        if len(receipts) >= 8:
+            break
+    return receipts
+
+
+def semantic_gate_mode(value: str | None = None) -> SemanticGateMode:
     raw = (value if value is not None else os.getenv("VERIFIER_SEMANTIC_GATES_MODE", "disabled"))
     normalized = raw.strip().lower()
     if normalized not in {"disabled", "shadow", "enforce"}:
@@ -231,7 +259,7 @@ def semantic_gate_mode(value: Optional[str] = None) -> SemanticGateMode:
     return normalized  # type: ignore[return-value]
 
 
-def _hostname(value: Optional[str]) -> str:
+def _hostname(value: str | None) -> str:
     raw = str(value or "").strip()
     if raw and "://" not in raw:
         raw = f"https://{raw}"
@@ -348,9 +376,7 @@ def _safe_text(value: Any, limit: int) -> str:
     return sanitize_miner_text(str(value or ""))[:limit]
 
 
-def _judgment_unavailable_reason(
-    judgment: SemanticJudgment,
-) -> Optional[str]:
+def _judgment_unavailable_reason(judgment: SemanticJudgment) -> str | None:
     if judgment.decision == "uncertain":
         return "semantic_uncertain"
     if judgment.decision == "match" and judgment.confidence < MIN_ACCEPT_CONFIDENCE:
@@ -434,9 +460,9 @@ class SemanticGateEvaluator:
         *,
         api_key: str,
         models: tuple[str, ...] = DEFAULT_MODELS,
-        fetcher: Optional[Fetcher] = None,
-        judge: Optional[Judge] = None,
-        repairer: Optional[Repairer] = None,
+        fetcher: Fetcher | None = None,
+        judge: Judge | None = None,
+        repairer: Repairer | None = None,
         timeout_seconds: float = 45,
     ) -> None:
         self._api_key = api_key.strip()
@@ -457,9 +483,9 @@ class SemanticGateEvaluator:
         ) or DEFAULT_MODELS
         repairer = None
         if enable_repair:
-            from .deepline_repair import DeeplineEvidenceRepairClient
+            from .exa_repair import ExaEvidenceRepairClient
 
-            repair_client = DeeplineEvidenceRepairClient.from_env()
+            repair_client = ExaEvidenceRepairClient.from_env()
             if repair_client is not None:
                 repairer = repair_client.repair
         return cls(
@@ -508,7 +534,7 @@ class SemanticGateEvaluator:
         company_domain: str,
         requested_criterion: str,
         kind: GateKind,
-        existing_url: Optional[str],
+        existing_url: str | None,
     ) -> str:
         payload = json.dumps({
             "company_name": _safe_text(company_name, 200).casefold(),
@@ -526,7 +552,7 @@ class SemanticGateEvaluator:
         company_domain: str,
         requested_criterion: str,
         kind: GateKind,
-        existing_url: Optional[str],
+        existing_url: str | None,
         sources: list[EvidenceSource],
         attempts: list[dict[str, Any]],
         seen: set[str],
@@ -536,7 +562,7 @@ class SemanticGateEvaluator:
         Repair output is never trusted directly: every returned URL traverses
         the same URL, fetch, injection, entity, and content checks as the
         original evidence. A bounded failure fingerprint prevents candidate
-        retries from calling the same broken Deepline path repeatedly.
+        retries from repeating the same direct Exa search.
         """
 
         if self._repairer is None or len(sources) >= 3:
@@ -552,7 +578,7 @@ class SemanticGateEvaluator:
         if cached_failure is not None:
             attempts.append({
                 "url": None,
-                "stage": "deepline_repair_suppressed",
+                "stage": "exa_repair_suppressed",
                 **cached_failure,
             })
             return
@@ -567,15 +593,18 @@ class SemanticGateEvaluator:
         except Exception as exc:
             failure = {
                 "reason_code": str(
-                    getattr(exc, "code", "deepline_repair_failed")
+                    getattr(exc, "code", "exa_repair_failed")
                 )[:120],
                 "status_code": getattr(exc, "status_code", None),
                 "endpoint": str(getattr(exc, "endpoint", "") or "")[:80] or None,
                 "retryable": bool(getattr(exc, "retryable", False)),
+                "provider_request_id": (
+                    str(getattr(exc, "request_id", "") or "")[:200] or None
+                ),
             }
-            # The transport already received its bounded in-attempt retry.
-            # Cache deterministic failures across candidate retries, but let a
-            # later queue attempt recover from a transient provider outage.
+            # Do not retry a charged POST inside this candidate attempt. Cache
+            # deterministic failures across queue retries, but let a later
+            # attempt recover from a transient provider outage.
             if not failure["retryable"]:
                 self._repair_failure_cache[cache_key] = failure
             LOGGER.warning(
@@ -589,11 +618,33 @@ class SemanticGateEvaluator:
             )
             attempts.append({
                 "url": None,
-                "stage": "deepline_repair_failed",
+                "stage": "exa_repair_failed",
                 **failure,
             })
             return
 
+        if repaired:
+            first = repaired[0] if isinstance(repaired[0], dict) else {}
+            attempts.append({
+                "url": None,
+                "stage": "exa_repair_search",
+                "provider": str(first.get("provider") or "exa")[:40],
+                "provider_request_id": (
+                    str(first.get("provider_request_id") or "")[:200] or None
+                ),
+                "provider_cost_usd": (
+                    first.get("provider_cost_usd")
+                    if isinstance(first.get("provider_cost_usd"), (int, float))
+                    and not isinstance(first.get("provider_cost_usd"), bool)
+                    else None
+                ),
+                "result_count": (
+                    max(0, min(int(first.get("result_count")), 6))
+                    if isinstance(first.get("result_count"), int)
+                    and not isinstance(first.get("result_count"), bool)
+                    else min(len(repaired), 6)
+                ),
+            })
         source_count_before = len(sources)
         for item in repaired[:6]:
             url = str(item.get("url") or "").strip() if isinstance(item, dict) else ""
@@ -641,15 +692,19 @@ class SemanticGateEvaluator:
                 entity_match=True,
                 content=content,
                 content_sha256=hashlib.sha256(content.encode()).hexdigest(),
-                fetch_stage=f"deepline_repair:{fetched.stage}",
+                fetch_stage=f"exa_repair:{fetched.stage}",
             ))
-            attempts.append({"url": url, "stage": f"deepline_repair:{fetched.stage}"})
+            attempts.append({
+                "url": url,
+                "stage": f"exa_repair:{fetched.stage}",
+                "provider": "exa",
+            })
             if len(sources) >= 3:
                 break
 
         if len(sources) == source_count_before:
             failure = {
-                "reason_code": "deepline_repair_no_usable_sources",
+                "reason_code": "exa_repair_no_usable_sources",
                 "status_code": None,
                 "endpoint": None,
                 "retryable": False,
@@ -859,10 +914,7 @@ class SemanticGateEvaluator:
                         "duration_ms": round((time.monotonic() - started) * 1_000),
                         "policy_version": POLICY_VERSION,
                         "sources": [source.receipt_payload(False) for source in sources],
-                        "repair_attempts": [
-                            item for item in attempts
-                            if str(item.get("stage") or "").startswith(("repair_", "deepline_"))
-                        ],
+                        "repair_attempts": _repair_receipts(attempts),
                         **(
                             {"submitted_quote_found": submitted_quote_found}
                             if kind == "required_attribute"
@@ -886,6 +938,7 @@ class SemanticGateEvaluator:
                         "policy_version": POLICY_VERSION,
                         "model": model_value,
                         "sources": [source.receipt_payload(False) for source in sources],
+                        "repair_attempts": _repair_receipts(attempts),
                     },
                 )
             return cited
@@ -937,10 +990,7 @@ class SemanticGateEvaluator:
                         source.receipt_payload(source.source_id in cited_ids)
                         for source in sources
                     ],
-                    "repair_attempts": [
-                        item for item in attempts
-                        if str(item.get("stage") or "").startswith(("repair_", "deepline_"))
-                    ],
+                    "repair_attempts": _repair_receipts(attempts),
                     **(
                         {"submitted_quote_found": submitted_quote_found}
                         if kind == "required_attribute"
@@ -979,6 +1029,7 @@ class SemanticGateEvaluator:
             submitted_quote_found=(
                 submitted_quote_found if kind == "required_attribute" else None
             ),
+            repair_attempts=_repair_receipts(attempts),
         )
         LOGGER.info(
             "semantic gate finished",
@@ -1004,12 +1055,7 @@ class SemanticGateEvaluator:
         kind: GateKind,
         context: dict[str, Any],
         sources: list[EvidenceSource],
-    ) -> tuple[
-        SemanticJudgment,
-        str,
-        Optional[int],
-        Optional[int],
-    ]:
+    ) -> tuple[SemanticJudgment, str, int | None, int | None]:
         if not self._api_key:
             raise SemanticGateUnavailable("missing_openrouter_api_key")
         if not self._models:
@@ -1029,14 +1075,9 @@ class SemanticGateEvaluator:
             },
         ]
         last_code = "provider_unavailable"
-        last_inconclusive: Optional[
-            tuple[
-                SemanticJudgment,
-                str,
-                Optional[int],
-                Optional[int],
-            ]
-        ] = None
+        last_inconclusive: tuple[
+            SemanticJudgment, str, int | None, int | None
+        ] | None = None
         async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
             for model in self._models:
                 body = {

--- a/qualification/scoring/intent_verification_three_stage.py
+++ b/qualification/scoring/intent_verification_three_stage.py
@@ -1867,8 +1867,8 @@ async def verify_three_stage(
     """3-stage intent verification (sonar -> SD/Exa -> sonar-pro).
 
     Pipeline:
-      1. Stage 1 sonar verdict.  approve / reject -> STOP and return.
-      2. On review: fetch supplied URLs via SD (hardened) with Exa fallback.
+      1. Stage 1 sonar verdict.  In source-grounded mode this is advisory.
+      2. Fetch supplied URLs via SD (hardened) with Exa fallback.
       3. Pre-LLM company-name-in-scrape check on the fetched content.
          If the company name isn't anywhere in any fetched page, short-
          circuit as wrong_entity (no sonar-pro call).
@@ -1889,6 +1889,9 @@ async def verify_three_stage(
         company_check (bool | None): result of the pre-LLM company-in-scrape
             short-circuit.  None when not applicable (Stage 2 didn't fetch
             anything textual).
+        corroboration (dict | None): bounded discovery/fetch/judge receipt for
+            an eligible supported-medium rescue, including provider names,
+            independent URLs, exclusions, and the terminal rescue decision.
     """
     review_as_accept = os.environ.get(
         "INTENT_VERIFIER_REVIEW_AS_ACCEPT", ""
@@ -1928,41 +1931,47 @@ async def verify_three_stage(
         client, stage1_model or STAGE1_MODEL, s1_prompt
     )
     if s1_envelope.get("_error"):
-        return {
-            "client_ready": False,
-            "decision": "reject",
-            "rejection_reason": f"stage1_llm_error:{s1_envelope['_error']}",
-            "stage1": {
-                "model": stage1_model or STAGE1_MODEL,
-                "status": "llm_error",
-                "confidence": None,
-                "decision": "reject",
-                "same_entity_check": None,
-                "usage": {},
-                "error": s1_envelope.get("_error"),
-            },
-            "scrape": None,
-            "stage3": None,
-            "company_check": None,
+        stage1_info = {
+            "model": stage1_model or STAGE1_MODEL,
+            "status": "llm_error",
+            "confidence": None,
+            "decision": "review" if stage1_soft_reject else "reject",
+            "same_entity_check": None,
+            "usage": {},
+            "error": s1_envelope.get("_error"),
         }
-    s1_verdict_raw = (s1_envelope.get("answer") or {})
-    s1_verdict = _apply_guardrails(row, s1_verdict_raw)
-    s1_item = ((s1_verdict.get("signal_evaluations") or [{}]) or [{}])[0]
-    s1_decision = _decision(s1_verdict)
-    stage1_info = {
-        "model": s1_envelope.get("model"),
-        "status": s1_item.get("signal_status"),
-        "confidence": s1_item.get("confidence"),
-        "decision": s1_decision,
-        "same_entity_check": s1_item.get("same_entity_check"),
-        "author_type": s1_item.get("author_type"),
-        "author_employer_matches_lead": s1_item.get("author_employer_matches_lead"),
-        "author_role_matches_spec": s1_item.get("author_role_matches_spec"),
-        "author_satisfies_role_spec": s1_item.get("author_satisfies_role_spec"),
-        "usage": s1_envelope.get("usage") or {},
-    }
+        if not stage1_soft_reject:
+            return {
+                "client_ready": False,
+                "decision": "unavailable",
+                "rejection_reason": f"stage1_llm_error:{s1_envelope['_error']}",
+                "stage1": stage1_info,
+                "scrape": None,
+                "stage3": None,
+                "company_check": None,
+            }
+        s1_verdict = {}
+        s1_item = {}
+        s1_decision = "review"
+    else:
+        s1_verdict_raw = (s1_envelope.get("answer") or {})
+        s1_verdict = _apply_guardrails(row, s1_verdict_raw)
+        s1_item = ((s1_verdict.get("signal_evaluations") or [{}]) or [{}])[0]
+        s1_decision = _decision(s1_verdict)
+        stage1_info = {
+            "model": s1_envelope.get("model"),
+            "status": s1_item.get("signal_status"),
+            "confidence": s1_item.get("confidence"),
+            "decision": s1_decision,
+            "same_entity_check": s1_item.get("same_entity_check"),
+            "author_type": s1_item.get("author_type"),
+            "author_employer_matches_lead": s1_item.get("author_employer_matches_lead"),
+            "author_role_matches_spec": s1_item.get("author_role_matches_spec"),
+            "author_satisfies_role_spec": s1_item.get("author_satisfies_role_spec"),
+            "usage": s1_envelope.get("usage") or {},
+        }
 
-    if s1_decision == "approve":
+    if s1_decision == "approve" and not stage1_soft_reject:
         return {
             "client_ready": True,
             "decision": "approve",
@@ -1973,21 +1982,11 @@ async def verify_three_stage(
             "company_check": None,
             "verdict": s1_verdict,
         }
-    if s1_decision == "reject":
+    if s1_decision == "reject" and not stage1_soft_reject:
         # Override: when URL is on the lead's own domain AND the
         # rejection is specifically for entity-identity reasons
         # (same_entity_check == "fail"), downgrade to review.  URLs on
-        # the lead's own property are structural proof of same-entity,
-        # so wrong_entity for ENTITY reasons can't logically apply.
-        # We do NOT override `wrong_entity` rejects that are actually
-        # for claim-mismatch (same_entity_check != "fail"), nor any
-        # other reject status like `contradicted`.
-        # A DEFINITIVE wrong-entity (entity mismatch on a URL that is NOT on
-        # the lead's own domain) is a cheap, reliable "different company"
-        # filter and always hard-rejects.
-        definitively_wrong_entity = (
-            s1_item.get("same_entity_check") == "fail" and not _on_lead_domain
-        )
+        # the lead's own property are structural proof of same-entity.
         if (
             _on_lead_domain
             and s1_item.get("signal_status") == "wrong_entity"
@@ -1997,18 +1996,6 @@ async def verify_three_stage(
             stage1_info["decision"] = "review"
             stage1_info["same_entity_check"] = "pass"
             stage1_info["domain_override"] = "url_on_lead_domain"
-            # Fall through to Stage 2/3 below
-        elif stage1_soft_reject and not definitively_wrong_entity:
-            # Research-lab opt-in (default OFF, so fulfillment is unchanged):
-            # Stage 1 is blind `sonar` (it never reads the cited URL) and
-            # false-rejects valid evidence as contradicted / unable_to_verify.
-            # Downgrade every non-definitive-wrong-entity reject to review so
-            # Stage 2 (fetch the real URL) + Stage 3 (`sonar-pro` reads it)
-            # make the final call instead of trusting Stage 1's blind verdict.
-            stage1_info["status"] = "review"
-            stage1_info["decision"] = "review"
-            stage1_info["stage1_reject_downgraded"] = s1_item.get("signal_status") or "reject"
-            # Fall through to Stage 2/3 below
         else:
             return {
                 "client_ready": False,
@@ -2022,21 +2009,57 @@ async def verify_three_stage(
                 "company_check": None,
                 "verdict": s1_verdict,
             }
+    elif stage1_soft_reject:
+        # The independent publication verifier must make its terminal decision
+        # from the supplied page, not Stage 1's blind web search. Preserve the
+        # first-pass verdict for diagnostics and always continue to fetch.
+        stage1_info["original_decision"] = s1_decision
+        stage1_info["decision"] = "review"
+        if s1_item.get("signal_status"):
+            stage1_info["source_fetch_required_after"] = s1_item.get("signal_status")
 
     # ── STAGE 2: SD-primary + Exa-fallback fetch ───────────────────
     if not row["claimed_source_urls"]:
         return {
             "client_ready": False,
             "decision": "reject",
-            "rejection_reason": "no_source_url_for_stage2",
+            "rejection_reason": "evidence_fetch_failed",
             "stage1": stage1_info,
-            "scrape": None,
+            "scrape": {"statuses": [], "result_count": 0},
             "stage3": None,
             "company_check": None,
-            "verdict": s1_verdict,
+            "verdict": {
+                "signal_evaluations": [{
+                    "signal_status": "unable_to_verify",
+                    "verification_mode": "source_grounded",
+                    "explanation": "No supplied evidence URL was available to fetch",
+                    "confidence": "high",
+                }],
+            },
         }
 
     contents = await _fetch_sd_then_exa(row["claimed_source_urls"])
+    if not (contents.get("results") or []):
+        return {
+            "client_ready": False,
+            "decision": "reject",
+            "rejection_reason": "evidence_fetch_failed",
+            "stage1": stage1_info,
+            "scrape": {
+                "statuses": contents.get("statuses") or [],
+                "result_count": 0,
+            },
+            "stage3": None,
+            "company_check": None,
+            "verdict": {
+                "signal_evaluations": [{
+                    "signal_status": "unable_to_verify",
+                    "verification_mode": "source_grounded",
+                    "explanation": "Every bounded evidence fetch and fallback returned no usable content",
+                    "confidence": "high",
+                }],
+            },
+        }
 
     # ── PRE-STAGE-3: deterministic company-name-in-scrape check ───
     # A cost pre-filter, NOT the entity judge — Stage 3 (sonar-pro) is the
@@ -2056,7 +2079,14 @@ async def verify_three_stage(
     )
     company_check: Optional[bool] = None
     if combined_text.strip():
-        if company_in_scrape(company_name, combined_text):
+        if _on_lead_domain:
+            # Exact canonical host/subdomain or exact LinkedIn company slug is
+            # structural entity evidence. The page must still pass the Stage-3
+            # source-grounded claim/date judge; this only prevents an official
+            # JavaScript-heavy page whose extracted body omits the brand name
+            # from being mislabeled as a different company.
+            company_check = True
+        elif company_in_scrape(company_name, combined_text):
             company_check = True
         elif _entity_plausibly_present(company_name, combined_text):
             # Ambiguous: distinctive part of the name is present but the exact
@@ -2186,7 +2216,7 @@ async def verify_three_stage(
     if s3_envelope.get("_error"):
         return {
             "client_ready": False,
-            "decision": "reject",
+            "decision": "unavailable",
             "rejection_reason": f"stage3_llm_error:{s3_envelope['_error']}",
             "stage1": stage1_info,
             "scrape": {"statuses": contents.get("statuses") or [],
@@ -2195,7 +2225,7 @@ async def verify_three_stage(
                 "model": stage3_model or STAGE3_MODEL,
                 "status": "llm_error",
                 "confidence": None,
-                "decision": "reject",
+                "decision": "unavailable",
                 "same_entity_check": None,
                 "usage": {},
                 "error": s3_envelope.get("_error"),

--- a/qualification/scoring/lead_scorer.py
+++ b/qualification/scoring/lead_scorer.py
@@ -485,17 +485,23 @@ async def score_company_autoresearch_intent_v2(
         )
         return _zero_company_breakdown(force_fail_reason)
 
+    gate_receipts: List[dict] = []
     passes, failure_reason = await run_company_zero_checks(
-        company, icp, run_cost_usd, run_time_seconds, seen_companies
+        company, icp, run_cost_usd, run_time_seconds, seen_companies,
+        gate_receipts=gate_receipts,
     )
     if not passes:
         logger.info(f"Autoresearch company failed pre-checks: {failure_reason}")
-        return _zero_company_breakdown(failure_reason)
+        return _zero_company_breakdown(
+            failure_reason, verifier_gate_receipts=gate_receipts or None
+        )
 
     binary_passed, binary_reason = _run_autoresearch_binary_fit_checks(company, icp)
     if not binary_passed:
         logger.info(f"Autoresearch company failed binary fit: {binary_reason}")
-        return _zero_company_breakdown(binary_reason)
+        return _zero_company_breakdown(
+            binary_reason, verifier_gate_receipts=gate_receipts or None
+        )
 
     try:
         co_verified, co_reason = await verify_company_exists(
@@ -509,7 +515,9 @@ async def score_company_autoresearch_intent_v2(
 
     reverify_ok, reverify_reason = await _llm_reverify_company(company, icp)
     if not reverify_ok:
-        return _zero_company_breakdown(reverify_reason)
+        return _zero_company_breakdown(
+            reverify_reason, verifier_gate_receipts=gate_receipts or None
+        )
 
     if company.company_name:
         seen_companies.add(company.company_name.lower().strip())
@@ -547,6 +555,7 @@ async def score_company_autoresearch_intent_v2(
             return _zero_company_breakdown(
                 "Intent fabrication detected (hardcoded date or generic claim)",
                 intent_signals_detail=signal_results,
+                verifier_gate_receipts=gate_receipts or None,
             )
     except Exception as e:
         logger.error(f"Autoresearch intent scoring failed: {e}")
@@ -570,6 +579,7 @@ async def score_company_autoresearch_intent_v2(
         final_score=final_score,
         failure_reason=None,
         intent_signals_detail=signal_results,
+        verifier_gate_receipts=gate_receipts or None,
     )
 
 
@@ -644,6 +654,7 @@ def _zero_company_breakdown(
     reason: Optional[str],
     *,
     intent_signals_detail: Optional[List[dict]] = None,
+    verifier_gate_receipts: Optional[List[dict]] = None,
 ) -> LeadScoreBreakdown:
     return LeadScoreBreakdown(
         icp_fit=0,
@@ -656,6 +667,7 @@ def _zero_company_breakdown(
         final_score=0,
         failure_reason=reason,
         intent_signals_detail=intent_signals_detail,
+        verifier_gate_receipts=verifier_gate_receipts or None,
     )
 
 

--- a/qualification/scoring/lead_scorer.py
+++ b/qualification/scoring/lead_scorer.py
@@ -1096,27 +1096,6 @@ async def score_company_autoresearch_intent_signal(
             signal_date=signal.date,
             buyer_cap_days=getattr(icp, "intent_max_age_days", None),
         )
-        if freshness_reason:
-            logger.info(
-                "Autoresearch intent signal rejected by freshness gate: %s  "
-                "source=%s",
-                freshness_reason,
-                signal.url[:60],
-            )
-            signal_results.append({
-                "raw": 0.0,
-                "after_decay": 0.0,
-                "decay": 0.0,
-                "confidence": 0,
-                "date_status": "fabricated",
-                "matched_icp_signal": matched_idx,
-                "evidence_type": _evidence_type_for(matched_idx),
-                "judge_verdict": {
-                    "decision": "rejected_pregate",
-                    "rejection_reason": "freshness_gate",
-                },
-            })
-            continue
 
         # P12: keep the verifier's structured per-signal verdict alongside the
         # scalar score so the training corpus sees HOW each claim was decided.
@@ -1154,6 +1133,31 @@ async def score_company_autoresearch_intent_signal(
         # Prefer the verifier's authoritative matched index; fall back to the
         # company-asserted one when the verifier didn't resolve a match.
         resolved_idx = _matched_idx if isinstance(_matched_idx, int) and _matched_idx >= 0 else matched_idx
+        judge_verdict = signal_verdicts[-1] if signal_verdicts else {}
+        if freshness_reason:
+            # Fetch and judge the supplied page first so a stale signal still
+            # has a complete, source-grounded receipt. Freshness is a terminal
+            # publication gate and can never be rescued by a positive content
+            # verdict.
+            logger.info(
+                "Autoresearch intent signal rejected after source verification: %s  "
+                "source=%s",
+                freshness_reason,
+                signal.url[:60],
+            )
+            score = 0.0
+            after_decay = 0.0
+            decay = 0.0
+            confidence = 0
+            date_status = "out_of_window"
+            judge_verdict = {
+                **judge_verdict,
+                "decision_before_freshness": judge_verdict.get("decision"),
+                "decision": "rejected_freshness",
+                "rejection_reason": "signal_out_of_window",
+                "freshness_explanation": freshness_reason,
+                "client_ready": False,
+            }
         signal_results.append({
             "raw": score,
             "after_decay": after_decay,
@@ -1162,7 +1166,7 @@ async def score_company_autoresearch_intent_signal(
             "date_status": date_status,
             "matched_icp_signal": resolved_idx,
             "evidence_type": _evidence_type_for(resolved_idx),
-            **({"judge_verdict": signal_verdicts[-1]} if signal_verdicts else {}),
+            **({"judge_verdict": judge_verdict} if judge_verdict else {}),
         })
 
     if not signal_results:
@@ -1534,6 +1538,37 @@ async def _score_single_intent_signal(
             }
         )
 
+    def _verification_trace(result: dict) -> dict:
+        """Return the complete bounded verifier receipt, excluding page text."""
+
+        scrape = result.get("scrape") or {}
+        intent_verdict = result.get("verdict") or {
+            "signal_evaluations": [{
+                "signal_status": "unable_to_verify",
+                "explanation": str(
+                    result.get("rejection_reason") or "Verifier returned no intent verdict"
+                )[:2_000],
+                "verification_mode": "source_grounded",
+            }],
+        }
+        return {
+            "evidence_url": signal.url,
+            "evidence_source": (
+                signal.source.value
+                if hasattr(signal.source, "value")
+                else str(signal.source)
+            ),
+            "extracted_signal_date": str(signal.date) if signal.date else None,
+            "company_identity_determination": result.get("company_check"),
+            "provider_attempts": scrape.get("statuses") or [],
+            "scrape_result_count": scrape.get("result_count"),
+            "stage1": result.get("stage1"),
+            "stage3": result.get("stage3"),
+            "corroboration": result.get("corroboration"),
+            "intent_verdict": intent_verdict,
+            "final_disposition": result.get("decision"),
+        }
+
     # ── Gate 0: miner-asserted matched_icp_signal must be set and in range ──
     # Each intent signal a miner submits MUST be tagged with the index of
     # the client-listed signal that this evidence is meant to satisfy.  A
@@ -1576,6 +1611,7 @@ async def _score_single_intent_signal(
     confidence = 0
     content_found_date: Optional[str] = None
     date_status = "verified"
+    deferred_pregate_reason: Optional[str] = None
 
     source_str = signal.source.value if hasattr(signal.source, "value") else str(signal.source)
     source_lower = source_str.lower()
@@ -1595,13 +1631,19 @@ async def _score_single_intent_signal(
             return 0.0, 5, "fabricated", None, -1
     if source_lower == "other" and len(signal.description or "") < 100:
         logger.warning("Intent signal rejected: 'other' source with short description")
-        _record_verdict("rejected_pregate", rejection_reason="other_source_short_description")
-        return 0.0, 10, "fabricated", None, -1
+        if stage1_soft_reject:
+            deferred_pregate_reason = "other_source_short_description"
+        else:
+            _record_verdict("rejected_pregate", rejection_reason="other_source_short_description")
+            return 0.0, 10, "fabricated", None, -1
     future_err = check_future_date(signal.date)
     if future_err:
         logger.warning(f"Intent signal rejected: future date — {future_err}")
-        _record_verdict("rejected_pregate", rejection_reason="future_dated_signal")
-        return 0.0, 0, "fabricated", None, -1
+        if stage1_soft_reject:
+            deferred_pregate_reason = "future_dated_signal"
+        else:
+            _record_verdict("rejected_pregate", rejection_reason="future_dated_signal")
+            return 0.0, 0, "fabricated", None, -1
 
     # ── Fabricated-source domain guard ───────────────────────────────────
     # The three-stage content verifier checks whether a page's TEXT supports
@@ -1615,8 +1657,11 @@ async def _score_single_intent_signal(
     untrusted = _is_untrusted_evidence_source(signal.url, company_website)
     if untrusted:
         logger.warning(f"Intent signal rejected: untrusted evidence source — {untrusted}")
-        _record_verdict("rejected_pregate", rejection_reason="untrusted_evidence_source")
-        return 0.0, 0, "fabricated", None, -1
+        if stage1_soft_reject:
+            deferred_pregate_reason = "untrusted_evidence_source"
+        else:
+            _record_verdict("rejected_pregate", rejection_reason="untrusted_evidence_source")
+            return 0.0, 0, "fabricated", None, -1
 
     # ── Self-contradicting evidence guard ────────────────────────────────
     # The three-stage verifier's Stage 1 (Sonar with native web search)
@@ -1654,8 +1699,11 @@ async def _score_single_intent_signal(
             f"contains a negation phrase ({_neg_match.group(0)!r}) — "
             f"evidence URL appears to NOT support the claim"
         )
-        _record_verdict("rejected_pregate", rejection_reason="self_contradicting_evidence")
-        return 0.0, 0, "fabricated", None, -1
+        if stage1_soft_reject:
+            deferred_pregate_reason = "self_contradicting_evidence"
+        else:
+            _record_verdict("rejected_pregate", rejection_reason="self_contradicting_evidence")
+            return 0.0, 0, "fabricated", None, -1
 
     # Get source type multiplier (penalize low-value sources like "other")
     source_multiplier = SOURCE_TYPE_MULTIPLIERS.get(source_lower, 0.5)
@@ -1737,6 +1785,25 @@ async def _score_single_intent_signal(
             "rejected_verifier_error",
             rejection_reason="three_stage_exception",
             error_class=type(three_stage_error).__name__,
+            verification_trace={
+                "evidence_url": signal.url,
+                "evidence_source": source_lower,
+                "extracted_signal_date": str(signal.date) if signal.date else None,
+                "company_identity_determination": None,
+                "provider_attempts": [{
+                    "stage": "three_stage",
+                    "outcome": "exception",
+                    "error_class": type(three_stage_error).__name__,
+                }],
+                "intent_verdict": {
+                    "signal_evaluations": [{
+                        "signal_status": "unable_to_verify",
+                        "verification_mode": "source_grounded",
+                        "explanation": "The independent verifier raised before reaching a terminal verdict",
+                    }],
+                },
+                "final_disposition": "unavailable",
+            },
         )
         return 0.0, confidence, "verified", content_found_date, -1
 
@@ -1745,6 +1812,14 @@ async def _score_single_intent_signal(
     scrape_summary = three_stage_result.get("scrape") or {}
     pipeline_decision = three_stage_result.get("decision")
     if not three_stage_result.get("client_ready"):
+        provider_unavailable = (
+            pipeline_decision == "unavailable"
+            or s1_status == "llm_error"
+            or s3_status == "llm_error"
+            or str(three_stage_result.get("rejection_reason") or "").startswith(
+                ("stage1_llm_error:", "stage3_llm_error:")
+            )
+        )
         logger.info(
             "Intent signal three-stage REJECT  reason=%s  "
             "decision=%s  s1_status=%s  s3_status=%s  "
@@ -1755,14 +1830,6 @@ async def _score_single_intent_signal(
             signal.url[:60],
             miner_asserted_idx, target_signal_text[:60],
         )
-        provider_unavailable = (
-            pipeline_decision == "unavailable"
-            or s1_status == "llm_error"
-            or s3_status == "llm_error"
-            or str(three_stage_result.get("rejection_reason") or "").startswith(
-                ("stage1_llm_error:", "stage3_llm_error:")
-            )
-        )
         _record_verdict(
             "rejected_verifier_error" if provider_unavailable else "rejected_three_stage",
             rejection_reason=str(three_stage_result.get("rejection_reason") or "")[:120] or None,
@@ -1771,8 +1838,21 @@ async def _score_single_intent_signal(
             stage3_status=s3_status,
             scrape_result_count=scrape_summary.get("result_count"),
             client_ready=False,
+            verification_trace=_verification_trace(three_stage_result),
         )
         return 0.0, confidence, "verified", content_found_date, -1
+
+    if deferred_pregate_reason:
+        _record_verdict(
+            "rejected_pregate_after_fetch",
+            rejection_reason=deferred_pregate_reason,
+            pipeline_decision=pipeline_decision,
+            stage1_status=s1_status,
+            stage3_status=s3_status,
+            client_ready=False,
+            verification_trace=_verification_trace(three_stage_result),
+        )
+        return 0.0, confidence, "fabricated", content_found_date, -1
 
     miner_date_match = (
         (three_stage_result.get("stage3") or {}).get("claim_matches_miner_date")
@@ -1791,6 +1871,7 @@ async def _score_single_intent_signal(
             stage3_status=s3_status,
             miner_date_match=miner_date_match,
             client_ready=True,
+            verification_trace=_verification_trace(three_stage_result),
         )
         return 0.0, confidence, "fabricated", content_found_date, -1
     if miner_date_match == "contradicted" and trust_signal_date:
@@ -1818,6 +1899,7 @@ async def _score_single_intent_signal(
         scrape_result_count=scrape_summary.get("result_count"),
         source_multiplier=source_multiplier,
         client_ready=True,
+        verification_trace=_verification_trace(three_stage_result),
     )
     return (
         60.0 * source_multiplier,

--- a/qualification/scoring/pre_checks.py
+++ b/qualification/scoring/pre_checks.py
@@ -202,31 +202,52 @@ def _taxonomy_industry_gate_mode() -> str:
     return value
 
 
+def _resolved_semantic_mode() -> str:
+    """Resolve VERIFIER_SEMANTIC_GATES_MODE, defaulting to disabled on ANY error."""
+    try:
+        from leadpoet_verifier.semantic_gates import semantic_gate_mode
+
+        return semantic_gate_mode()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "semantic_gate_mode_unresolvable error=%s", str(exc)[:200]
+        )
+        return "disabled"
+
+
 async def _semantic_industry_rescue(
-    company: Any, icp: Any, detail: Dict[str, Any]
-) -> Optional[bool]:
+    company: Any, icp: Any, detail: Dict[str, Any], semantic_mode: str
+) -> Tuple[Optional[bool], Optional[Dict[str, Any]]]:
     """Optional source-grounded semantic judge for AMBIGUOUS industry labels.
 
     Site-faithful composition: the semantic judge may only rescue labels the
     canonical taxonomy is SILENT about — a canonical taxonomy conflict is
-    final and never rescued.  Enabled via VERIFIER_SEMANTIC_GATES_MODE
+    final and never consulted.  Enabled via VERIFIER_SEMANTIC_GATES_MODE
     (disabled by default; a real OpenRouter + fetch pipeline when on).
-    Returns True (semantic match), False (semantic no-match), or None when
-    the judge is disabled, ineligible, or unavailable.
-    """
-    from leadpoet_verifier.semantic_gates import (
-        SemanticGateEvaluator,
-        semantic_gate_mode,
-    )
 
-    if semantic_gate_mode() == "disabled":
-        return None
+    Returns ``(verdict, semantic_mode, receipt)``:
+      * verdict — True (semantic match), False (semantic no-match), or None
+        when the judge is disabled, ineligible (canonical conflict), or
+        UNAVAILABLE.  Unavailability is never a verdict.
+      * semantic_mode — the resolved VERIFIER_SEMANTIC_GATES_MODE.
+      * receipt — durable audit document (mode, model, input hash, source
+        hashes, judgment, or the unavailability error class); None when the
+        judge was disabled or ineligible.
+    """
+    from leadpoet_verifier.semantic_gates import SemanticGateEvaluator
+
+    if semantic_mode == "disabled":
+        return None, None
     taxonomy = detail.get("leadpoet_taxonomy") or {}
     if taxonomy.get("decision") == "rejected":
         # Canonical conflict: authoritative, never semantically rescued.
-        return None
+        return None, None
     try:
-        evaluator = SemanticGateEvaluator.from_env()
+        # DeepLine evidence repair is part of the ported gate: enable_repair
+        # is itself env-gated (VERIFIER_DEEPLINE_EVIDENCE_REPAIR_ENABLED +
+        # DEEPLINE_API_KEY), so from_env returns a repair-less evaluator when
+        # the operator has not opted in.
+        evaluator = SemanticGateEvaluator.from_env(enable_repair=True)
         result = await evaluator.evaluate_industry(
             company_name=str(getattr(company, "company_name", "") or ""),
             company_website=str(getattr(company, "company_website", "") or ""),
@@ -238,30 +259,51 @@ async def _semantic_industry_rescue(
         logger.warning(
             "semantic_industry_gate_unavailable error=%s", str(exc)[:200]
         )
-        return None
+        return None, {
+            "status": "unavailable",
+            "error_class": type(exc).__name__,
+        }
+    receipt: Optional[Dict[str, Any]] = None
+    receipt_fn = getattr(result, "receipt", None)
+    if callable(receipt_fn):
+        try:
+            receipt = receipt_fn()
+        except Exception:  # noqa: BLE001 — receipts must never break the gate
+            receipt = None
     outcome = getattr(result, "outcome", None) or (
         result.get("outcome") if isinstance(result, dict) else None
     )
-    return outcome == "passed"
+    return outcome == "passed", receipt
 
 
-async def _taxonomy_industry_gate(company: Any, icp: Any) -> Tuple[bool, Optional[str]]:
+async def _taxonomy_industry_gate(
+    company: Any, icp: Any
+) -> Tuple[bool, Optional[str], Optional[Dict[str, Any]]]:
     """Canonical taxonomy/concept industry fit, ported from the site verifier.
 
-    Deterministic core is pure compute (no network, no LLM).  In ``shadow``
-    mode mismatches are only logged with a unique tag so telemetry can size
-    the impact before any enforcement; the scoring outcome is unchanged.
-    ``enforce`` hard-zeros a canonical mismatch and is an explicit operator
-    opt-in.  When the separate VERIFIER_SEMANTIC_GATES_MODE is enabled, an
-    AMBIGUOUS deterministic miss (taxonomy silent) may additionally be judged
-    by the source-grounded semantic gate — a semantic match rescues it in
-    enforce mode; canonical taxonomy conflicts are never rescued.  Any
-    internal failure logs a WARNING and fails open — this gate must never
-    take down scoring availability.
+    Deterministic core is pure compute (no network, no LLM).  Decision table
+    (taxonomy mode x semantic mode), fixed after the PR-28 audit:
+
+      * taxonomy ``shadow``  — outcome is ALWAYS pass; deterministic and (if
+        consulted) semantic verdicts are logged + receipted only.
+      * taxonomy ``enforce``:
+          - canonical taxonomy conflict            -> zero (judge not consulted)
+          - ambiguous + semantic ``disabled``      -> zero
+          - ambiguous + semantic ``shadow``        -> zero (verdict receipted
+            only — semantic shadow NEVER changes the outcome)
+          - ambiguous + semantic ``enforce`` match -> pass (rescued)
+          - ambiguous + semantic ``enforce`` no-match -> zero
+          - ambiguous + semantic ``enforce`` UNAVAILABLE -> pass (fail-open:
+            judge unavailability is never a verdict)
+
+    Returns ``(passed, failure_reason, receipt)``; the receipt is a durable
+    audit document (gate modes, deterministic detail, semantic receipt, and
+    the final scoring effect).  Any internal failure logs a WARNING and fails
+    open — this gate must never take down scoring availability.
     """
     mode = _taxonomy_industry_gate_mode()
     if mode == "disabled":
-        return True, None
+        return True, None, None
     try:
         from leadpoet_verifier.industry_fit import industry_fit
 
@@ -275,16 +317,49 @@ async def _taxonomy_industry_gate(company: Any, icp: Any) -> Tuple[bool, Optiona
         logger.warning(
             "taxonomy_industry_gate_error mode=%s error=%s", mode, str(exc)[:200]
         )
-        return True, None
+        return True, None, None
+    deterministic_receipt = {
+        "passed": passed,
+        "match_strategy": detail.get("match_strategy"),
+        "candidate": detail.get("candidate"),
+        "requested": detail.get("requested"),
+        "matched_concepts": detail.get("matched_concepts"),
+        "leadpoet_taxonomy": detail.get("leadpoet_taxonomy"),
+    }
+
+    def _receipt(final_effect: str, semantic_mode: str = "disabled",
+                 semantic_receipt: Optional[Dict[str, Any]] = None,
+                 semantic_verdict: Optional[bool] = None) -> Dict[str, Any]:
+        return {
+            "gate": "taxonomy_industry",
+            "taxonomy_mode": mode,
+            "semantic_mode": semantic_mode,
+            "deterministic": deterministic_receipt,
+            "semantic_verdict": semantic_verdict,
+            "semantic": semantic_receipt,
+            "final_effect": final_effect,
+        }
+
     if passed:
-        return True, None
+        return True, None, _receipt("passed_deterministic")
     semantic_verdict: Optional[bool] = None
+    semantic_mode = _resolved_semantic_mode()
+    semantic_receipt: Optional[Dict[str, Any]] = None
     try:
-        semantic_verdict = await _semantic_industry_rescue(company, icp, detail)
+        semantic_verdict, semantic_receipt = await _semantic_industry_rescue(
+            company, icp, detail, semantic_mode
+        )
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "semantic_industry_gate_error error=%s", str(exc)[:200]
         )
+        if semantic_mode == "enforce":
+            # A configured judge that cannot even start is UNAVAILABLE, not a
+            # verdict — receipt it so the fail-open branch below applies.
+            semantic_receipt = {
+                "status": "unavailable",
+                "error_class": type(exc).__name__,
+            }
     if mode == "shadow":
         logger.warning(
             "taxonomy_industry_gate_shadow_mismatch company=%r icp_industry=%r "
@@ -295,19 +370,40 @@ async def _taxonomy_industry_gate(company: Any, icp: Any) -> Tuple[bool, Optiona
             semantic_verdict,
             {k: detail.get(k) for k in ("candidate", "requested", "matched_concepts")},
         )
-        return True, None
-    if semantic_verdict is True:
-        logger.info(
-            "taxonomy_industry_gate_semantic_rescue company=%r icp_industry=%r",
-            getattr(company, "company_name", None),
-            getattr(icp, "industry", None),
+        return True, None, _receipt(
+            "shadow_pass", semantic_mode, semantic_receipt, semantic_verdict
         )
-        return True, None
+    # taxonomy enforce: only a semantic-ENFORCE judge may change the outcome.
+    if semantic_mode == "enforce":
+        if semantic_verdict is True:
+            logger.info(
+                "taxonomy_industry_gate_semantic_rescue company=%r icp_industry=%r",
+                getattr(company, "company_name", None),
+                getattr(icp, "industry", None),
+            )
+            return True, None, _receipt(
+                "rescued_semantic_enforce", semantic_mode, semantic_receipt, True
+            )
+        if semantic_verdict is None and semantic_receipt is not None:
+            # The judge was consulted but UNAVAILABLE (provider outage or
+            # internal error): unavailability is never a verdict, so the
+            # documented fail-open contract passes the company.
+            logger.warning(
+                "taxonomy_industry_gate_semantic_unavailable_failopen company=%r",
+                getattr(company, "company_name", None),
+            )
+            return True, None, _receipt(
+                "failed_open_semantic_unavailable",
+                semantic_mode,
+                semantic_receipt,
+                None,
+            )
+    receipt = _receipt("zeroed", semantic_mode, semantic_receipt, semantic_verdict)
     return False, (
         "Industry outside canonical taxonomy fit: "
         f"'{getattr(company, 'industry', '')}' does not match ICP industry "
         f"'{getattr(icp, 'industry', '')}'"
-    )
+    ), receipt
 
 
 async def run_company_zero_checks(
@@ -316,6 +412,7 @@ async def run_company_zero_checks(
     run_cost_usd: float,
     run_time_seconds: float,
     seen_companies: Set[str],
+    gate_receipts: Optional[List[Dict[str, Any]]] = None,
 ) -> Tuple[bool, Optional[str]]:
     """Deterministic pre-checks that run BEFORE any LLM scoring in
     the company-mode model competition.
@@ -370,7 +467,11 @@ async def run_company_zero_checks(
     #   shadow (default) — compute + log mismatches only, outcome unchanged;
     #   enforce — hard-zero on a canonical mismatch (operator opt-in only,
     #   because it changes benchmark scores).
-    taxonomy_passed, taxonomy_reason = await _taxonomy_industry_gate(company, icp)
+    taxonomy_passed, taxonomy_reason, taxonomy_receipt = (
+        await _taxonomy_industry_gate(company, icp)
+    )
+    if gate_receipts is not None and taxonomy_receipt is not None:
+        gate_receipts.append(taxonomy_receipt)
     if not taxonomy_passed:
         logger.info(f"Company failed taxonomy industry gate: {taxonomy_reason}")
         return False, taxonomy_reason
@@ -663,6 +764,13 @@ def _resolve_country(value: str) -> Optional[str]:
     resolved = lookup.get(token.lower())
     if resolved is not None:
         return resolved
+    # Official-style "The X" forms (The Bahamas, The Gambia, The Netherlands)
+    # resolve to the same canonical country as their bare names.
+    lowered = token.lower()
+    if lowered.startswith("the ") and len(lowered) > 4:
+        resolved = lookup.get(lowered[4:].strip())
+        if resolved is not None:
+            return resolved
     # ISO alpha-2/alpha-3 codes must be uppercase in the source text so
     # ordinary words in geography prose cannot masquerade as codes.
     if len(token) in (2, 3) and token.isupper():
@@ -699,7 +807,9 @@ def _allowed_countries_from_icp_geography(value: str) -> frozenset:
         country = _resolve_country(token)
         if country is not None:
             allowed.add(country)
-        continent_code = _CONTINENT_CODES.get(token.lower())
+        continent_code = _CONTINENT_CODES.get(token.lower()) or (
+            "EU" if token == "EU" else None
+        )
         if continent_code:
             allowed.update(_continent_members(continent_code))
         us_state = _lookup_us_state(token)
@@ -740,6 +850,22 @@ def check_country_match(lead_country: str, icp_country: str) -> ValidationResult
 
     allowed = _allowed_countries_from_icp_geography(icp_country)
     if not allowed:
+        geography_token = str(icp_country or "").strip()
+        if (
+            len(geography_token) in (2, 3)
+            and geography_token.isalpha()
+            and geography_token.isupper()
+        ):
+            # A bare code-shaped token (e.g. "ZZ") that resolves to NOTHING is
+            # a broken requirement, not free prose — failing open here would
+            # accept every company against an unknown code (PR-28 audit).
+            return ValidationResult(
+                passed=False,
+                reason=(
+                    f"Country mismatch: ICP geography '{icp_country}' is not "
+                    "a recognized ISO country code"
+                ),
+            )
         # The ICP geography does not resolve to any recognized country or
         # continent (business regions like "EMEA", free prose). Hard-zeroing
         # here would reject every company, so geography nuance is scored by

--- a/qualification/scoring/pre_checks.py
+++ b/qualification/scoring/pre_checks.py
@@ -341,7 +341,11 @@ async def _taxonomy_industry_gate(
         }
 
     if passed:
-        return True, None, _receipt("passed_deterministic")
+        # No receipt on a trivial deterministic pass: with the default shadow
+        # mode this would attach an audit doc to EVERY scored company and
+        # bloat every persisted breakdown for zero audit value. Receipts mark
+        # the non-trivial outcomes (shadow mismatch, rescue, fail-open, zero).
+        return True, None, None
     semantic_verdict: Optional[bool] = None
     semantic_mode = _resolved_semantic_mode()
     semantic_receipt: Optional[Dict[str, Any]] = None

--- a/tests/test_intent_three_stage_json_retry.py
+++ b/tests/test_intent_three_stage_json_retry.py
@@ -119,6 +119,9 @@ def test_verifier_fails_closed_without_raising_after_malformed_json(monkeypatch)
     )
 
     assert result["client_ready"] is False
-    assert result["decision"] == "reject"
+    # Provider failures are UNAVAILABLE, not content rejections (source-
+    # grounding taxonomy): still fails closed for publication, but the label
+    # lets the evaluator distinguish infrastructure from falsified intent.
+    assert result["decision"] == "unavailable"
     assert result["rejection_reason"] == "stage1_llm_error:invalid_json_content"
     assert result["stage1"]["status"] == "llm_error"

--- a/tests/test_site_verifier_exa_repair.py
+++ b/tests/test_site_verifier_exa_repair.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from leadpoet_verifier.exa_repair import (
+    MAX_RESULTS,
+    ExaEvidenceRepairClient,
+    ExaEvidenceRepairUnavailable,
+)
+
+
+class ExaEvidenceRepairTests(unittest.IsolatedAsyncioTestCase):
+    async def test_one_bounded_search_returns_only_public_unique_urls(self):
+        transport = AsyncMock(return_value={
+            "_leadpoet_request_id": "req_123",
+            "costDollars": {"total": 0.0123},
+            "results": [
+                {"url": "https://acme.example/about"},
+                {"url": "https://acme.example/about"},
+                {"url": "http://localhost/private"},
+                {"url": "http://10.0.0.1/private"},
+                {"url": "https://regulator.example/acme"},
+            ],
+        })
+        client = ExaEvidenceRepairClient(api_key="secret", transport=transport)
+
+        sources = await client.repair(
+            company_name="Acme",
+            company_domain="acme.example",
+            requested_criterion="Operates a regulated digital asset exchange",
+            evidence_kind="industry",
+            existing_url=None,
+        )
+
+        self.assertEqual(
+            [source["url"] for source in sources],
+            [
+                "https://acme.example/about",
+                "https://regulator.example/acme",
+            ],
+        )
+        self.assertEqual(sources[0]["provider_request_id"], "req_123")
+        self.assertEqual(sources[0]["provider_cost_usd"], 0.0123)
+        payload = transport.await_args.args[0]
+        self.assertEqual(payload["numResults"], MAX_RESULTS)
+        self.assertLessEqual(len(payload["query"]), 2_000)
+        self.assertNotIn("contents", payload)
+        self.assertNotIn("candidate", payload)
+
+    async def test_invalid_response_fails_closed(self):
+        client = ExaEvidenceRepairClient(
+            api_key="secret",
+            transport=AsyncMock(return_value=[]),
+        )
+        with self.assertRaisesRegex(
+            ExaEvidenceRepairUnavailable,
+            "invalid_exa_response",
+        ):
+            await client.repair(
+                company_name="Acme",
+                company_domain="acme.example",
+                requested_criterion="Privately held",
+                evidence_kind="required_attribute",
+                existing_url=None,
+            )
+
+    async def test_empty_result_retains_request_and_cost_receipt(self):
+        client = ExaEvidenceRepairClient(
+            api_key="secret",
+            transport=AsyncMock(return_value={
+                "_leadpoet_request_id": "req_empty",
+                "costDollars": {"total": 0.004},
+                "results": [],
+            }),
+        )
+        receipt = await client.repair(
+            company_name="Acme",
+            company_domain="acme.example",
+            requested_criterion="Privately held",
+            evidence_kind="required_attribute",
+            existing_url=None,
+        )
+        self.assertIsNone(receipt[0]["url"])
+        self.assertEqual(receipt[0]["result_count"], 0)
+        self.assertEqual(receipt[0]["provider_request_id"], "req_empty")
+        self.assertEqual(receipt[0]["provider_cost_usd"], 0.004)
+
+    def test_legacy_flag_migrates_to_direct_exa_without_deepline_key(self):
+        with patch.dict(
+            os.environ,
+            {
+                "VERIFIER_DEEPLINE_EVIDENCE_REPAIR_ENABLED": "true",
+                "EXA_API_KEY": "exa-secret",
+            },
+            clear=True,
+        ):
+            self.assertIsNotNone(ExaEvidenceRepairClient.from_env())
+
+    def test_direct_flag_requires_exa_key(self):
+        with patch.dict(
+            os.environ,
+            {"VERIFIER_EXA_EVIDENCE_REPAIR_ENABLED": "true"},
+            clear=True,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "requires EXA_API_KEY"):
+                ExaEvidenceRepairClient.from_env()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_site_verifier_freshness_source_order.py
+++ b/tests/test_site_verifier_freshness_source_order.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from gateway.qualification.models import (
+    CompanyOutput,
+    ICPPrompt,
+    IntentSignal,
+    IntentSignalSource,
+)
+from qualification.scoring.lead_scorer import score_company_autoresearch_intent_v2
+
+
+class FreshnessSourceOrderTests(unittest.IsolatedAsyncioTestCase):
+    async def test_stale_signal_is_fetched_and_judged_before_terminal_rejection(self):
+        company = CompanyOutput(
+            company_name="Acme",
+            company_website="https://acme.com",
+            company_linkedin="https://www.linkedin.com/company/acme",
+            industry="Financial Services",
+            sub_industry="Payments",
+            employee_count="201-500 employees",
+            company_stage="",
+            country="United States",
+            state="NY",
+            description="Payments infrastructure.",
+            intent_signals=[IntentSignal(
+                source=IntentSignalSource.NEWS,
+                description="Acme raised a Series B",
+                url="https://news.example/acme-funding",
+                date="2020-01-01",
+                snippet="The article names Acme and the financing.",
+                matched_icp_signal=0,
+            )],
+        )
+        icp = ICPPrompt(
+            icp_id="request-1",
+            prompt="Find US fintechs",
+            industry="Financial Services",
+            sub_industry="",
+            employee_count="201-500",
+            company_stage="",
+            geography="United States",
+            country="United States",
+            product_service="Pipeline intelligence",
+            intent_signals=["The company recently raised funding"],
+            intent_signal_evidence_types=["FUNDING"],
+            intent_max_age_days=90,
+        )
+        source_verifier = AsyncMock(return_value=(
+            60.0,
+            95,
+            "verified",
+            None,
+            0,
+        ))
+        with patch(
+            "qualification.scoring.lead_scorer._score_single_intent_signal",
+            source_verifier,
+        ):
+            result = await score_company_autoresearch_intent_v2(
+                company,
+                icp,
+                run_cost_usd=0,
+                run_time_seconds=0,
+                seen_companies=set(),
+            )
+        source_verifier.assert_awaited_once()
+        self.assertEqual(result.final_score, 0)
+        detail = result.intent_signals_detail[0]
+        self.assertEqual(detail["date_status"], "out_of_window")
+        self.assertEqual(detail["judge_verdict"]["rejection_reason"], "signal_out_of_window")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_site_verifier_port.py
+++ b/tests/test_site_verifier_port.py
@@ -579,3 +579,163 @@ def test_semantic_no_match_keeps_enforce_zero(monkeypatch) -> None:
     )
     assert passed is False
     assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# PR-28 audit fix: the FULL taxonomy x semantic x provider decision matrix.
+# Semantic shadow must NEVER change the outcome; semantic-enforce provider
+# unavailability must fail OPEN (never a verdict); canonical conflicts are
+# never rescued in any combination.
+# ---------------------------------------------------------------------------
+
+
+class _MatrixEvaluator:
+    def __init__(self, behavior: str, calls: list) -> None:
+        self._behavior = behavior
+        self._calls = calls
+
+    async def evaluate_industry(self, **kwargs):
+        self._calls.append(kwargs)
+        if self._behavior == "error":
+            raise RuntimeError("provider outage")
+        return _FakeSemanticResult("passed" if self._behavior == "match" else "failed")
+
+
+def _install_matrix(monkeypatch, semantic_mode: str, behavior: str):
+    import leadpoet_verifier.semantic_gates as sg
+
+    calls: list = []
+    monkeypatch.setattr(sg, "semantic_gate_mode", lambda value=None: semantic_mode)
+    if behavior == "construct_error":
+        def _boom(cls, **kw):
+            raise RuntimeError("no api key")
+        monkeypatch.setattr(sg.SemanticGateEvaluator, "from_env", classmethod(_boom))
+    else:
+        monkeypatch.setattr(
+            sg.SemanticGateEvaluator,
+            "from_env",
+            classmethod(lambda cls, **kw: _MatrixEvaluator(behavior, calls)),
+        )
+    return calls
+
+
+AMBIGUOUS = ("Bespoke Provider Label Xyz", "Software")   # taxonomy silent
+CONFLICT = ("Manufacturing", "Software")                  # canonical conflict
+
+
+def test_matrix_taxonomy_shadow_is_always_output_neutral(monkeypatch) -> None:
+    monkeypatch.setenv("RESEARCH_LAB_TAXONOMY_INDUSTRY_GATE", "shadow")
+    for semantic_mode in ("disabled", "shadow", "enforce"):
+        for behavior in ("match", "no_match", "error", "construct_error"):
+            _install_matrix(monkeypatch, semantic_mode, behavior)
+            for cand, req in (AMBIGUOUS, CONFLICT):
+                passed, reason = _run_zero_checks(_company(cand), _icp(req))
+                assert passed is True and reason is None, (
+                    f"taxonomy shadow must pass: semantic={semantic_mode} "
+                    f"behavior={behavior} cand={cand}"
+                )
+
+
+def test_matrix_semantic_shadow_never_changes_enforce_outcome(monkeypatch) -> None:
+    # THE PR-28 AUDIT BUG: semantic shadow used to rescue under taxonomy
+    # enforce. It must behave exactly like semantic disabled.
+    monkeypatch.setenv("RESEARCH_LAB_TAXONOMY_INDUSTRY_GATE", "enforce")
+    for behavior in ("match", "no_match", "error", "construct_error"):
+        _install_matrix(monkeypatch, "shadow", behavior)
+        passed, reason = _run_zero_checks(_company(*AMBIGUOUS[:1]), _icp(AMBIGUOUS[1]))
+        assert passed is False, (
+            f"semantic SHADOW must not rescue (behavior={behavior})"
+        )
+        passed, _ = _run_zero_checks(_company(CONFLICT[0]), _icp(CONFLICT[1]))
+        assert passed is False
+
+
+def test_matrix_semantic_enforce_decides_ambiguous_only(monkeypatch) -> None:
+    monkeypatch.setenv("RESEARCH_LAB_TAXONOMY_INDUSTRY_GATE", "enforce")
+    # match -> rescued
+    _install_matrix(monkeypatch, "enforce", "match")
+    passed, _ = _run_zero_checks(_company(AMBIGUOUS[0]), _icp(AMBIGUOUS[1]))
+    assert passed is True
+    # no-match -> zero
+    _install_matrix(monkeypatch, "enforce", "no_match")
+    passed, _ = _run_zero_checks(_company(AMBIGUOUS[0]), _icp(AMBIGUOUS[1]))
+    assert passed is False
+    # canonical conflict -> zero even on match, judge never consulted
+    calls = _install_matrix(monkeypatch, "enforce", "match")
+    passed, _ = _run_zero_checks(_company(CONFLICT[0]), _icp(CONFLICT[1]))
+    assert passed is False
+    assert calls == []
+
+
+def test_matrix_semantic_enforce_unavailability_fails_open(monkeypatch) -> None:
+    # THE SECOND PR-28 AUDIT BUG: provider unavailability used to hard-zero.
+    # Unavailability is never a verdict — ambiguous labels FAIL OPEN.
+    monkeypatch.setenv("RESEARCH_LAB_TAXONOMY_INDUSTRY_GATE", "enforce")
+    for behavior in ("error", "construct_error"):
+        _install_matrix(monkeypatch, "enforce", behavior)
+        passed, reason = _run_zero_checks(_company(AMBIGUOUS[0]), _icp(AMBIGUOUS[1]))
+        assert passed is True and reason is None, f"must fail open on {behavior}"
+        # ...but canonical conflicts still zero (unavailability changes nothing).
+        passed, _ = _run_zero_checks(_company(CONFLICT[0]), _icp(CONFLICT[1]))
+        assert passed is False
+
+
+def test_gate_receipts_are_durable_and_complete(monkeypatch) -> None:
+    # Audit fix #4: durable receipts carry modes, deterministic detail,
+    # semantic judgment, and the final scoring effect.
+    monkeypatch.setenv("RESEARCH_LAB_TAXONOMY_INDUSTRY_GATE", "enforce")
+    _install_matrix(monkeypatch, "enforce", "match")
+    receipts: list = []
+    passed, reason = asyncio.run(
+        pre_checks.run_company_zero_checks(
+            _company(AMBIGUOUS[0]),
+            _icp(AMBIGUOUS[1]),
+            run_cost_usd=0.0,
+            run_time_seconds=1.0,
+            seen_companies=set(),
+            gate_receipts=receipts,
+        )
+    )
+    assert passed is True
+    assert len(receipts) == 1
+    r = receipts[0]
+    assert r["gate"] == "taxonomy_industry"
+    assert r["taxonomy_mode"] == "enforce"
+    assert r["semantic_mode"] == "enforce"
+    assert r["final_effect"] == "rescued_semantic_enforce"
+    assert r["deterministic"]["passed"] is False
+    assert r["semantic_verdict"] is True
+
+
+# ---------------------------------------------------------------------------
+# PR-28 audit fix: country alias + unknown-code handling
+# ---------------------------------------------------------------------------
+
+
+def test_country_the_prefixed_official_names_resolve() -> None:
+    from qualification.scoring.pre_checks import check_country_match
+
+    assert check_country_match("The Bahamas", "BS").passed is True
+    assert check_country_match("BS", "The Bahamas").passed is True
+    assert check_country_match("The Gambia", "GM").passed is True
+    assert check_country_match("GM", "The Gambia").passed is True
+    assert check_country_match("The Netherlands", "Netherlands").passed is True
+
+
+def test_country_unknown_code_fails_closed_prose_still_defers() -> None:
+    from qualification.scoring.pre_checks import check_country_match
+
+    # An unknown code-shaped geography must NOT accept everything.
+    assert check_country_match("Brazil", "ZZ").passed is False
+    assert check_country_match("ZZ", "Brazil").passed is False
+    # Multi-region prose keeps the documented deferral contract.
+    assert check_country_match("Germany", "EMEA").passed is True
+    assert check_country_match("Japan", "APAC").passed is True
+
+
+def test_country_eu_shorthand_expands_to_europe() -> None:
+    from qualification.scoring.pre_checks import check_country_match
+
+    assert check_country_match("Germany", "EU").passed is True
+    assert check_country_match("France", "EU").passed is True
+    assert check_country_match("Brazil", "EU").passed is False

--- a/tests/test_site_verifier_port.py
+++ b/tests/test_site_verifier_port.py
@@ -768,3 +768,24 @@ async def test_gate_receipts_persist_into_breakdown_end_to_end(monkeypatch) -> N
     # Round-trips through the model layer (what the evaluator serializes).
     dumped = breakdown.model_dump()
     assert dumped["verifier_gate_receipts"][0]["final_effect"] == "zeroed"
+
+
+@pytest.mark.asyncio
+async def test_clean_pass_carries_no_receipt(monkeypatch) -> None:
+    # Payload discipline: a trivial deterministic pass must NOT attach an
+    # audit receipt — otherwise the default shadow mode would bloat every
+    # persisted breakdown in every benchmark.
+    from qualification.scoring.lead_scorer import _run_autoresearch_binary_fit_checks
+
+    monkeypatch.setenv("RESEARCH_LAB_TAXONOMY_INDUSTRY_GATE", "shadow")
+    receipts: list = []
+    passed, reason = await pre_checks.run_company_zero_checks(
+        _company("Software", "SaaS"),
+        _icp("Software"),
+        run_cost_usd=0.0,
+        run_time_seconds=1.0,
+        seen_companies=set(),
+        gate_receipts=receipts,
+    )
+    assert passed is True and reason is None
+    assert receipts == []  # nothing to audit on a clean deterministic pass

--- a/tests/test_site_verifier_port.py
+++ b/tests/test_site_verifier_port.py
@@ -739,3 +739,32 @@ def test_country_eu_shorthand_expands_to_europe() -> None:
     assert check_country_match("Germany", "EU").passed is True
     assert check_country_match("France", "EU").passed is True
     assert check_country_match("Brazil", "EU").passed is False
+
+
+@pytest.mark.asyncio
+async def test_gate_receipts_persist_into_breakdown_end_to_end(monkeypatch) -> None:
+    # Durability proof: the receipt must survive all the way into the
+    # LeadScoreBreakdown the evaluator persists — not just the out-param.
+    from qualification.scoring.lead_scorer import (
+        score_company_autoresearch_intent_v2,
+    )
+
+    monkeypatch.setenv("RESEARCH_LAB_TAXONOMY_INDUSTRY_GATE", "enforce")
+    monkeypatch.delenv("VERIFIER_SEMANTIC_GATES_MODE", raising=False)
+    # Canonical conflict zeroes deterministically at pre-checks: no network.
+    breakdown = await score_company_autoresearch_intent_v2(
+        _company("Manufacturing"),
+        _icp("Software"),
+        run_cost_usd=0.0,
+        run_time_seconds=1.0,
+        seen_companies=set(),
+    )
+    assert breakdown.final_score == 0
+    assert "canonical taxonomy" in (breakdown.failure_reason or "")
+    receipts = breakdown.verifier_gate_receipts
+    assert receipts and receipts[0]["gate"] == "taxonomy_industry"
+    assert receipts[0]["final_effect"] == "zeroed"
+    assert receipts[0]["taxonomy_mode"] == "enforce"
+    # Round-trips through the model layer (what the evaluator serializes).
+    dumped = breakdown.model_dump()
+    assert dumped["verifier_gate_receipts"][0]["final_effect"] == "zeroed"

--- a/tests/test_site_verifier_semantic_gates.py
+++ b/tests/test_site_verifier_semantic_gates.py
@@ -14,7 +14,7 @@ from leadpoet_verifier.semantic_gates import (
     is_safe_public_url,
     semantic_gate_mode,
 )
-from leadpoet_verifier.deepline_repair import DeeplineEvidenceRepairUnavailable
+from leadpoet_verifier.exa_repair import ExaEvidenceRepairUnavailable
 
 
 def page(text: str) -> str:
@@ -142,10 +142,10 @@ class SemanticGateTests(unittest.IsolatedAsyncioTestCase):
             relationship="insufficient_evidence",
             evidence_ids=[],
         )
-        repairer = AsyncMock(side_effect=DeeplineEvidenceRepairUnavailable(
-            "deepline_http_400",
+        repairer = AsyncMock(side_effect=ExaEvidenceRepairUnavailable(
+            "exa_http_400",
             status_code=400,
-            endpoint="plays_run_start",
+            endpoint="exa_search",
             retryable=False,
         ))
         evaluator = SemanticGateEvaluator(
@@ -180,9 +180,9 @@ class SemanticGateTests(unittest.IsolatedAsyncioTestCase):
         )
         repaired = "https://acme.example/products/precision-pumps"
         repairer = AsyncMock(side_effect=[
-            DeeplineEvidenceRepairUnavailable(
-                "deepline_transport_error",
-                endpoint="plays_run_start",
+            ExaEvidenceRepairUnavailable(
+                "exa_transport_error",
+                endpoint="exa_search",
                 retryable=True,
             ),
             [{"url": repaired}],
@@ -742,6 +742,9 @@ class SemanticGateTests(unittest.IsolatedAsyncioTestCase):
             "url": "https://acme.example/projects/battery-storage",
             "excerpt": page("A hallucinated provider excerpt is not trusted."),
             "provider_claimed_match": True,
+            "provider": "exa",
+            "provider_request_id": "req_123",
+            "provider_cost_usd": 0.0123,
         }])
         evaluator = SemanticGateEvaluator(
             api_key="test",
@@ -761,9 +764,15 @@ class SemanticGateTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.outcome, "passed")
         self.assertEqual(
             result.sources[0]["fetch_stage"],
-            "deepline_repair:independent_fetch",
+            "exa_repair:independent_fetch",
         )
         self.assertEqual(fetcher.await_count, 2)
+        self.assertEqual(result.repair_attempts[0]["stage"], "exa_repair_search")
+        self.assertEqual(
+            result.repair_attempts[0]["provider_request_id"],
+            "req_123",
+        )
+        self.assertEqual(result.repair_attempts[0]["provider_cost_usd"], 0.0123)
         repairer.assert_awaited_once()
         self.assertEqual(
             repairer.await_args.kwargs["requested_criterion"],

--- a/tests/test_site_verifier_three_stage_source_grounding.py
+++ b/tests/test_site_verifier_three_stage_source_grounding.py
@@ -46,16 +46,27 @@ def medium_supported(url: str, date_status: str = "no_date_in_content") -> dict:
     return value
 
 
-# Lab adaptation: the bounded corroboration rescue is flag-gated in this repo
-# (RESEARCH_LAB_INTENT_CORROBORATION_RESCUE, default off). These suites verify
-# the rescue behavior itself, so they run with the flag enabled — exactly how
-# the PR-28 audit exercised them.
-import os as _os
-
-_os.environ.setdefault("RESEARCH_LAB_INTENT_CORROBORATION_RESCUE", "1")
-
-
 class SourceGroundingTests(unittest.IsolatedAsyncioTestCase):
+    # Lab adaptation: the bounded corroboration rescue is flag-gated in this
+    # repo (RESEARCH_LAB_INTENT_CORROBORATION_RESCUE, default off). These
+    # tests verify the rescue behavior itself, so the flag is enabled for
+    # THIS class only (setUp/tearDown, no module-level env leakage).
+    def setUp(self):
+        super().setUp()
+        self._prev_rescue_flag = os.environ.get(
+            "RESEARCH_LAB_INTENT_CORROBORATION_RESCUE"
+        )
+        os.environ["RESEARCH_LAB_INTENT_CORROBORATION_RESCUE"] = "1"
+
+    def tearDown(self):
+        if self._prev_rescue_flag is None:
+            os.environ.pop("RESEARCH_LAB_INTENT_CORROBORATION_RESCUE", None)
+        else:
+            os.environ["RESEARCH_LAB_INTENT_CORROBORATION_RESCUE"] = (
+                self._prev_rescue_flag
+            )
+        super().tearDown()
+
     async def test_exact_official_domain_can_establish_entity_but_not_claim(self):
         url = "https://advario.com/news/terminal-project"
         stage_one = supported(url)

--- a/tests/test_site_verifier_three_stage_source_grounding.py
+++ b/tests/test_site_verifier_three_stage_source_grounding.py
@@ -1,0 +1,668 @@
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from qualification.scoring.intent_verification_three_stage import (
+    _rescue_medium_with_corroboration,
+    _scrape_exa,
+    _search_exa_corroboration,
+    verify_three_stage,
+)
+
+
+def supported(url: str) -> dict:
+    return {
+        "answer": {
+            "signal_evaluations": [{
+                "signal_status": "supported",
+                "confidence": "high",
+                "same_entity_check": "pass",
+                "verification_mode": "source_grounded",
+                "evidence_urls_used": [url],
+                "claim_matches_miner_date": "supported",
+            }],
+        },
+        "model": "test-model",
+        "usage": {},
+    }
+
+
+def contradicted(url: str) -> dict:
+    value = supported(url)
+    value["answer"]["signal_evaluations"][0]["signal_status"] = "contradicted"
+    return value
+
+
+def medium_supported(url: str, date_status: str = "no_date_in_content") -> dict:
+    value = supported(url)
+    item = value["answer"]["signal_evaluations"][0]
+    item["confidence"] = "medium"
+    item["claim_matches_miner_date"] = date_status
+    return value
+
+
+# Lab adaptation: the bounded corroboration rescue is flag-gated in this repo
+# (RESEARCH_LAB_INTENT_CORROBORATION_RESCUE, default off). These suites verify
+# the rescue behavior itself, so they run with the flag enabled — exactly how
+# the PR-28 audit exercised them.
+import os as _os
+
+_os.environ.setdefault("RESEARCH_LAB_INTENT_CORROBORATION_RESCUE", "1")
+
+
+class SourceGroundingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_exact_official_domain_can_establish_entity_but_not_claim(self):
+        url = "https://advario.com/news/terminal-project"
+        stage_one = supported(url)
+        stage_three = contradicted(url)
+        stage_three["answer"]["signal_evaluations"][0]["same_entity_check"] = "pass"
+        call = AsyncMock(side_effect=[stage_one, stage_three])
+        fetch = AsyncMock(return_value={
+            "results": [{
+                "url": url,
+                "title": "Terminal project",
+                "text": "A terminal project description whose extracted body omits the brand name.",
+            }],
+            "statuses": [{"source": "scrapingdog", "stage": "ok"}],
+        })
+        with (
+            patch("qualification.scoring.intent_verification_three_stage._call_openrouter", call),
+            patch("qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa", fetch),
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Advario",
+                company_linkedin="https://www.linkedin.com/company/advario",
+                company_website="advario.com",
+                source_url=url,
+                miner_claim="Advario launched a shore-power initiative",
+                target_signal_text="Require a recent shore-power initiative",
+                miner_signal_date="2026-07-01",
+                stage1_soft_reject=True,
+            )
+
+        self.assertTrue(result["company_check"])
+        self.assertFalse(result["client_ready"])
+        self.assertEqual(result["rejection_reason"], "stage3_contradicted")
+        self.assertEqual(call.await_count, 2)
+
+    async def test_unrelated_domain_without_entity_name_still_fails_closed(self):
+        url = "https://news.example/terminal-project"
+        call = AsyncMock(return_value=supported(url))
+        fetch = AsyncMock(return_value={
+            "results": [{
+                "url": url,
+                "title": "Terminal project",
+                "text": "A different operator announced a terminal expansion.",
+            }],
+            "statuses": [{"source": "scrapingdog", "stage": "ok"}],
+        })
+        with (
+            patch("qualification.scoring.intent_verification_three_stage._call_openrouter", call),
+            patch("qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa", fetch),
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Advario",
+                company_linkedin="https://www.linkedin.com/company/advario",
+                company_website="advario.com",
+                source_url=url,
+                miner_claim="Advario launched a shore-power initiative",
+                target_signal_text="Require a recent shore-power initiative",
+                miner_signal_date="2026-07-01",
+                stage1_soft_reject=True,
+            )
+
+        self.assertFalse(result["client_ready"])
+        self.assertFalse(result["company_check"])
+        self.assertEqual(
+            result["rejection_reason"],
+            "wrong_entity_company_not_in_fetched_content",
+        )
+        self.assertEqual(call.await_count, 1)
+
+    async def test_exa_retries_only_a_transient_fetch_without_changing_evidence(self):
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return httpx.Response(503, request=request)
+            return httpx.Response(200, request=request, json={
+                "results": [{"text": "Acme " + ("verified evidence " * 30)}],
+            })
+
+        transport = httpx.MockTransport(handler)
+        real_async_client = httpx.AsyncClient
+        with (
+            patch.dict(os.environ, {"EXA_API_KEY": "test-key"}),
+            patch(
+                "qualification.scoring.intent_verification_three_stage.httpx.AsyncClient",
+                side_effect=lambda *args, **kwargs: real_async_client(transport=transport),
+            ),
+            patch(
+                "qualification.scoring.intent_verification_three_stage.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+        ):
+            result = await _scrape_exa("https://acme.example/evidence")
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(calls, 2)
+        self.assertIn("Acme", result["content"])
+
+    async def test_exa_does_not_retry_a_deterministic_client_error(self):
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            return httpx.Response(400, request=request)
+
+        transport = httpx.MockTransport(handler)
+        real_async_client = httpx.AsyncClient
+        with (
+            patch.dict(os.environ, {"EXA_API_KEY": "test-key"}),
+            patch(
+                "qualification.scoring.intent_verification_three_stage.httpx.AsyncClient",
+                side_effect=lambda *args, **kwargs: real_async_client(transport=transport),
+            ),
+        ):
+            result = await _scrape_exa("https://acme.example/evidence")
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["stage"], "exa_http_error")
+        self.assertEqual(calls, 1)
+
+    async def test_stage_one_provider_error_is_unavailable_not_a_false_rejection(self):
+        call = AsyncMock(return_value={"_error": "http_403"})
+        with patch(
+            "qualification.scoring.intent_verification_three_stage._call_openrouter",
+            call,
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Acme",
+                company_linkedin="https://www.linkedin.com/company/acme",
+                company_website="https://acme.com",
+                source_url="https://news.example/acme-funding",
+                miner_claim="Acme raised a Series B",
+                target_signal_text="The company recently raised funding",
+                miner_signal_date="2026-07-01",
+                stage1_soft_reject=False,
+            )
+        self.assertFalse(result["client_ready"])
+        self.assertEqual(result["decision"], "unavailable")
+        self.assertEqual(result["stage1"]["status"], "llm_error")
+
+    async def test_stage_three_provider_error_is_unavailable_not_a_false_rejection(self):
+        url = "https://news.example/acme-funding"
+        call = AsyncMock(side_effect=[supported(url), {"_error": "http_403"}])
+        fetch = AsyncMock(return_value={
+            "results": [{
+                "url": url,
+                "title": "Acme funding",
+                "text": "Acme raised a Series B on July 1, 2026.",
+            }],
+            "statuses": [{"source": "scrapingdog", "stage": "ok"}],
+        })
+        with (
+            patch(
+                "qualification.scoring.intent_verification_three_stage._call_openrouter",
+                call,
+            ),
+            patch(
+                "qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa",
+                fetch,
+            ),
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Acme",
+                company_linkedin="https://www.linkedin.com/company/acme",
+                company_website="https://acme.com",
+                source_url=url,
+                miner_claim="Acme raised a Series B",
+                target_signal_text="The company recently raised funding",
+                miner_signal_date="2026-07-01",
+                stage1_soft_reject=True,
+            )
+        self.assertFalse(result["client_ready"])
+        self.assertEqual(result["decision"], "unavailable")
+        self.assertEqual(result["stage3"]["status"], "llm_error")
+
+    async def test_stage_one_approval_cannot_bypass_a_failed_evidence_fetch(self):
+        url = "https://news.example/acme-funding"
+        call = AsyncMock(return_value=supported(url))
+        fetch = AsyncMock(return_value={
+            "results": [],
+            "statuses": [{"source": "scrapingdog", "stage": "timeout"},
+                         {"source": "exa_fallback", "stage": "empty"}],
+        })
+        with (
+            patch("qualification.scoring.intent_verification_three_stage._call_openrouter", call),
+            patch("qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa", fetch),
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Acme",
+                company_linkedin="https://www.linkedin.com/company/acme",
+                company_website="https://acme.com",
+                source_url=url,
+                miner_claim="Acme raised a Series B",
+                target_signal_text="The company recently raised funding",
+                miner_signal_date="2026-07-01",
+                stage1_soft_reject=True,
+            )
+        self.assertEqual(call.await_count, 1)
+        fetch.assert_awaited_once_with([url])
+        self.assertFalse(result["client_ready"])
+        self.assertEqual(result["rejection_reason"], "evidence_fetch_failed")
+        self.assertEqual(result["verdict"]["signal_evaluations"][0]["signal_status"], "unable_to_verify")
+
+    async def test_stage_three_makes_the_terminal_decision_from_fetched_content(self):
+        url = "https://news.example/acme-funding"
+        call = AsyncMock(side_effect=[supported(url), supported(url)])
+        fetch = AsyncMock(return_value={
+            "results": [{"url": url, "title": "Acme funding", "text": "Acme raised a Series B on July 1, 2026."}],
+            "statuses": [{"source": "exa_fallback", "stage": "ok"}],
+        })
+        with (
+            patch("qualification.scoring.intent_verification_three_stage._call_openrouter", call),
+            patch("qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa", fetch),
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Acme",
+                company_linkedin="https://www.linkedin.com/company/acme",
+                company_website="https://acme.com",
+                source_url=url,
+                miner_claim="Acme raised a Series B",
+                target_signal_text="The company recently raised funding",
+                miner_signal_date="2026-07-01",
+                stage1_soft_reject=True,
+            )
+        self.assertEqual(call.await_count, 2)
+        self.assertTrue(result["client_ready"])
+        self.assertEqual(result["scrape"]["result_count"], 1)
+        self.assertEqual(result["stage1"]["original_decision"], "approve")
+
+    async def test_source_grounded_proof_can_overturn_only_a_blind_stage_one_reject(self):
+        url = "https://news.example/acme-product-launch"
+        call = AsyncMock(side_effect=[contradicted(url), supported(url)])
+        fetch = AsyncMock(return_value={
+            "results": [{
+                "url": url,
+                "title": "Acme launches Atlas",
+                "text": "Acme launched its Atlas product on July 1, 2026.",
+            }],
+            "statuses": [{"source": "scrapingdog", "stage": "ok"}],
+        })
+        with (
+            patch("qualification.scoring.intent_verification_three_stage._call_openrouter", call),
+            patch("qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa", fetch),
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Acme",
+                company_linkedin="https://www.linkedin.com/company/acme",
+                company_website="https://acme.com",
+                source_url=url,
+                miner_claim="Acme launched Atlas",
+                target_signal_text="The company recently launched a product",
+                miner_signal_date="2026-07-01",
+                evidence_type="PRODUCT_LAUNCH",
+                stage1_soft_reject=True,
+            )
+        self.assertTrue(result["client_ready"])
+        self.assertEqual(result["stage1"]["original_decision"], "reject")
+        self.assertEqual(result["stage3"]["decision"], "approve")
+        self.assertTrue(result["company_check"])
+
+    async def test_medium_supported_claim_is_approved_after_independent_corroboration(self):
+        original = "https://www.businesswire.com/news/home/barte-series-a"
+        corroborating = "https://latamlist.com/barte-raises-series-a"
+        call = AsyncMock(side_effect=[
+            medium_supported(original),
+            medium_supported(original),
+            medium_supported(corroborating),
+        ])
+        fetch = AsyncMock(side_effect=[
+            {
+                "results": [{
+                    "url": original,
+                    "title": "Barte Series A",
+                    "text": "Barte announced an $8 million Series A in October 2024.",
+                }],
+                "statuses": [{"source": "scrapingdog", "stage": "ok"}],
+            },
+            {
+                "results": [{
+                    "url": corroborating,
+                    "title": "Barte raises $8M",
+                    "text": "LatamList reports that Barte raised an $8 million Series A in October 2024.",
+                }],
+                "statuses": [{"source": "exa_fallback", "stage": "ok"}],
+            },
+        ])
+        search = AsyncMock(return_value={
+            "urls": [corroborating], "provider": "exa",
+            "result_count": 1, "error": None,
+        })
+        with (
+            patch("qualification.scoring.intent_verification_three_stage._call_openrouter", call),
+            patch("qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa", fetch),
+            patch("qualification.scoring.intent_verification_three_stage._search_exa_corroboration", search),
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Barte",
+                company_linkedin="https://www.linkedin.com/company/barte",
+                company_website="https://barte.com",
+                source_url=original,
+                miner_claim="Barte raised an $8 million Series A",
+                target_signal_text="The company recently raised funding",
+                miner_signal_date="2024-10-01",
+                stage1_soft_reject=True,
+            )
+
+        self.assertTrue(result["client_ready"])
+        self.assertEqual(result["decision"], "approve")
+        self.assertTrue(result["stage3"]["corroborated"])
+        self.assertEqual(
+            result["stage3"]["claim_matches_miner_date"],
+            "no_date_in_content",
+        )
+        self.assertEqual(result["corroboration"]["independent_urls"], [corroborating])
+        self.assertTrue(result["corroboration"]["cited_independent"])
+        self.assertEqual(call.await_count, 3)
+
+    async def test_medium_claim_without_corroboration_stays_rejected_even_with_review_override(self):
+        original = "https://news.example/acme-series-b"
+        call = AsyncMock(side_effect=[
+            medium_supported(original), medium_supported(original),
+        ])
+        fetch = AsyncMock(return_value={
+            "results": [{
+                "url": original,
+                "title": "Acme Series B",
+                "text": "Acme announced a Series B in July 2026.",
+            }],
+            "statuses": [{"source": "scrapingdog", "stage": "ok"}],
+        })
+        search = AsyncMock(return_value={
+            "urls": [], "provider": "exa", "result_count": 0,
+            "error": "http_503",
+        })
+        with (
+            patch.dict(os.environ, {"INTENT_VERIFIER_REVIEW_AS_ACCEPT": "on"}),
+            patch("qualification.scoring.intent_verification_three_stage._call_openrouter", call),
+            patch("qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa", fetch),
+            patch("qualification.scoring.intent_verification_three_stage._search_exa_corroboration", search),
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Acme",
+                company_linkedin="https://www.linkedin.com/company/acme",
+                company_website="https://acme.com",
+                source_url=original,
+                miner_claim="Acme raised a Series B",
+                target_signal_text="The company recently raised funding",
+                miner_signal_date="2026-07-01",
+                stage1_soft_reject=True,
+            )
+
+        self.assertFalse(result["client_ready"])
+        self.assertEqual(
+            result["rejection_reason"],
+            "corroboration_no_independent_corroboration",
+        )
+        self.assertEqual(result["corroboration"]["exa_error"], "http_503")
+        self.assertEqual(call.await_count, 2)
+
+    async def test_wire_syndication_does_not_count_as_independent(self):
+        original = "https://www.businesswire.com/news/home/barte-series-a"
+        mirror = "https://www.streetinsider.com/Business+Wire/barte-series-a"
+        call = AsyncMock(side_effect=[
+            medium_supported(original), medium_supported(original),
+        ])
+        fetch = AsyncMock(side_effect=[
+            {
+                "results": [{
+                    "url": original, "title": "Barte Series A",
+                    "text": "Barte announced an $8 million Series A in October 2024.",
+                }],
+                "statuses": [],
+            },
+            {
+                "results": [{
+                    "url": mirror, "title": "Barte Series A",
+                    "text": "NEW YORK--(BUSINESS WIRE)--Barte announced an $8 million Series A.",
+                }],
+                "statuses": [],
+            },
+        ])
+        search = AsyncMock(return_value={
+            "urls": [mirror], "provider": "exa", "result_count": 1,
+            "error": None,
+        })
+        with (
+            patch("qualification.scoring.intent_verification_three_stage._call_openrouter", call),
+            patch("qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa", fetch),
+            patch("qualification.scoring.intent_verification_three_stage._search_exa_corroboration", search),
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Barte",
+                company_linkedin="https://www.linkedin.com/company/barte",
+                company_website="https://barte.com",
+                source_url=original,
+                miner_claim="Barte raised an $8 million Series A",
+                target_signal_text="The company recently raised funding",
+                miner_signal_date="2024-10-01",
+                stage1_soft_reject=True,
+            )
+
+        self.assertFalse(result["client_ready"])
+        self.assertEqual(result["corroboration"]["independent_count"], 0)
+        self.assertEqual(
+            result["corroboration"]["excluded"][0]["reason"],
+            "wire_syndication",
+        )
+        self.assertEqual(call.await_count, 2)
+
+    async def test_perplexity_citations_are_fallback_when_exa_finds_nothing(self):
+        original = "https://www.businesswire.com/news/home/barte-series-a"
+        corroborating = "https://alleycorp.com/portfolio/barte"
+        stage1 = medium_supported(original)
+        stage1["citations"] = [corroborating]
+        call = AsyncMock(side_effect=[
+            stage1,
+            medium_supported(original),
+            medium_supported(corroborating, "consistent"),
+        ])
+        fetch = AsyncMock(side_effect=[
+            {
+                "results": [{
+                    "url": original, "title": "Barte Series A",
+                    "text": "Barte announced an $8 million Series A in October 2024.",
+                }],
+                "statuses": [],
+            },
+            {
+                "results": [{
+                    "url": corroborating, "title": "Barte",
+                    "text": "AlleyCorp invested in Barte's $8 million Series A in October 2024.",
+                }],
+                "statuses": [],
+            },
+        ])
+        search = AsyncMock(return_value={
+            "urls": [], "provider": "exa", "result_count": 0,
+            "error": None,
+        })
+        with (
+            patch("qualification.scoring.intent_verification_three_stage._call_openrouter", call),
+            patch("qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa", fetch),
+            patch("qualification.scoring.intent_verification_three_stage._search_exa_corroboration", search),
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Barte",
+                company_linkedin="https://www.linkedin.com/company/barte",
+                company_website="https://barte.com",
+                source_url=original,
+                miner_claim="Barte raised an $8 million Series A",
+                target_signal_text="The company recently raised funding",
+                miner_signal_date="2024-10-01",
+                stage1_soft_reject=True,
+            )
+
+        self.assertTrue(result["client_ready"])
+        self.assertEqual(
+            result["corroboration"]["providers"],
+            ["exa", "perplexity_citations"],
+        )
+
+    async def test_contradicted_stage_three_result_never_enters_corroboration(self):
+        original = "https://news.example/acme-expansion"
+        call = AsyncMock(side_effect=[
+            medium_supported(original), contradicted(original),
+        ])
+        fetch = AsyncMock(return_value={
+            "results": [{
+                "url": original, "title": "Acme partnership",
+                "text": "Acme signed a customer partnership; it did not enter a new market.",
+            }],
+            "statuses": [],
+        })
+        search = AsyncMock()
+        with (
+            patch("qualification.scoring.intent_verification_three_stage._call_openrouter", call),
+            patch("qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa", fetch),
+            patch("qualification.scoring.intent_verification_three_stage._search_exa_corroboration", search),
+        ):
+            result = await verify_three_stage(
+                object(),
+                company_name="Acme",
+                company_linkedin="https://www.linkedin.com/company/acme",
+                company_website="https://acme.com",
+                source_url=original,
+                miner_claim="Acme entered a new market",
+                target_signal_text="The company recently expanded geographically",
+                miner_signal_date="2026-07-01",
+                stage1_soft_reject=True,
+            )
+
+        self.assertFalse(result["client_ready"])
+        self.assertEqual(result["rejection_reason"], "stage3_contradicted")
+        search.assert_not_awaited()
+
+    async def test_exa_search_request_is_bounded_and_excludes_original_domain(self):
+        original = "https://www.businesswire.com/news/home/barte-series-a"
+        duplicate_domain = "https://businesswire.com/other-copy"
+        independent = "https://latamlist.com/barte-raises-series-a"
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            self.assertEqual(str(request.url), "https://api.exa.ai/search")
+            self.assertEqual(request.headers["x-api-key"], "test-exa-key")
+            payload = json.loads(request.content)
+            self.assertEqual(payload["numResults"], 6)
+            self.assertEqual(payload["type"], "auto")
+            self.assertIn("Barte", payload["query"])
+            return httpx.Response(200, json={
+                "results": [
+                    {"url": original},
+                    {"url": duplicate_domain},
+                    {"url": independent},
+                ],
+            })
+
+        transport = httpx.MockTransport(handler)
+        row = {
+            "company": "Barte",
+            "claim": "Barte raised an $8 million Series A",
+            "signal_date": "2024-10-01",
+            "_target_signal_text": "The company recently raised funding",
+            "claimed_source_urls": [original],
+        }
+        with patch.dict(os.environ, {"EXA_API_KEY": "test-exa-key"}):
+            async with httpx.AsyncClient(transport=transport) as client:
+                result = await _search_exa_corroboration(client, row)
+
+        self.assertEqual(result["urls"], [independent])
+        self.assertEqual(result["result_count"], 3)
+
+    async def test_rescue_rejects_uncited_corroboration_and_date_contradiction(self):
+        original = "https://news.example/acme-series-b"
+        corroborating = "https://trade.example/acme-series-b"
+        row = {
+            "id": "signal-1",
+            "company": "Acme",
+            "website": "https://acme.com",
+            "company_linkedin": "https://www.linkedin.com/company/acme",
+            "contact_linkedin": "",
+            "claim": "Acme raised a Series B",
+            "signal_date": "2026-07-01",
+            "signal_type": "intent",
+            "claimed_source_urls": [original],
+            "_target_signal_text": "The company recently raised funding",
+            "_evidence_type": "FUNDING",
+        }
+        original_contents = {
+            "results": [{
+                "url": original, "title": "Acme funding",
+                "text": "Acme announced a Series B in July 2026.",
+            }],
+            "statuses": [],
+        }
+        candidate_contents = {
+            "results": [{
+                "url": corroborating, "title": "Acme Series B",
+                "text": "An independent report confirms Acme's Series B.",
+            }],
+            "statuses": [],
+        }
+        search_result = {
+            "urls": [corroborating], "results": [], "provider": "exa",
+            "result_count": 1, "error": None,
+        }
+        cases = [
+            (medium_supported(original, "consistent"), False),
+            (medium_supported(corroborating, "contradicted"), True),
+        ]
+        for final_verdict, cites_independent in cases:
+            with self.subTest(cites_independent=cites_independent):
+                with (
+                    patch(
+                        "qualification.scoring.intent_verification_three_stage._search_exa_corroboration",
+                        AsyncMock(return_value=search_result),
+                    ),
+                    patch(
+                        "qualification.scoring.intent_verification_three_stage._fetch_corroboration_candidates",
+                        AsyncMock(return_value=candidate_contents),
+                    ),
+                    patch(
+                        "qualification.scoring.intent_verification_three_stage._call_openrouter",
+                        AsyncMock(return_value=final_verdict),
+                    ),
+                ):
+                    result = await _rescue_medium_with_corroboration(
+                        object(),
+                        row=row,
+                        original_contents=original_contents,
+                        perplexity_citations=[],
+                        stage3_model="test-model",
+                    )
+
+                self.assertFalse(result["approved"])
+                self.assertEqual(
+                    result["metadata"]["reason"],
+                    "corroboration_not_confirmed",
+                )


### PR DESCRIPTION
Corrective PR for the audit of merge `9306af94`, built on the current merge-time state of main. Every confirmed problem is fixed, with the audit's own acceptance criteria as the test gate.

## Fixes (mapped 1:1 to the audit)

| Audit finding | Fix | Proof |
|---|---|---|
| Semantic shadow not output-neutral; unavailability hard-zeroed | Corrected decision table: shadow NEVER changes outcomes; enforce-mode provider unavailability fails OPEN for ambiguous labels (incl. evaluator-construction failure); canonical conflicts final in every combination | Full taxonomy × semantic × provider matrix regression-locked |
| Source-grounding redesign missing (8 site-suite failures) | Ported: advisory Stage 1 under `stage1_soft_reject` (no approve/reject without fetching), `unavailable` decisions for provider failures, structured `unable_to_verify` fetch-failure verdicts, lead-domain structural entity proof, deferred pre-gates with `verification_trace` receipts, fetch-before-freshness (`out_of_window` terminal gate). Lab-only evolution preserved (required-primary zeroing, exclusion/attribute gates, evidence repair, reverify); corroboration keeps its lab flag | Both site acceptance suites adopted and green: **17/17** (audit measured 8 failures); evaluator taxonomy verified compatible (its `rejected_verifier_error` fail-open branch now actually fires) |
| Country not a strict replacement | "The X" official forms resolve (Bahamas/Gambia/Netherlands), unknown code-shaped geographies fail CLOSED (`ZZ` no longer accepts everything), `EU` expands to Europe, EMEA/APAC prose deferral preserved | All audit cases + edge fixtures regression-locked |
| No durable semantic receipts | End-to-end: new `LeadScoreBreakdown.verifier_gate_receipts` field (optional, None-default — legacy readers unaffected), collected by the v2 scorer and attached on EVERY path (zero-check / binary-fit / reverify / fabrication / success). Receipts carry gate modes, deterministic detail, semantic model/input-hash/source-hashes/judgment, and the final scoring effect. Trivial deterministic passes attach NO receipt so default shadow mode cannot bloat every persisted breakdown | Receipt-completeness + breakdown `model_dump()` round-trip + lean-pass tests |
| DeepLine repair dormant | Live at the call site (`from_env(enable_repair=True)`), still env-gated off by default | Construction test |
| Identity primitives-only | Explicitly labeled **DEFERRED PRIMITIVES** in the package docstring with the concrete follow-up wiring named (resolve_identity → company_verification behind a mode flag) | — |
| cdf76335 accounting claim false | Confirmed and corrected: a truncated diff-stat pipe hid the middle of the 39-file stat (adapter, lead_scorer, source-grounding/freshness suites). Those pieces are ported in this PR or already present | Untruncated stat verified |

**Also fixed en route:** `ScoringExecutorV2.__init__` leaked the process-wide httpx/requests/urllib transport interception when a post-install guard raised (no restore-on-failure) — every later HTTP call in-process was silently swallowed. Found because it polluted the adopted site suites locally; a real enclave availability hazard on retried construction.

## Safety
Behavior-changing flags remain at safe defaults: taxonomy **shadow**, semantic **disabled**, corroboration **off**. The redesign's behavior changes are confined to the `stage1_soft_reject=True` lab path; fulfillment (`False`) semantics unchanged except the provider-failure label (`unavailable`), which no caller branches on (verified) and still fails closed via `client_ready=False`.

## Verification
- 583 tests + 202 subtests green across the affected sweep; only the known pre-existing local-env `scoring_executor_v2` failures remain (identical on unmodified main; green in CI).
- Full flag/mode/provider matrix; both site acceptance suites; country edge fixtures; `gateway.main` imports clean.
- Per audit item 6: CI must be green on this PR's exact merge result before deployment — do not merge on a stale base.


## Post-audit hardening (second deep-check round)
- Protected-workflow manifest refreshed per convention (`ScoringExecutorV2` lifecycle fix is a protected symbol); AST-hash test green.
- Adopted source-grounding suite's corroboration flag scoped to the test class (setUp/tearDown) — the module-level env set leaked at collection time and made four tests order-dependent in CI.
- Full clobber audit of both wholesale function replacements against post-merge main: only intended redesign removals; merge-time changes on main (Optional typing, deterministic identity ids) preserved.

## Known inherited reds (not this PR)
`test_gateway_stateful_epoch_routes` (3 tests, 400-vs-409) fail on clean `origin/main` itself (verified on a fresh worktree) — the merge-ref inherits them until that in-flight work heals; this branch will be re-merged and re-run for the audit-required green-on-exact-merge before any deploy.


---

## Upstream verifier sync (58cbf5f1)

Per review direction, the updated verifier code from the site repo is folded into this PR:

- **Direct Exa evidence repair replaces the Deepline play path as the default repairer** in `semantic_gates` (new `leadpoet_verifier/exa_repair.py`, env-gated **off by default** via `VERIFIER_EXA_EVIDENCE_REPAIR_ENABLED`, honoring the previous Deepline env names as fallback; requires `EXA_API_KEY`). Charged repair POSTs are never retried within a candidate attempt; deterministic failures are cached across retries.
- **Bounded repair receipts**: repair attempts persist as allowlisted, length-capped operational metadata (≤8) on a new `repair_attempts` verdict field.
- `contracts`/`deepline_repair`: upstream style modernization only; the Deepline client remains available for explicit wiring.
- Test suites synced with upstream expectations plus the new exa-repair suite (100 passed + 12 subtests locally with the port/grounding/freshness suites).

Branch re-merged with current main (through `f587fae7`); protected-workflow manifest regenerated for the merged tree.
