### PR TITLE
Convert PriorityMiddleware to pure ASGI (fix anyio deque race dropping epochs)

### DIFF
--- a/gateway/middleware/priority.py
+++ b/gateway/middleware/priority.py
@@ -9,9 +9,8 @@ from collections import Counter
 from dataclasses import dataclass
 from typing import Iterable
 
-from fastapi import Request
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from gateway.utils.ops_registry import set_priority_middleware
 
@@ -149,9 +148,24 @@ class _Pool:
         }
 
 
-class PriorityMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app, max_concurrent_miners: int | None = None):
-        super().__init__(app)
+class PriorityMiddleware:
+    """Pure-ASGI request-priority middleware.
+
+    Implemented as raw ASGI (not Starlette ``BaseHTTPMiddleware``) on purpose.
+    ``BaseHTTPMiddleware`` bridges the downstream app through an anyio task
+    group and memory-object streams; under concurrent load, or when the
+    endpoint raises / the client disconnects mid-request, that task group's
+    ``__aexit__`` iterates its internal task deque while it is mutated,
+    surfacing as ``RuntimeError: deque mutated during iteration`` and turning
+    a valid response into an intermittent 5xx. On the weight path that
+    intermittent 5xx burns the validator's tight submission window and drops
+    the epoch. Awaiting ``self.app`` directly keeps the concurrency-pool
+    accounting identical while removing the task-group wrapper entirely, so
+    the race cannot occur.
+    """
+
+    def __init__(self, app: ASGIApp, max_concurrent_miners: int | None = None):
+        self.app = app
         if max_concurrent_miners is not None and "MINER_MAX_CONCURRENT" not in os.environ:
             miner_class = RouteClass(
                 MINER_CLASS.name,
@@ -169,8 +183,14 @@ class PriorityMiddleware(BaseHTTPMiddleware):
         self.path_counts = Counter()
         set_priority_middleware(self)
 
-    async def dispatch(self, request: Request, call_next):
-        path = request.url.path
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Only HTTP requests are pooled; websockets and lifespan pass through
+        # untouched, exactly as BaseHTTPMiddleware did.
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
         route_class = classify_path(path)
         pool = self.pools[route_class]
         self.path_counts[route_class] += 1
@@ -180,17 +200,19 @@ class PriorityMiddleware(BaseHTTPMiddleware):
             logger.warning(
                 "gateway_request_shed class=%s method=%s path=%s",
                 route_class,
-                request.method,
+                scope.get("method", ""),
                 path,
             )
-            return JSONResponse(
+            response = JSONResponse(
                 status_code=503,
                 content={"detail": "Gateway at capacity - retry shortly"},
                 headers={"Retry-After": "15"},
             )
+            await response(scope, receive, send)
+            return
 
         try:
-            return await call_next(request)
+            await self.app(scope, receive, send)
         finally:
             await pool.release()
 

--- a/tests/test_priority_middleware_asgi.py
+++ b/tests/test_priority_middleware_asgi.py
@@ -1,0 +1,155 @@
+"""PriorityMiddleware is pure ASGI and cannot hit the anyio task-group race.
+
+Starlette ``BaseHTTPMiddleware`` bridges the app through an anyio task group;
+under concurrency, or when the endpoint raises / the client disconnects, that
+group's ``__aexit__`` mutates its task deque during iteration and raises
+``RuntimeError: deque mutated during iteration``, turning a valid response
+into an intermittent 5xx. On the weight path that dropped whole epochs. The
+pure-ASGI implementation awaits the app directly, so the wrapper — and the
+race — are gone, while the concurrency-pool accounting is unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from gateway.middleware.priority import (
+    PriorityMiddleware,
+    RouteClass,
+    _Pool,
+    classify_path,
+)
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+
+def _http_scope(path: str = "/other", method: str = "GET") -> dict:
+    return {"type": "http", "path": path, "method": method, "headers": []}
+
+
+async def _receive() -> dict:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+class _Collector:
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+
+    async def __call__(self, message: dict) -> None:
+        self.messages.append(message)
+
+    @property
+    def status(self) -> int | None:
+        for m in self.messages:
+            if m["type"] == "http.response.start":
+                return m["status"]
+        return None
+
+
+def test_classify_path_unchanged():
+    assert classify_path("/weights/submit/v2") == "validator"
+    assert classify_path("/epoch/24123") == "validator"
+    assert classify_path("/fulfillment/requests/active") == "miner"
+    assert classify_path("/anything-else") == "other"
+
+
+def test_http_request_passes_through_and_releases_slot():
+    async def app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    mw = PriorityMiddleware(app)
+    send = _Collector()
+    asyncio.run(mw(_http_scope("/weights/submit/v2"), _receive, send))
+
+    assert send.status == 200
+    # The validator slot must be fully released after a normal response.
+    assert mw.pools["validator"].in_flight == 0
+
+
+def test_downstream_exception_releases_slot_and_propagates():
+    # This is the exact scenario the old BaseHTTPMiddleware masked as
+    # "deque mutated during iteration": the endpoint raises. Pure ASGI must
+    # propagate the real error AND release the slot in finally.
+    async def app(scope, receive, send):
+        raise RuntimeError("endpoint failed")
+
+    mw = PriorityMiddleware(app)
+    send = _Collector()
+    with pytest.raises(RuntimeError, match="endpoint failed"):
+        asyncio.run(mw(_http_scope("/weights/submit/v2"), _receive, send))
+
+    assert mw.pools["validator"].in_flight == 0  # released despite the raise
+
+
+def test_non_http_scope_passes_through_untouched():
+    seen = {}
+
+    async def app(scope, receive, send):
+        seen["type"] = scope["type"]
+
+    mw = PriorityMiddleware(app)
+    send = _Collector()
+    for kind in ("websocket", "lifespan"):
+        asyncio.run(mw({"type": kind}, _receive, send))
+        assert seen["type"] == kind
+    # No HTTP pooling occurred for non-http scopes.
+    assert all(p.requests == 0 for p in mw.pools.values())
+
+
+def test_shed_returns_503_without_calling_app():
+    async def app(scope, receive, send):
+        raise AssertionError("app must not run when the request is shed")
+
+    mw = PriorityMiddleware(app)
+    # max_waiting=0 makes acquire() shed every request deterministically.
+    mw.pools["other"] = _Pool(RouteClass("other", 1, 0, 1.0))
+    send = _Collector()
+    asyncio.run(mw(_http_scope("/random-path"), _receive, send))
+
+    assert send.status == 503
+    assert mw.pools["other"].shed == 1
+    assert mw.pools["other"].in_flight == 0
+
+
+def test_no_slot_leak_under_repeated_exceptions():
+    async def app(scope, receive, send):
+        raise RuntimeError("boom")
+
+    mw = PriorityMiddleware(app)
+
+    async def drive():
+        for _ in range(50):
+            with pytest.raises(RuntimeError):
+                await mw(_http_scope("/weights/submit/v2"), _receive, _Collector())
+
+    asyncio.run(drive())
+    # 50 failing requests must leave zero in-flight and full capacity.
+    assert mw.pools["validator"].in_flight == 0
+    assert (
+        mw.pools["validator"].semaphore._value
+        == mw.pools["validator"].route_class.max_concurrent
+    )
+
+
+def test_integration_in_real_starlette_stack():
+    async def ok(request):
+        return PlainTextResponse("ok")
+
+    async def boom(request):
+        raise RuntimeError("kaboom")
+
+    app = Starlette(routes=[Route("/validate", ok), Route("/boom", boom)])
+    app.add_middleware(PriorityMiddleware, max_concurrent_miners=75)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    assert client.get("/validate").status_code == 200
+    # An unhandled endpoint error becomes a clean 500 via ServerErrorMiddleware,
+    # never a masked deque error, and the slot is released.
+    assert client.get("/boom").status_code == 500
+    # Subsequent requests still succeed (no slot leak from the error above).
+    assert client.get("/validate").status_code == 200


### PR DESCRIPTION
## Root cause

The gateway intermittently returned 5xx on `/weights/submit/v2` (and fulfillment/allocation endpoints). On the weight path that intermittent 5xx burned the primary validator's tight ~45-block submission window and dropped whole epochs (`Refusing stale weight submission for epoch N`, primary + auditors go stale). A bundle was produced, but the on-chain `set_weights` never landed.

The gateway-side error behind the 503 (`Authoritative V2 persistence/publication failed closed` wraps it) is, from the live traceback:

```
RuntimeError: deque mutated during iteration
  anyio/_backends/_asyncio.py __aexit__
  starlette/_utils.py collapse_excgroups
  starlette/middleware/base.py:190  (BaseHTTPMiddleware.__call__)
```

This is the well-known **Starlette `BaseHTTPMiddleware` + anyio task-group race**. `PriorityMiddleware(BaseHTTPMiddleware)` wrapped every request via `call_next`, which bridges the downstream app through an anyio task group + memory-object streams. Under concurrent load — or when the endpoint raises / the client disconnects mid-request — the group's `__aexit__` iterates its internal task deque while it is being mutated, surfacing as an intermittent `RuntimeError` that masks a valid response as a 5xx. Confirmed versions on the gateway: **anyio 4.14.2, starlette 0.37.2**. Because this middleware wraps *every* request, it is the likely source of much of the intermittent 502/503/500 seen across the gateway under load, not just this epoch.

## Fix

Reimplement `PriorityMiddleware` as **raw ASGI** — an `async def __call__(self, scope, receive, send)` that awaits `self.app` directly instead of subclassing `BaseHTTPMiddleware`/`call_next`. This is exactly the Starlette-maintainer-recommended remedy for this bug: it removes the anyio task-group wrapper (and thus the race) while keeping everything else identical.

**Unchanged:** the concurrency-pool accounting (`acquire`/shed/`release`), `classify_path`, all route classes and env knobs, `path_counts`, `snapshot()`, and `set_priority_middleware()` registration. `add_middleware(PriorityMiddleware, max_concurrent_miners=75)` wiring is unchanged (Starlette instantiates `cls(app, **options)`), and no code used the old `.dispatch` API (only `main.py` add_middleware and the `__init__` re-export reference the class). Non-http scopes (websocket/lifespan) pass through untouched, as before.

## Verification

`tests/test_priority_middleware_asgi.py` (7, all green):
- http pass-through + slot fully released
- **downstream-exception propagation with slot released** — the exact scenario the old wrapper masked as the deque error
- non-http scope passthrough (no pooling)
- shed → 503 without calling the app
- no slot leak across 50 consecutive failing requests (semaphore restored to full capacity)
- real Starlette-stack integration: 200 / unhandled-error → clean 500 / 200 (no leak)

## Scope note

This is `gateway/middleware/priority.py` (the flood-protection path, recently touched by `8af39b1f`/`557e0076`) — request-path-critical, so it warrants review. The change is a mechanical BaseHTTPMiddleware→ASGI port with behavior-preserving tests; it does not alter the pooling policy or limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)