### PR TITLE
Log the real cause when V2 allocation fails closed

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -3931,9 +3931,13 @@ class Validator(BaseValidatorNeuron):
                 },
             }
         except Exception as exc:
+            # bt.logging does not interpolate printf-style args — a "%s"
+            # template prints literally and the cause is dropped, which is
+            # exactly how epoch 24125's allocation failures became
+            # undiagnosable. Pre-format so the cause always lands in the log.
             bt.logging.error(
-                "Authoritative V2 Research Lab allocation failed closed: %s",
-                exc,
+                "Authoritative V2 Research Lab allocation failed closed: "
+                f"{type(exc).__name__}: {exc}"
             )
             return {
                 "abort_chain_submission": True,


### PR DESCRIPTION
One-line diagnosability fix from the epoch-24125 miss.

**What happened:** during 24125's submission window the primary's allocation fetch got HTTP 500 from the gateway ten times and the pre-submission guard blocked weights (`authoritative_v2_allocation_unavailable`). The only log line was:

```
ERROR | HTTP Error 500: Internal Server Error - Authoritative V2 Research Lab allocation failed closed: %s
```

`bt.logging` does not interpolate printf-style args — the `%s` printed literally and the actual cause was dropped, exactly when it was needed. (Probing the endpoint directly afterwards showed the live cause: `deque mutated during iteration` — the HPACK race, since the running gateway predates the 0fa2af00 HTTP/1 pin.)

**Fix:** pre-format the message (`type(exc).__name__: exc`) so the cause always lands in the log regardless of the logging backend. The structured return already preserved `errors=[str(exc)]`; this makes the printed line match.

Checked for siblings: this is the only printf-style `bt.logging` call with args in `neurons/validator.py`; the new `auditor_event` logging in `auditor_validator.py` uses stdlib `logging`, which interpolates correctly — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)