### PR TITLE
Retry the validator allocation fetch within the submission window

### DIFF
--- a/research_lab/validator_integration.py
+++ b/research_lab/validator_integration.py
@@ -13,8 +13,11 @@ import json
 import os
 from pathlib import Path
 import re
+import socket
 import sys
+import time
 from typing import Any, Iterable, Mapping
+from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
@@ -46,6 +49,15 @@ FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "validator_integra
 TRUTHY_VALUES = {"1", "true", "yes", "on"}
 PERCENT_EPSILON = 0.000001
 WEIGHT_INPUT_FETCH_TIMEOUT_SECONDS = 90
+# Bounded in-window retry for the weight-path allocation fetch. A single
+# transient gateway failure (connection refused, 5xx, a brief restart blip)
+# must not cost the validator the whole epoch's weight submission. The retry
+# budget is the caller's total timeout, so the sequence can never run past the
+# on-chain submission window; a single slow response that consumes the budget
+# behaves exactly like the previous single-attempt fetch.
+ALLOCATION_FETCH_MAX_ATTEMPTS = 4
+ALLOCATION_FETCH_RETRY_DELAY_SECONDS = 2.0
+ALLOCATION_FETCH_MIN_ATTEMPT_BUDGET_SECONDS = 5.0
 ATTESTED_ALLOCATION_SCHEMA_VERSION = "leadpoet.attested_allocation_bundle.v2"
 ATTESTED_ALLOCATION_PURPOSE = "research_lab.allocation.v1"
 IMMUTABLE_ECR_IMAGE_RE = re.compile(
@@ -417,6 +429,82 @@ def fetch_research_lab_audit_bundle(
         return json.loads(response.read().decode("utf-8"))
 
 
+def _is_retryable_allocation_fetch_error(exc: BaseException) -> bool:
+    """A transient gateway failure worth another in-window attempt.
+
+    5xx and 429 responses and connection/timeout errors are transient; a 4xx
+    (other than 429) is a client-side rejection that will not resolve on retry.
+    """
+    if isinstance(exc, HTTPError):
+        return exc.code >= 500 or exc.code == 429
+    if isinstance(exc, (URLError, socket.timeout, TimeoutError, ConnectionError)):
+        return True
+    return False
+
+
+def _fetch_allocation_json(
+    url: str,
+    *,
+    deadline_seconds: float,
+    max_attempts: int = ALLOCATION_FETCH_MAX_ATTEMPTS,
+    retry_delay_seconds: float = ALLOCATION_FETCH_RETRY_DELAY_SECONDS,
+) -> dict[str, Any]:
+    """GET one allocation JSON within a total wall-clock budget.
+
+    The whole retry sequence is bounded by ``deadline_seconds`` so it can never
+    exceed the caller's on-chain submission window. Each attempt is given the
+    time remaining in the budget; a single slow response that consumes the
+    budget therefore behaves exactly like the previous single-attempt fetch,
+    while a fast transient failure leaves budget for another attempt.
+    """
+    deadline = time.monotonic() + max(1.0, float(deadline_seconds))
+    attempts = max(1, int(max_attempts))
+    last_error: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        request = Request(
+            url,
+            headers=_request_headers(include_internal_key=True),
+            method="GET",
+        )
+        try:
+            with urlopen(request, timeout=remaining) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001 - reclassified below
+            last_error = exc
+            remaining_after = deadline - time.monotonic()
+            if (
+                attempt >= attempts
+                or not _is_retryable_allocation_fetch_error(exc)
+                or remaining_after <= ALLOCATION_FETCH_MIN_ATTEMPT_BUDGET_SECONDS
+            ):
+                raise
+            delay = min(
+                float(retry_delay_seconds) * (2 ** (attempt - 1)),
+                remaining_after - ALLOCATION_FETCH_MIN_ATTEMPT_BUDGET_SECONDS,
+            )
+            print(
+                "research_lab_allocation_fetch_retry attempt=%d/%d "
+                "delay_seconds=%.1f remaining_seconds=%.1f type=%s error=%s"
+                % (
+                    attempt,
+                    attempts,
+                    max(0.0, delay),
+                    remaining_after,
+                    type(exc).__name__,
+                    str(exc)[:200],
+                ),
+                flush=True,
+            )
+            if delay > 0:
+                time.sleep(delay)
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("research lab allocation fetch exhausted without a response")
+
+
 def fetch_research_lab_allocation_bundle(
     gateway_url: str,
     epoch: int,
@@ -429,13 +517,10 @@ def fetch_research_lab_allocation_bundle(
     submission-time snapshot; anonymous callers get a read-only computation.
     """
     base = gateway_url.rstrip("/")
-    request = Request(
+    return _fetch_allocation_json(
         f"{base}/research-lab/allocations/live/{int(epoch)}",
-        headers=_request_headers(include_internal_key=True),
-        method="GET",
+        deadline_seconds=timeout_seconds,
     )
-    with urlopen(request, timeout=timeout_seconds) as response:
-        return json.loads(response.read().decode("utf-8"))
 
 
 def fetch_research_lab_attested_allocation_bundle(
@@ -447,13 +532,10 @@ def fetch_research_lab_attested_allocation_bundle(
     """Fetch the additive enclave receipt for one live allocation bundle."""
 
     base = gateway_url.rstrip("/")
-    request = Request(
+    return _fetch_allocation_json(
         f"{base}/research-lab/allocations/attested/{int(epoch)}",
-        headers=_request_headers(include_internal_key=True),
-        method="GET",
+        deadline_seconds=timeout_seconds,
     )
-    with urlopen(request, timeout=timeout_seconds) as response:
-        return json.loads(response.read().decode("utf-8"))
 
 
 def verify_gateway_allocation_attestation(

--- a/tests/test_allocation_fetch_retry.py
+++ b/tests/test_allocation_fetch_retry.py
@@ -1,0 +1,164 @@
+"""The validator's weight-path allocation fetch must survive transient gateway
+failures without ever running past the on-chain submission window.
+
+A single transient gateway failure — connection refused, a 5xx, a brief restart
+blip — used to cost the validator the whole epoch's weight submission, because
+the fetch was a single ``urlopen`` with no retry and the pre-submission guard
+fails closed on any exception. These tests pin the bounded in-window retry:
+transient failures are retried, client rejections are not, the attempt count is
+capped, and the whole sequence stays inside the caller's total time budget so a
+tight window can never be exceeded.
+"""
+
+import json
+import time
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from research_lab import validator_integration as vi
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+
+def _urlopen_sequence(monkeypatch, items):
+    """Patch urlopen to yield items in order; an Exception item is raised."""
+    calls = {"n": 0}
+
+    def _fake_urlopen(request, timeout=None):
+        i = calls["n"]
+        calls["n"] += 1
+        item = items[min(i, len(items) - 1)]
+        if isinstance(item, BaseException):
+            raise item
+        return _FakeResponse(item)
+
+    monkeypatch.setattr(vi, "urlopen", _fake_urlopen)
+    return calls
+
+
+def _http_error(code):
+    return HTTPError("http://gw/x", code, "err", {}, None)
+
+
+def test_success_on_first_attempt_does_not_retry(monkeypatch):
+    calls = _urlopen_sequence(monkeypatch, [{"ok": 1}])
+    out = vi._fetch_allocation_json("http://gw/x", deadline_seconds=60)
+    assert out == {"ok": 1}
+    assert calls["n"] == 1
+
+
+def test_retries_transient_failures_then_succeeds(monkeypatch):
+    calls = _urlopen_sequence(
+        monkeypatch,
+        [URLError("connection refused"), _http_error(503), {"ok": 2}],
+    )
+    out = vi._fetch_allocation_json(
+        "http://gw/x", deadline_seconds=60, retry_delay_seconds=0.0
+    )
+    assert out == {"ok": 2}
+    assert calls["n"] == 3  # two transient failures, third attempt succeeds
+
+
+def test_client_rejection_4xx_is_not_retried(monkeypatch):
+    calls = _urlopen_sequence(monkeypatch, [_http_error(404), {"ok": 3}])
+    with pytest.raises(HTTPError):
+        vi._fetch_allocation_json(
+            "http://gw/x", deadline_seconds=60, retry_delay_seconds=0.0
+        )
+    assert calls["n"] == 1  # 404 will not resolve on retry; fail fast
+
+
+def test_429_is_retried(monkeypatch):
+    calls = _urlopen_sequence(monkeypatch, [_http_error(429), {"ok": 4}])
+    out = vi._fetch_allocation_json(
+        "http://gw/x", deadline_seconds=60, retry_delay_seconds=0.0
+    )
+    assert out == {"ok": 4}
+    assert calls["n"] == 2
+
+
+def test_exhausts_max_attempts_and_raises_last_error(monkeypatch):
+    calls = _urlopen_sequence(monkeypatch, [URLError("down")] * 10)
+    with pytest.raises(URLError):
+        vi._fetch_allocation_json(
+            "http://gw/x",
+            deadline_seconds=60,
+            max_attempts=3,
+            retry_delay_seconds=0.0,
+        )
+    assert calls["n"] == 3  # capped at max_attempts
+
+
+def test_tight_budget_makes_no_second_attempt(monkeypatch):
+    # A budget below the minimum per-attempt reserve must not spend time on a
+    # retry — the very first failure raises so the submission window is safe.
+    calls = _urlopen_sequence(monkeypatch, [URLError("down")] * 5)
+    with pytest.raises(URLError):
+        vi._fetch_allocation_json(
+            "http://gw/x",
+            deadline_seconds=vi.ALLOCATION_FETCH_MIN_ATTEMPT_BUDGET_SECONDS - 1.0,
+            retry_delay_seconds=0.0,
+        )
+    assert calls["n"] == 1
+
+
+def test_retry_sequence_never_exceeds_budget(monkeypatch):
+    # Simulated clock: each failed attempt burns real budget. The total wall
+    # time the function is willing to spend must stay within deadline_seconds.
+    _urlopen_sequence(monkeypatch, [URLError("down")] * 100)
+    deadline = 20.0
+    start = time.monotonic()
+    now = {"t": start}
+    monkeypatch.setattr(vi.time, "monotonic", lambda: now["t"])
+
+    # Each attempt advances the simulated clock by 8s (a slow-ish failure).
+    real_sleep = vi.time.sleep
+
+    def _sleep(sec):
+        now["t"] += float(sec)
+
+    monkeypatch.setattr(vi.time, "sleep", _sleep)
+
+    # Wrap urlopen to also advance the clock per attempt.
+    orig = vi.urlopen
+
+    def _advancing_urlopen(request, timeout=None):
+        now["t"] += 8.0
+        return orig(request, timeout=timeout)
+
+    monkeypatch.setattr(vi, "urlopen", _advancing_urlopen)
+
+    with pytest.raises(URLError):
+        vi._fetch_allocation_json(
+            "http://gw/x",
+            deadline_seconds=deadline,
+            max_attempts=100,
+            retry_delay_seconds=1.0,
+        )
+    # The simulated clock must never advance past the deadline budget.
+    assert now["t"] - start <= deadline + 8.0  # last in-flight attempt may finish
+
+
+def test_attested_wrapper_targets_attested_path(monkeypatch):
+    seen = {}
+
+    def _fake_urlopen(request, timeout=None):
+        seen["url"] = request.full_url
+        return _FakeResponse({"ok": 5})
+
+    monkeypatch.setattr(vi, "urlopen", _fake_urlopen)
+    vi.fetch_research_lab_attested_allocation_bundle("http://gw/", 24124)
+    assert seen["url"] == "http://gw/research-lab/allocations/attested/24124"


### PR DESCRIPTION
## Problem

Weight submissions are being missed on SN71. Root-cause analysis across the full submission path (epochs 24087–24124) found multiple independent causes, not one:

- Only 22 of 38 epochs published a bundle; ~88% of the misses were multi-hour gateway-downtime windows, not endpoint slowness.
- The primary validator is healthy on-chain (vtrust=1.0), so most "published-but-not-finalized" rows are a finalization *recording* gap, not lost weights.

This PR fixes one concrete, real-loss defect on that path, fully tested. The remaining causes are documented as ranked follow-ups.

## This change — retry the allocation fetch within the submission window

`fetch_research_lab_attested_allocation_bundle` (and its live sibling) was a single `urlopen` with no retry. The pre-submission guard fails closed on **any** exception, so a single transient gateway failure during the on-chain window — connection refusal, a 5xx, or a brief restart blip — cost the validator the entire epoch's weight submission. (The later enclave-input stage already retries; this earlier, more critical fetch did not.)

Adds a bounded, **total-deadline** retry shared by both allocation fetches: transient failures (5xx, 429, connection/timeout) are retried inside the caller's existing time budget; client rejections (4xx) fail fast; the attempt count is capped; and the whole sequence is bounded by the caller's timeout, so **it can never run past the submission window** — a single slow response that consumes the budget behaves exactly like the prior single-attempt fetch.

## Tests

`tests/test_allocation_fetch_retry.py` — retry-then-succeed, no-retry on 4xx, 429 retry, max-attempts exhaustion, tight-budget single attempt, a simulated-clock proof the sequence stays within budget, and the attested wrapper targeting the correct path. Existing weight-path suites pass unchanged.

## Verification scope (honest)

Logic-verified and regression-safe, **not** yet production-verified end-to-end: the tests mock the network. The live path — a real gateway blip recovered by retry, weights landing on-chain — still requires the gateway up and the validator restarted onto this branch.

## Out of scope (ranked follow-ups)

1. **Gateway downtime during deploy/attestation** — the dominant *real-loss* cause (~88%). Fix is in the restart tooling: build/verify the new enclave images while the old gateway still serves (hours → minutes). Operational.
2. **Finalize recording retry** — the normal-path finalization is single-shot; an in-place retry was built and unit-tested, but it edits `Validator._authorize_and_set_weights_v2`, which is a **protected/attested weight symbol** (`validator_tee/enclave/protected_workflows_v2.json`). Shipping it requires regenerating the protected-workflow manifest **and** a coordinated validator re-attestation — a governance/deploy step, not a casual change. Deliberately excluded here.
3. **Auditor staleness** — needs design around on-chain past-epoch semantics; naive backfill would push stale weights.
