### PR TITLE
Build each attested allocation at most once per epoch

### DIFF
--- a/gateway/research_lab/api.py
+++ b/gateway/research_lab/api.py
@@ -7,6 +7,7 @@ require explicit Research Lab flags and write only Research Lab tables/events.
 from __future__ import annotations
 
 import asyncio
+from collections import OrderedDict
 import copy
 from datetime import datetime, timezone
 import json
@@ -3057,6 +3058,57 @@ async def get_research_lab_live_allocation(
         raise HTTPException(status_code=500, detail=f"Research Lab allocation unavailable: {str(exc)[:200]}") from exc
 
 
+# Assembling one attested allocation bundle is expensive: it reconstructs the
+# full ancestry receipt graph (hundreds of chunked reads over the large
+# receipt tables) and takes tens of seconds. The validator polls this endpoint
+# inside a fixed on-chain submission window and retries on slow responses, so
+# without coordination every retry — and every concurrent poll — launches a
+# fresh rebuild. The rebuilds then contend for the database pool and the
+# enclave, each one slowing past the validator's fetch timeout, so the
+# validator never receives an allocation and its fail-closed guard blocks the
+# weight submission for the whole epoch. The assembled bundle is deterministic
+# for a given epoch (only a cosmetic bundle_id and generated_at timestamp vary
+# between builds), so it is safe to build it at most once per epoch and serve
+# every other caller from that result.
+_ALLOCATION_HANDOFF_CACHE: "OrderedDict[int, tuple[float, dict[str, Any]]]" = (
+    OrderedDict()
+)
+_ALLOCATION_BUILD_LOCKS: dict[int, asyncio.Lock] = {}
+_ALLOCATION_CACHE_TTL_SECONDS = 300.0
+_ALLOCATION_CACHE_MAX_EPOCHS = 16
+
+
+def _allocation_handoff_cache_get(epoch: int) -> Optional[dict[str, Any]]:
+    entry = _ALLOCATION_HANDOFF_CACHE.get(int(epoch))
+    if entry is None:
+        return None
+    expires_at, handoff = entry
+    if time.monotonic() >= expires_at:
+        _ALLOCATION_HANDOFF_CACHE.pop(int(epoch), None)
+        return None
+    _ALLOCATION_HANDOFF_CACHE.move_to_end(int(epoch))
+    return handoff
+
+
+def _allocation_handoff_cache_put(epoch: int, handoff: dict[str, Any]) -> None:
+    _ALLOCATION_HANDOFF_CACHE[int(epoch)] = (
+        time.monotonic() + _ALLOCATION_CACHE_TTL_SECONDS,
+        handoff,
+    )
+    _ALLOCATION_HANDOFF_CACHE.move_to_end(int(epoch))
+    while len(_ALLOCATION_HANDOFF_CACHE) > _ALLOCATION_CACHE_MAX_EPOCHS:
+        evicted, _ = _ALLOCATION_HANDOFF_CACHE.popitem(last=False)
+        _ALLOCATION_BUILD_LOCKS.pop(evicted, None)
+
+
+def _allocation_build_lock(epoch: int) -> asyncio.Lock:
+    lock = _ALLOCATION_BUILD_LOCKS.get(int(epoch))
+    if lock is None:
+        lock = asyncio.Lock()
+        _ALLOCATION_BUILD_LOCKS[int(epoch)] = lock
+    return lock
+
+
 @router.get("/allocations/attested/{epoch}")
 async def get_research_lab_attested_allocation(
     epoch: int,
@@ -3068,9 +3120,34 @@ async def get_research_lab_attested_allocation(
     _require_enabled(config.api_enabled, "Research Lab gateway API is disabled")
     _require_enabled(config.reports_enabled, "Research Lab reports are disabled")
     _require_enabled(config.shadow_bundles_enabled, "Research Lab report bundles are disabled")
+    # The guard rejects future epochs and decides snapshot persistence; it must
+    # run on every request and is cheap relative to the bundle build.
     persist_snapshot = await _allocation_epoch_guard_and_persistence(
         config, int(epoch), x_leadpoet_internal_key
     )
+    cached_handoff = _allocation_handoff_cache_get(int(epoch))
+    if cached_handoff is not None:
+        return cached_handoff
+    # Serialize builds per epoch so concurrent polls and retries wait for one
+    # rebuild instead of launching contending ones. Re-check the cache after
+    # acquiring the lock: the first builder populates it for everyone waiting.
+    async with _allocation_build_lock(int(epoch)):
+        cached_handoff = _allocation_handoff_cache_get(int(epoch))
+        if cached_handoff is not None:
+            return cached_handoff
+        return await _build_and_cache_attested_allocation(
+            config=config,
+            epoch=int(epoch),
+            persist_snapshot=persist_snapshot,
+        )
+
+
+async def _build_and_cache_attested_allocation(
+    *,
+    config: "ResearchLabGatewayConfig",
+    epoch: int,
+    persist_snapshot: Any,
+) -> dict[str, Any]:
     attestation: dict[str, Any] = {}
     try:
         bundle = await build_research_lab_allocation_bundle(
@@ -3131,7 +3208,7 @@ async def get_research_lab_attested_allocation(
                     receipt_graph["host_operations"]
                 ),
             }
-        return build_allocation_handoff_v2(
+        handoff = build_allocation_handoff_v2(
             bundle=bundle,
             receipt_graph=receipt_graph,
             lineage_bindings=lineage_bindings,
@@ -3143,6 +3220,10 @@ async def get_research_lab_attested_allocation(
             status_code=503,
             detail="Research Lab allocation V2 handoff is invalid",
         ) from exc
+    # Only fully-assembled bundles are cached; failures above raise and are
+    # retried by the next caller without poisoning the cache.
+    _allocation_handoff_cache_put(int(epoch), handoff)
+    return handoff
 
 
 async def _verify_signed_miner(payload: object) -> None:

--- a/tests/test_allocation_endpoint_cache.py
+++ b/tests/test_allocation_endpoint_cache.py
@@ -1,0 +1,175 @@
+"""The attested-allocation endpoint must build each epoch's bundle at most once.
+
+Assembling a bundle reconstructs the full ancestry receipt graph and takes tens
+of seconds. The validator polls this endpoint inside a fixed on-chain window and
+retries slow responses, so without coordination each retry and each concurrent
+poll launched a fresh rebuild; the rebuilds contended for the database pool and
+the enclave, every one slowed past the validator's fetch timeout, and the
+validator's fail-closed guard then blocked the epoch's weight submission. These
+tests pin the coordination: one build per epoch, cache hits skip the build,
+failures are not cached, the guard runs on every request, and the cache expires.
+"""
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.research_lab import api
+
+
+def _config():
+    return SimpleNamespace(
+        api_enabled=True,
+        reports_enabled=True,
+        shadow_bundles_enabled=True,
+        reimbursements_enabled=False,
+        weight_mutation_enabled=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_allocation_cache():
+    api._ALLOCATION_HANDOFF_CACHE.clear()
+    api._ALLOCATION_BUILD_LOCKS.clear()
+    yield
+    api._ALLOCATION_HANDOFF_CACHE.clear()
+    api._ALLOCATION_BUILD_LOCKS.clear()
+
+
+def _install(monkeypatch, *, build, guard=None, handoff=None):
+    monkeypatch.setattr(api.ResearchLabGatewayConfig, "from_env", _config)
+    monkeypatch.setattr(api, "build_research_lab_allocation_bundle", build)
+    if guard is None:
+        async def guard(config, epoch, key):
+            return False
+    monkeypatch.setattr(api, "_allocation_epoch_guard_and_persistence", guard)
+    if handoff is None:
+        def handoff(**kwargs):
+            return {"handoff_for": kwargs["bundle"]["epoch"]}
+    monkeypatch.setattr(
+        "leadpoet_canonical.allocation_handoff_v2.build_allocation_handoff_v2",
+        handoff,
+    )
+
+
+def _matched_build(counter, *, delay=0.0):
+    receipt = {"receipt_hash": "sha256:" + "1" * 64}
+    graph = {"root_receipt_hash": receipt["receipt_hash"], "receipts": [receipt]}
+
+    async def build(**kwargs):
+        counter["n"] += 1
+        if delay:
+            await asyncio.sleep(delay)
+        kwargs["attestation_out"].update({
+            "status": "matched",
+            "receipt": receipt,
+            "receipt_graph": graph,
+            "lineage_bindings": [],
+            "lineage_complete": True,
+            "persistence": {"root_receipt_hash": receipt["receipt_hash"]},
+        })
+        return {"bundle_type": "live", "epoch": kwargs["epoch"]}
+
+    return build
+
+
+@pytest.mark.asyncio
+async def test_repeat_request_serves_cache_without_rebuild(monkeypatch):
+    counter = {"n": 0}
+    _install(monkeypatch, build=_matched_build(counter))
+
+    first = await api.get_research_lab_attested_allocation(7)
+    second = await api.get_research_lab_attested_allocation(7)
+
+    assert first == second == {"handoff_for": 7}
+    assert counter["n"] == 1  # built once, second served from cache
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_build_once(monkeypatch):
+    counter = {"n": 0}
+    # A slow build so all pollers overlap on the same in-flight rebuild.
+    _install(monkeypatch, build=_matched_build(counter, delay=0.2))
+
+    results = await asyncio.gather(
+        *[api.get_research_lab_attested_allocation(9) for _ in range(12)]
+    )
+
+    assert all(r == {"handoff_for": 9} for r in results)
+    assert counter["n"] == 1  # 12 concurrent pollers, exactly one build
+
+
+@pytest.mark.asyncio
+async def test_distinct_epochs_build_independently(monkeypatch):
+    counter = {"n": 0}
+    _install(monkeypatch, build=_matched_build(counter))
+
+    await api.get_research_lab_attested_allocation(1)
+    await api.get_research_lab_attested_allocation(2)
+    await api.get_research_lab_attested_allocation(1)
+
+    assert counter["n"] == 2  # one build per distinct epoch, epoch 1 reused
+
+
+@pytest.mark.asyncio
+async def test_failed_build_is_not_cached(monkeypatch):
+    counter = {"n": 0}
+
+    async def failing_build(**kwargs):
+        counter["n"] += 1
+        raise ValueError("allocation not ready")
+
+    _install(monkeypatch, build=failing_build)
+
+    for _ in range(3):
+        with pytest.raises(Exception):
+            await api.get_research_lab_attested_allocation(5)
+
+    assert counter["n"] == 3  # every retry rebuilds; failures never cached
+
+
+@pytest.mark.asyncio
+async def test_guard_runs_on_every_request_including_cache_hits(monkeypatch):
+    counter = {"n": 0}
+    guard_calls = {"n": 0}
+
+    async def guard(config, epoch, key):
+        guard_calls["n"] += 1
+        return False
+
+    _install(monkeypatch, build=_matched_build(counter), guard=guard)
+
+    await api.get_research_lab_attested_allocation(3)
+    await api.get_research_lab_attested_allocation(3)
+    await api.get_research_lab_attested_allocation(3)
+
+    assert counter["n"] == 1  # one build
+    assert guard_calls["n"] == 3  # guard (future-epoch + persistence) every time
+
+
+@pytest.mark.asyncio
+async def test_cache_entry_expires_after_ttl(monkeypatch):
+    counter = {"n": 0}
+    _install(monkeypatch, build=_matched_build(counter))
+    monkeypatch.setattr(api, "_ALLOCATION_CACHE_TTL_SECONDS", 0.05)
+
+    await api.get_research_lab_attested_allocation(4)
+    assert counter["n"] == 1
+    time.sleep(0.1)  # let the entry expire
+    await api.get_research_lab_attested_allocation(4)
+    assert counter["n"] == 2  # rebuilt after expiry
+
+
+@pytest.mark.asyncio
+async def test_cache_is_bounded_by_max_epochs(monkeypatch):
+    counter = {"n": 0}
+    _install(monkeypatch, build=_matched_build(counter))
+    monkeypatch.setattr(api, "_ALLOCATION_CACHE_MAX_EPOCHS", 4)
+
+    for epoch in range(10):
+        await api.get_research_lab_attested_allocation(epoch)
+
+    assert len(api._ALLOCATION_HANDOFF_CACHE) <= 4
+    assert len(api._ALLOCATION_BUILD_LOCKS) <= 4  # evicted locks are dropped too


### PR DESCRIPTION
## Problem

The validator fetches its allocation from `GET /research-lab/allocations/attested/{epoch}` inside a fixed on-chain submission window, and its pre-submission guard is fail-closed: no allocation means it will not set weights for that epoch.

Measured on the live gateway:
- Assembling one allocation bundle takes **~60s** and **586 DB round-trips**, dominated by **319 reads of `transport_attempts_v2` (14.5s, ~15.8k rows)** and a **5.2s single read of the `finalized_allocation_epochs_v2` view**, plus enclave round-trips. The endpoint reconstructs the full ancestry receipt graph on every call and does **not** cache.
- The validator's fetch timeout is **90s**. A single uncontended build (60s) fits, but the validator retries slow responses and polls concurrently — and with no caching, every retry and every concurrent poll launches a fresh 60s rebuild. Under production load the rebuilds contend for the DB pool and the enclave, each slows past 90s, the validator gets `allocation_unavailable` (validator log: `Research Lab pre-submission guard blocked weights: authoritative_v2_allocation_unavailable`), and the epoch's weight submission is blocked.
- A blocked epoch publishes no bundle, so audit validators have nothing to mirror and also stop submitting.

## Fix

Build each epoch's bundle at most once and serve every other caller from that result. The assembled bundle is deterministic for a given epoch — building epoch 24124 twice on the live gateway produced byte-identical output across **497 of 499** fields, the only two differences being a cosmetic `bundle_id` and `generated_at` timestamp — so caching is safe.

- A **per-epoch `asyncio.Lock`** serializes builds: the first request for an epoch builds while holding the lock; concurrent and retry requests wait and are served the cached result. One ~60s build completes inside the 90s window instead of many contending builds all timing out.
- A **short-TTL (300s), size-bounded (16 epochs)** cache holds assembled bundles.
- The epoch guard (future-epoch rejection + snapshot persistence) still runs on **every** request. Only fully-assembled bundles are cached, so a build failure is retried by the next caller without poisoning the cache.

## Verification

- Profiled the live endpoint to obtain the per-table call counts, timings, and row volumes above; measured the single-build time (60s) and the validator timeout (90s).
- Confirmed determinism by building the same epoch twice against the live gateway (497/499 fields identical).
- New tests (`tests/test_allocation_endpoint_cache.py`): one build per epoch under 12 concurrent requests, cache hit skips the rebuild, per-epoch isolation, failures never cached, guard runs on every request, TTL expiry, cache bounding.
- Full run green on py3.11: the new tests plus the existing allocation/validator/weight-submission suites (`test_attested_allocation_api`, `test_attested_allocation_validator`, `test_weight_submission_readiness_v2`, `test_allocation_handoff_v2`) — 27 passed, no regressions. `gateway.research_lab.api` imports cleanly.

## Scope note

This is the systemic blocker: it restores the validator's ability to fetch its allocation in-window, which unblocks weight submission and lets the healthy audit validators mirror again. Audit validators that are stale for a separate, node-local verification reason are unaffected by this change and need their own operator restart onto current code.

A complementary follow-up (not in this PR to keep it focused and schema-free) is to index/optimize the `finalized_allocation_epochs_v2` read (5.2s for 13 rows) to shrink the first-build time further.
