### PR TITLE
Add opt-in infra-only OpenTelemetry for the gateway host

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,56 @@
+# Telemetry — leadpoet-gateway
+
+Opt-in, **infra-only** OpenTelemetry for the gateway HOST process. Off by
+default; ships nothing unless explicitly enabled via env.
+
+## Service
+
+- `service.name`: `leadpoet-gateway` (override with `OTEL_SERVICE_NAME`)
+- Runtime: Python 3.11 / FastAPI (gateway host process, `python -m gateway.main`)
+- Instrumentation: hand-written request middleware in
+  `gateway/observability/otel_bootstrap.py` using the already-pinned
+  `opentelemetry-sdk` / `opentelemetry-exporter-otlp-proto-http` 1.27.0. **No new
+  dependencies; the attested enclaves are not instrumented and their PCR0 is
+  unaffected.**
+- Last regenerated: 2026-07-24
+
+## Enabling (deploy env only — never committed)
+
+Both must be set, or the bootstrap is a complete no-op:
+
+```
+GATEWAY_OTEL_ENABLED=true
+OTEL_EXPORTER_OTLP_ENDPOINT=https://leadpoet.logger.onepatch.dev
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer <token>
+OTEL_SERVICE_NAME=leadpoet-gateway
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+The endpoint and token are set in the gateway host's runtime environment, never
+baked into an image or committed to the repo.
+
+## Spans (hand-instrumented)
+
+| Span name | Kind | Source | When it fires | Attributes |
+|---|---|---|---|---|
+| `<METHOD> <route-template>` | SERVER | `gateway/observability/otel_bootstrap.py` | Once per HTTP request to the gateway host (health probes suppressed) | `http.request.method`, `http.route`, `http.response.status_code`, `duration_ms` |
+
+`http.route` is always the **route template** (e.g.
+`/research-lab/allocations/attested/{epoch}`), never the concrete path.
+
+## What is deliberately NOT emitted
+
+This instrumentation is scoped to protect data. It never records:
+
+- Concrete path ids, hotkeys, epochs (only route templates)
+- Query strings, request bodies, or response bodies
+- Request/response headers (including auth)
+- Database statements or query parameters
+- Any LLM prompt/completion or model I/O — the Research Lab / scoring / model /
+  Langfuse code paths are **not** instrumented
+- Anything from inside the attested enclaves
+
+The only data that leaves the host is operational metadata: which route was hit,
+its HTTP status, and how long it took. This is enough to observe availability,
+latency, and error-rate incidents (e.g. a gateway outage shows as request
+failures / absence of traffic) without exposing business or training data.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,56 +1,69 @@
-# Telemetry — leadpoet-gateway
+# Gateway infra-only telemetry
 
-Opt-in, **infra-only** OpenTelemetry for the gateway HOST process. Off by
-default; ships nothing unless explicitly enabled via env.
+Opt-in OpenTelemetry for the gateway HOST process. One server span per HTTP
+request; nothing else. See `gateway/observability/otel_bootstrap.py` for the
+full contract.
 
-## Service
+## What a span contains — and all it can ever contain
 
-- `service.name`: `leadpoet-gateway` (override with `OTEL_SERVICE_NAME`)
-- Runtime: Python 3.11 / FastAPI (gateway host process, `python -m gateway.main`)
-- Instrumentation: hand-written request middleware in
-  `gateway/observability/otel_bootstrap.py` using the already-pinned
-  `opentelemetry-sdk` / `opentelemetry-exporter-otlp-proto-http` 1.27.0. **No new
-  dependencies; the attested enclaves are not instrumented and their PCR0 is
-  unaffected.**
-- Last regenerated: 2026-07-24
+| attribute | example |
+|---|---|
+| `http.request.method` | `GET` |
+| `http.route` | `/research-lab/allocations/attested/{epoch}` (route *template* — never the concrete path) |
+| `http.response.status_code` | `200` |
+| `duration_ms` | `12.4` |
 
-## Enabling (deploy env only — never committed)
+No bodies, query strings, headers, DB statements, model I/O, prompts, or
+completions. Health/liveness routes are suppressed entirely.
 
-Both must be set, or the bootstrap is a complete no-op:
+## Enabling (gateway host only)
 
+```bash
+export GATEWAY_OTEL_ENABLED=1
+export GATEWAY_OTEL_ENDPOINT="https://<collector>/v1/traces"
+export GATEWAY_OTEL_TOKEN="<token>"            # sent as Authorization: Bearer
+export GATEWAY_OTEL_SERVICE_NAME="leadpoet-gateway"   # optional
 ```
-GATEWAY_OTEL_ENABLED=true
-OTEL_EXPORTER_OTLP_ENDPOINT=https://leadpoet.logger.onepatch.dev
-OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer <token>
-OTEL_SERVICE_NAME=leadpoet-gateway
-OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-```
 
-The endpoint and token are set in the gateway host's runtime environment, never
-baked into an image or committed to the repo.
+Both `GATEWAY_OTEL_ENABLED` and `GATEWAY_OTEL_ENDPOINT` are required; anything
+less is a complete no-op. Wiring failures are swallowed — telemetry can never
+delay or break gateway startup.
 
-## Spans (hand-instrumented)
+## Why the boundary is a guarantee, not a promise
 
-| Span name | Kind | Source | When it fires | Attributes |
-|---|---|---|---|---|
-| `<METHOD> <route-template>` | SERVER | `gateway/observability/otel_bootstrap.py` | Once per HTTP request to the gateway host (health probes suppressed) | `http.request.method`, `http.route`, `http.response.status_code`, `duration_ms` |
+1. **Explicit destination, fixed resource.** The exporter is constructed
+   with explicit `endpoint=`/`headers=` arguments from the private
+   `GATEWAY_OTEL_*` variables, and the provider resource is a fixed
+   attribute dict (the SDK's env-merging resource factory is never used).
+   The standard ambient exporter/resource variables are never read and
+   never set — ambient auto-instrumentation or a stray bare exporter has no
+   destination and no-ops.
+2. **Fail-closed span validator.** Before export every span must have the
+   `gateway.http` instrumentation scope, exactly the four attributes above
+   with the approved types, no events/links/status descriptions, the fixed
+   resource, and a registered route template (or the literal `/_unmatched`).
+   A span violating any of that is dropped entirely — never mutated, never
+   partially exported — and counted in a warning that omits the rejected
+   values.
+3. **CI guard** (`tests/test_otel_boundary_guard.py`) fails the build if:
+   auto-instrumentation packages enter the requirements, a launch path uses
+   the process-wrapping launcher, anything sets the global tracer provider,
+   ambient exporter/resource variables appear anywhere, an OTLP exporter is
+   imported outside the bootstrap module, or the bootstrap stops building a
+   fixed resource / fixed unmatched-route label.
 
-`http.route` is always the **route template** (e.g.
-`/research-lab/allocations/attested/{epoch}`), never the concrete path.
+## Isolation properties
 
-## What is deliberately NOT emitted
+- Dedicated (non-global) tracer provider: Langfuse and every other library
+  are untouched.
+- Unresolved routes export the fixed `/_unmatched` label — a
+  client-controlled path segment is never exported.
+- Gateway host process only — never the attested enclaves; no new
+  dependencies, so no PCR0 change.
 
-This instrumentation is scoped to protect data. It never records:
+## What this does NOT replace
 
-- Concrete path ids, hotkeys, epochs (only route templates)
-- Query strings, request bodies, or response bodies
-- Request/response headers (including auth)
-- Database statements or query parameters
-- Any LLM prompt/completion or model I/O — the Research Lab / scoring / model /
-  Langfuse code paths are **not** instrumented
-- Anything from inside the attested enclaves
-
-The only data that leaves the host is operational metadata: which route was hit,
-its HTTP status, and how long it took. This is enough to observe availability,
-latency, and error-rate incidents (e.g. a gateway outage shows as request
-failures / absence of traffic) without exposing business or training data.
+Code enforcement stops accidental leakage; it is not full security by
+itself. Operationally the collector token should be ingest-only and
+rotated, repository access stays scoped, and the telemetry vendor's
+retention / no-training / deletion terms should be agreed in writing.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -21,13 +21,18 @@ completions. Health/liveness routes are suppressed entirely.
 ```bash
 export GATEWAY_OTEL_ENABLED=1
 export GATEWAY_OTEL_ENDPOINT="https://<collector>/v1/traces"
-export GATEWAY_OTEL_TOKEN="<token>"            # sent as Authorization: Bearer
-export GATEWAY_OTEL_SERVICE_NAME="leadpoet-gateway"   # optional
+export GATEWAY_OTEL_TOKEN="<token>"            # REQUIRED; sent as Authorization: Bearer
 ```
 
-Both `GATEWAY_OTEL_ENABLED` and `GATEWAY_OTEL_ENDPOINT` are required; anything
-less is a complete no-op. Wiring failures are swallowed — telemetry can never
-delay or break gateway startup.
+All three variables are required; anything less is a complete no-op. The
+token must be non-empty (an empty explicit headers dict would let the pinned
+exporter fall back to ambient header variables). The service name is a
+constant (`leadpoet-gateway`), not an environment value. Initialization is
+REFUSED at runtime if any ambient standard exporter variable is present in
+the process environment — a CI grep cannot see variables injected by a
+restart script or the live process env, so the bootstrap checks and logs the
+offending names (never values) and stays off. Wiring failures are swallowed —
+telemetry can never delay or break gateway startup.
 
 ## Why the boundary is a guarantee, not a promise
 
@@ -38,11 +43,14 @@ delay or break gateway startup.
    The standard ambient exporter/resource variables are never read and
    never set — ambient auto-instrumentation or a stray bare exporter has no
    destination and no-ops.
-2. **Fail-closed span validator.** Before export every span must have the
-   `gateway.http` instrumentation scope, exactly the four attributes above
-   with the approved types, no events/links/status descriptions, the fixed
-   resource, and a registered route template (or the literal `/_unmatched`).
-   A span violating any of that is dropped entirely — never mutated, never
+2. **Fail-closed complete-envelope validator.** Before export every span
+   must have the `gateway.http` instrumentation scope with no
+   version/schema metadata, `SERVER` kind, a root context (no parent, empty
+   trace state), exactly the four attributes above with the approved types,
+   a standard HTTP method, a span name equal to exactly `<method> <route>`,
+   no events/links/status descriptions, the fixed resource, and a
+   registered route template (or the literal `/_unmatched`). A span
+   violating any of that is dropped entirely — never mutated, never
    partially exported — and counted in a warning that omits the rejected
    values.
 3. **CI guard** (`tests/test_otel_boundary_guard.py`) fails the build if:

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -530,7 +530,7 @@ app.add_middleware(
 # Optional OpenTelemetry (infra-only, off unless configured)
 # ============================================================
 # Emits request method/route-template/status/duration only when
-# GATEWAY_OTEL_ENABLED and OTEL_EXPORTER_OTLP_ENDPOINT are both set. Never
+# GATEWAY_OTEL_ENABLED and GATEWAY_OTEL_ENDPOINT are both set. Never
 # captures bodies, query strings, DB statements, or LLM/training content, and
 # never touches the enclaves. No-op by default.
 from gateway.observability.otel_bootstrap import configure_gateway_otel

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -526,6 +526,17 @@ app.add_middleware(
     max_concurrent_miners=75  # Pool=150, miners=75, leaves 75 for validators/consensus (doubled miners: 128→256 UIDs)
 )
 
+# ============================================================
+# Optional OpenTelemetry (infra-only, off unless configured)
+# ============================================================
+# Emits request method/route-template/status/duration only when
+# GATEWAY_OTEL_ENABLED and OTEL_EXPORTER_OTLP_ENDPOINT are both set. Never
+# captures bodies, query strings, DB statements, or LLM/training content, and
+# never touches the enclaves. No-op by default.
+from gateway.observability.otel_bootstrap import configure_gateway_otel
+
+configure_gateway_otel(app)
+
 # Production middleware: Only log errors and critical paths
 # Comment out request logging to reduce overhead in production
 # @app.middleware("http")

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -530,7 +530,8 @@ app.add_middleware(
 # Optional OpenTelemetry (infra-only, off unless configured)
 # ============================================================
 # Emits request method/route-template/status/duration only when
-# GATEWAY_OTEL_ENABLED and GATEWAY_OTEL_ENDPOINT are both set. Never
+# GATEWAY_OTEL_ENABLED, GATEWAY_OTEL_ENDPOINT, and GATEWAY_OTEL_TOKEN are
+# all set. Never
 # captures bodies, query strings, DB statements, or LLM/training content, and
 # never touches the enclaves. No-op by default.
 from gateway.observability.otel_bootstrap import configure_gateway_otel

--- a/gateway/observability/__init__.py
+++ b/gateway/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Gateway host-process observability (opt-in, infra-only)."""

--- a/gateway/observability/otel_bootstrap.py
+++ b/gateway/observability/otel_bootstrap.py
@@ -14,31 +14,72 @@ Scope is deliberately narrow and privacy-preserving:
   the attested enclaves, and adds no new dependencies (it uses the OpenTelemetry
   packages already pinned in requirements.txt), so it cannot change any enclave
   measurement / PCR0.
-- It is a complete no-op unless BOTH `GATEWAY_OTEL_ENABLED` is truthy and
-  `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Any failure while wiring it up is
-  swallowed so it can never delay or break gateway startup.
 
-The exporter reads the standard OTel environment variables
-(`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`,
-`OTEL_SERVICE_NAME`); no endpoint or token is ever hard-coded or committed.
+The boundary is CODE-ENFORCED, not discipline-enforced:
+
+1. The exporter destination is passed EXPLICITLY from private, namespaced
+   environment variables (``GATEWAY_OTEL_ENDPOINT``, ``GATEWAY_OTEL_TOKEN``,
+   ``GATEWAY_OTEL_SERVICE_NAME``). The standard ambient exporter/service
+   variables are never read and never set, so auto-instrumentation or a
+   stray bare exporter anywhere in the process has NO destination — it
+   no-ops or errors instead of silently shipping data. The telemetry
+   address lives only inside this module's exporter object. The provider
+   resource is constructed as a FIXED attribute set (never via the SDK's
+   env-merging factory), so ambient resource variables cannot leak either.
+2. Every span passes through a FAIL-CLOSED schema validator before export.
+   A span is exported only if it has the ``gateway.http`` instrumentation
+   scope, EXACTLY the four approved attributes with the approved types,
+   no events, no links, no status description, the fixed resource, and a
+   route label that is either a registered route template or the literal
+   ``/_unmatched``. Anything else is DROPPED (never mutated, never
+   exported) and counted in a warning that does not include the rejected
+   values.
+3. ``tests/test_otel_boundary_guard.py`` fails CI if the boundary is crossed
+   anywhere in the repo (auto-instrumentation packages, the
+   process-wrapping launcher, a global tracer provider, ambient exporter
+   or resource env vars, the env-merging resource factory in this module,
+   or OTLP exporter imports outside this module).
+
+It is a complete no-op unless BOTH ``GATEWAY_OTEL_ENABLED`` is truthy and
+``GATEWAY_OTEL_ENDPOINT`` is set. Any failure while wiring it up is swallowed
+so it can never delay or break gateway startup. No endpoint or token is ever
+hard-coded or committed.
 """
 
 from __future__ import annotations
 
 import os
 import time
-from typing import Any, Optional
+from typing import Any, Callable, Dict, Optional
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
 # Route templates whose spans are suppressed entirely — health/liveness noise.
 _SUPPRESSED_ROUTES = {"/health", "/health/live", "/health/ready"}
 
+# Route label used whenever the request did not resolve to a registered route
+# template. A client-controlled path segment must NEVER be exported.
+UNMATCHED_ROUTE_LABEL = "/_unmatched"
+
+# The instrumentation scope every exported span must carry.
+INSTRUMENTATION_SCOPE = "gateway.http"
+
+# The ONLY attributes a span may carry out of this process, with their
+# required types (bool is explicitly rejected for the numeric fields).
+SPAN_ATTRIBUTE_TYPES: Dict[str, tuple] = {
+    "http.request.method": (str,),
+    "http.route": (str,),
+    "http.response.status_code": (int,),
+    "duration_ms": (int, float),
+}
+
+SPAN_ATTRIBUTE_ALLOWLIST = frozenset(SPAN_ATTRIBUTE_TYPES)
+
 
 def _enabled() -> bool:
     return (
         os.getenv("GATEWAY_OTEL_ENABLED", "").strip().lower() in _TRUTHY
-        and bool(os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip())
+        and bool(os.getenv("GATEWAY_OTEL_ENDPOINT", "").strip())
     )
 
 
@@ -47,7 +88,8 @@ def _safe_route_label(request: Any) -> str:
 
     Using the matched route template (e.g. ``/research-lab/allocations/attested/
     {epoch}``) keeps ids, hotkeys, and epoch numbers out of telemetry. When the
-    template cannot be resolved, fall back to the first path segment only.
+    template cannot be resolved the label is the fixed ``/_unmatched`` literal —
+    a client-controlled path segment is never exported.
     """
     try:
         route = request.scope.get("route")
@@ -56,18 +98,111 @@ def _safe_route_label(request: Any) -> str:
             return template
     except Exception:
         pass
-    try:
-        segments = [s for s in request.url.path.split("/") if s]
-        return "/" + segments[0] + "/*" if segments else "/"
-    except Exception:
-        return "/"
+    return UNMATCHED_ROUTE_LABEL
+
+
+def _span_scope_name(span: Any) -> str:
+    scope = getattr(span, "instrumentation_scope", None)
+    if scope is None:  # older SDK naming
+        scope = getattr(span, "instrumentation_info", None)
+    return str(getattr(scope, "name", "") or "")
+
+
+def _attributes_conform(attributes: Dict[str, Any]) -> bool:
+    if set(attributes) != SPAN_ATTRIBUTE_ALLOWLIST:
+        return False
+    for key, allowed_types in SPAN_ATTRIBUTE_TYPES.items():
+        value = attributes[key]
+        if isinstance(value, bool) or not isinstance(value, allowed_types):
+            return False
+    return True
+
+
+def _validating_exporter(
+    delegate: Any,
+    *,
+    allowed_routes: Callable[[], set],
+    expected_resource: Dict[str, Any],
+) -> Any:
+    """Wrap a span exporter in a FAIL-CLOSED schema validator.
+
+    A span is exported only when every check passes; a non-conforming span is
+    dropped entirely — never mutated, never partially exported. Drops are
+    logged as a per-reason count WITHOUT the rejected values.
+    """
+    from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+    def _violation(span: Any) -> Optional[str]:
+        try:
+            if _span_scope_name(span) != INSTRUMENTATION_SCOPE:
+                return "scope"
+            if not _attributes_conform(dict(span.attributes or {})):
+                return "attributes"
+            if getattr(span, "events", None):
+                return "events"
+            if getattr(span, "links", None):
+                return "links"
+            status = getattr(span, "status", None)
+            if status is not None and getattr(status, "description", None):
+                return "status_description"
+            resource = getattr(span, "resource", None)
+            if dict(getattr(resource, "attributes", {}) or {}) != expected_resource:
+                return "resource"
+            route = dict(span.attributes or {}).get("http.route")
+            if route != UNMATCHED_ROUTE_LABEL and route not in allowed_routes():
+                return "route"
+            return None
+        except Exception:
+            # Fail closed: a span we cannot fully validate is never exported.
+            return "validation_error"
+
+    class _FailClosedSpanExporter(SpanExporter):
+        def export(self, spans):  # type: ignore[override]
+            accepted = []
+            dropped: Dict[str, int] = {}
+            for span in spans:
+                reason = _violation(span)
+                if reason is None:
+                    accepted.append(span)
+                else:
+                    dropped[reason] = dropped.get(reason, 0) + 1
+            if dropped:
+                try:
+                    # Reasons and counts only — never the rejected values.
+                    print(
+                        "gateway_otel_span_dropped %s"
+                        % " ".join("%s=%d" % kv for kv in sorted(dropped.items())),
+                        flush=True,
+                    )
+                except Exception:
+                    pass
+            if not accepted:
+                return SpanExportResult.SUCCESS
+            return delegate.export(accepted)
+
+        def shutdown(self) -> None:
+            try:
+                delegate.shutdown()
+            except Exception:
+                pass
+
+        def force_flush(self, timeout_millis: int = 30_000) -> bool:
+            try:
+                return bool(delegate.force_flush(timeout_millis))
+            except Exception:
+                return True
+
+    return _FailClosedSpanExporter()
 
 
 def configure_gateway_otel(app: Any, *, span_exporter: Optional[Any] = None) -> bool:
     """Wire infra-only request spans onto the gateway app. No-op unless enabled.
 
-    Returns True if instrumentation was installed, False otherwise. ``span_exporter``
-    is a test seam; production always builds the OTLP exporter from env.
+    Returns True if instrumentation was installed, False otherwise.
+    ``span_exporter`` is a test seam; production always builds the OTLP
+    exporter with an EXPLICIT endpoint + headers from the private
+    ``GATEWAY_OTEL_*`` variables (measure A) — ambient exporter variables
+    are never read.
     """
     if span_exporter is None and not _enabled():
         return False
@@ -80,22 +215,57 @@ def configure_gateway_otel(app: Any, *, span_exporter: Optional[Any] = None) -> 
         )
         from opentelemetry.trace import SpanKind, StatusCode, Status
 
+        service_name = (
+            os.getenv("GATEWAY_OTEL_SERVICE_NAME", "").strip() or "leadpoet-gateway"
+        )
+        # FIXED resource: the plain constructor takes exactly these attributes.
+        # The SDK's env-merging factory is deliberately avoided so ambient
+        # resource variables can never leak into exported metadata.
+        expected_resource = {"service.name": service_name}
+        resource = Resource(expected_resource)
+
+        def _registered_routes() -> set:
+            try:
+                return {
+                    template
+                    for template in (
+                        getattr(route, "path", None)
+                        for route in getattr(app, "routes", [])
+                    )
+                    if isinstance(template, str) and template
+                }
+            except Exception:
+                return set()
+
         if span_exporter is not None:
-            exporter = span_exporter
-            processor = SimpleSpanProcessor(exporter)
+            delegate = span_exporter
+            make_processor = SimpleSpanProcessor
         else:
             from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
                 OTLPSpanExporter,
             )
-            exporter = OTLPSpanExporter()  # reads OTEL_EXPORTER_OTLP_* env
-            processor = BatchSpanProcessor(exporter)
 
-        service_name = os.getenv("OTEL_SERVICE_NAME", "").strip() or "leadpoet-gateway"
+            endpoint = os.getenv("GATEWAY_OTEL_ENDPOINT", "").strip()
+            token = os.getenv("GATEWAY_OTEL_TOKEN", "").strip()
+            headers = {"Authorization": "Bearer " + token} if token else {}
+            # Explicit arguments only: the destination exists solely inside
+            # this exporter object, never in ambient environment variables.
+            delegate = OTLPSpanExporter(endpoint=endpoint, headers=headers)
+            make_processor = BatchSpanProcessor
+
+        processor = make_processor(
+            _validating_exporter(
+                delegate,
+                allowed_routes=_registered_routes,
+                expected_resource=expected_resource,
+            )
+        )
+
         # A dedicated provider, NOT the global one, so nothing else (e.g. Langfuse)
         # is affected and no ambient instrumentation is picked up.
-        provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+        provider = TracerProvider(resource=resource)
         provider.add_span_processor(processor)
-        tracer = provider.get_tracer("gateway.http")
+        tracer = provider.get_tracer(INSTRUMENTATION_SCOPE)
 
         def _emit(request, status_code, start_ns, start_mono):
             # Resolve the route template only after routing has run, so ids stay

--- a/gateway/observability/otel_bootstrap.py
+++ b/gateway/observability/otel_bootstrap.py
@@ -1,0 +1,140 @@
+"""Opt-in, infra-only OpenTelemetry for the gateway HOST process.
+
+Scope is deliberately narrow and privacy-preserving:
+
+- It emits ONE server span per HTTP request capturing only operational
+  metadata: request method, the matched route *template* (never the concrete
+  path, so ids/hotkeys/epochs do not leak), response status class, and
+  duration. It never records request/response bodies, query strings, headers,
+  database statements, or any LLM prompt/completion content.
+- It does NOT auto-instrument the database, outbound HTTP clients, or the
+  Research Lab / scoring / model / Langfuse code paths. Training data and model
+  I/O are never touched.
+- It runs only in the gateway host process (`python -m gateway.main`), never in
+  the attested enclaves, and adds no new dependencies (it uses the OpenTelemetry
+  packages already pinned in requirements.txt), so it cannot change any enclave
+  measurement / PCR0.
+- It is a complete no-op unless BOTH `GATEWAY_OTEL_ENABLED` is truthy and
+  `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Any failure while wiring it up is
+  swallowed so it can never delay or break gateway startup.
+
+The exporter reads the standard OTel environment variables
+(`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`,
+`OTEL_SERVICE_NAME`); no endpoint or token is ever hard-coded or committed.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Optional
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# Route templates whose spans are suppressed entirely — health/liveness noise.
+_SUPPRESSED_ROUTES = {"/health", "/health/live", "/health/ready"}
+
+
+def _enabled() -> bool:
+    return (
+        os.getenv("GATEWAY_OTEL_ENABLED", "").strip().lower() in _TRUTHY
+        and bool(os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "").strip())
+    )
+
+
+def _safe_route_label(request: Any) -> str:
+    """Return the low-cardinality route template, never the concrete path.
+
+    Using the matched route template (e.g. ``/research-lab/allocations/attested/
+    {epoch}``) keeps ids, hotkeys, and epoch numbers out of telemetry. When the
+    template cannot be resolved, fall back to the first path segment only.
+    """
+    try:
+        route = request.scope.get("route")
+        template = getattr(route, "path", None)
+        if isinstance(template, str) and template:
+            return template
+    except Exception:
+        pass
+    try:
+        segments = [s for s in request.url.path.split("/") if s]
+        return "/" + segments[0] + "/*" if segments else "/"
+    except Exception:
+        return "/"
+
+
+def configure_gateway_otel(app: Any, *, span_exporter: Optional[Any] = None) -> bool:
+    """Wire infra-only request spans onto the gateway app. No-op unless enabled.
+
+    Returns True if instrumentation was installed, False otherwise. ``span_exporter``
+    is a test seam; production always builds the OTLP exporter from env.
+    """
+    if span_exporter is None and not _enabled():
+        return False
+    try:
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import (
+            BatchSpanProcessor,
+            SimpleSpanProcessor,
+        )
+        from opentelemetry.trace import SpanKind, StatusCode, Status
+
+        if span_exporter is not None:
+            exporter = span_exporter
+            processor = SimpleSpanProcessor(exporter)
+        else:
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+                OTLPSpanExporter,
+            )
+            exporter = OTLPSpanExporter()  # reads OTEL_EXPORTER_OTLP_* env
+            processor = BatchSpanProcessor(exporter)
+
+        service_name = os.getenv("OTEL_SERVICE_NAME", "").strip() or "leadpoet-gateway"
+        # A dedicated provider, NOT the global one, so nothing else (e.g. Langfuse)
+        # is affected and no ambient instrumentation is picked up.
+        provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+        provider.add_span_processor(processor)
+        tracer = provider.get_tracer("gateway.http")
+
+        def _emit(request, status_code, start_ns, start_mono):
+            # Resolve the route template only after routing has run, so ids stay
+            # out of the label. Suppression already handled static health paths.
+            route = _safe_route_label(request)
+            span = tracer.start_span(
+                "%s %s" % (request.method, route),
+                kind=SpanKind.SERVER,
+                start_time=start_ns,
+            )
+            # Only method / route template / status / duration — nothing else.
+            span.set_attribute("http.request.method", request.method)
+            span.set_attribute("http.route", route)
+            span.set_attribute("http.response.status_code", int(status_code))
+            span.set_attribute("duration_ms", (time.monotonic() - start_mono) * 1000.0)
+            if int(status_code) >= 500:
+                span.set_status(Status(StatusCode.ERROR))
+            span.end()
+
+        @app.middleware("http")
+        async def _otel_request_span(request, call_next):
+            # Suppress health/liveness noise up front (static paths, no params).
+            if request.url.path in _SUPPRESSED_ROUTES:
+                return await call_next(request)
+            start_ns = time.time_ns()
+            start_mono = time.monotonic()
+            try:
+                response = await call_next(request)
+            except Exception:
+                _emit(request, 500, start_ns, start_mono)
+                raise
+            _emit(request, response.status_code, start_ns, start_mono)
+            return response
+
+        return True
+    except Exception as exc:  # never let telemetry break the gateway
+        try:
+            print("gateway_otel_bootstrap_skipped error=%s: %s"
+                  % (type(exc).__name__, str(exc)[:200]), flush=True)
+        except Exception:
+            pass
+        return False

--- a/gateway/observability/otel_bootstrap.py
+++ b/gateway/observability/otel_bootstrap.py
@@ -18,39 +18,44 @@ Scope is deliberately narrow and privacy-preserving:
 The boundary is CODE-ENFORCED, not discipline-enforced:
 
 1. The exporter destination is passed EXPLICITLY from private, namespaced
-   environment variables (``GATEWAY_OTEL_ENDPOINT``, ``GATEWAY_OTEL_TOKEN``,
-   ``GATEWAY_OTEL_SERVICE_NAME``). The standard ambient exporter/service
-   variables are never read and never set, so auto-instrumentation or a
-   stray bare exporter anywhere in the process has NO destination — it
-   no-ops or errors instead of silently shipping data. The telemetry
-   address lives only inside this module's exporter object. The provider
-   resource is constructed as a FIXED attribute set (never via the SDK's
-   env-merging factory), so ambient resource variables cannot leak either.
-2. Every span passes through a FAIL-CLOSED schema validator before export.
-   A span is exported only if it has the ``gateway.http`` instrumentation
-   scope, EXACTLY the four approved attributes with the approved types,
-   no events, no links, no status description, the fixed resource, and a
-   route label that is either a registered route template or the literal
-   ``/_unmatched``. Anything else is DROPPED (never mutated, never
-   exported) and counted in a warning that does not include the rejected
-   values.
+   environment variables (``GATEWAY_OTEL_ENDPOINT``, ``GATEWAY_OTEL_TOKEN``).
+   A non-empty token is REQUIRED (the pinned exporter falls back to ambient
+   header variables when the explicit headers dict is empty), and
+   initialization is REFUSED outright if any ambient standard exporter
+   variable is present in the runtime environment — the exporter also
+   consults those for TLS certificates, client keys, timeout, and
+   compression, and a CI grep cannot see variables injected by a restart
+   script or the live process environment. The service name is a CONSTANT,
+   not an environment value. The provider resource is a fixed attribute set
+   (never the SDK's env-merging factory), so ambient resource variables
+   cannot leak either.
+2. Every span passes a FAIL-CLOSED schema validator that checks the COMPLETE
+   span envelope before export: the ``gateway.http`` instrumentation scope
+   with no version/schema metadata, ``SERVER`` kind, a root span (no parent,
+   empty trace state), EXACTLY the four approved attributes with the
+   approved types, a standard HTTP method, a span name equal to exactly
+   ``<method> <route>``, no events, no links, no status description, the
+   fixed resource, and a route label that is either a registered route
+   template or the literal ``/_unmatched``. Anything else is DROPPED (never
+   mutated, never exported) and counted in a warning that does not include
+   the rejected values.
 3. ``tests/test_otel_boundary_guard.py`` fails CI if the boundary is crossed
    anywhere in the repo (auto-instrumentation packages, the
    process-wrapping launcher, a global tracer provider, ambient exporter
    or resource env vars, the env-merging resource factory in this module,
    or OTLP exporter imports outside this module).
 
-It is a complete no-op unless BOTH ``GATEWAY_OTEL_ENABLED`` is truthy and
-``GATEWAY_OTEL_ENDPOINT`` is set. Any failure while wiring it up is swallowed
-so it can never delay or break gateway startup. No endpoint or token is ever
-hard-coded or committed.
+It is a complete no-op unless ``GATEWAY_OTEL_ENABLED`` is truthy AND
+``GATEWAY_OTEL_ENDPOINT`` AND ``GATEWAY_OTEL_TOKEN`` are all set. Any failure
+while wiring it up is swallowed so it can never delay or break gateway
+startup. No endpoint or token is ever hard-coded or committed.
 """
 
 from __future__ import annotations
 
 import os
 import time
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
@@ -63,6 +68,21 @@ UNMATCHED_ROUTE_LABEL = "/_unmatched"
 
 # The instrumentation scope every exported span must carry.
 INSTRUMENTATION_SCOPE = "gateway.http"
+
+# Fixed service identity — a constant, never an environment value.
+SERVICE_NAME = "leadpoet-gateway"
+
+# The standard exporter env-var prefix that must NOT exist at runtime. The
+# pinned exporter consults these for headers, TLS certificates, client keys,
+# timeout, and compression even when endpoint/headers are passed explicitly.
+# (Split literal so the repo-wide CI grep for the ambient prefix stays
+# meaningful everywhere else.)
+_AMBIENT_EXPORTER_PREFIX = "OTEL_" + "EXPORTER_"
+
+# Standard HTTP request methods; anything else is a client-controlled string.
+_ALLOWED_HTTP_METHODS = frozenset(
+    {"GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"}
+)
 
 # The ONLY attributes a span may carry out of this process, with their
 # required types (bool is explicitly rejected for the numeric fields).
@@ -83,6 +103,10 @@ def _enabled() -> bool:
     )
 
 
+def _ambient_exporter_env_names() -> List[str]:
+    return sorted(k for k in os.environ if k.startswith(_AMBIENT_EXPORTER_PREFIX))
+
+
 def _safe_route_label(request: Any) -> str:
     """Return the low-cardinality route template, never the concrete path.
 
@@ -101,11 +125,11 @@ def _safe_route_label(request: Any) -> str:
     return UNMATCHED_ROUTE_LABEL
 
 
-def _span_scope_name(span: Any) -> str:
+def _span_scope(span: Any) -> Any:
     scope = getattr(span, "instrumentation_scope", None)
     if scope is None:  # older SDK naming
         scope = getattr(span, "instrumentation_info", None)
-    return str(getattr(scope, "name", "") or "")
+    return scope
 
 
 def _attributes_conform(attributes: Dict[str, Any]) -> bool:
@@ -124,20 +148,39 @@ def _validating_exporter(
     allowed_routes: Callable[[], set],
     expected_resource: Dict[str, Any],
 ) -> Any:
-    """Wrap a span exporter in a FAIL-CLOSED schema validator.
+    """Wrap a span exporter in a FAIL-CLOSED complete-envelope validator.
 
     A span is exported only when every check passes; a non-conforming span is
     dropped entirely — never mutated, never partially exported. Drops are
     logged as a per-reason count WITHOUT the rejected values.
     """
     from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+    from opentelemetry.trace import SpanKind
 
     def _violation(span: Any) -> Optional[str]:
         try:
-            if _span_scope_name(span) != INSTRUMENTATION_SCOPE:
+            scope = _span_scope(span)
+            if str(getattr(scope, "name", "") or "") != INSTRUMENTATION_SCOPE:
                 return "scope"
-            if not _attributes_conform(dict(span.attributes or {})):
+            if getattr(scope, "version", None) or getattr(scope, "schema_url", None):
+                return "scope_metadata"
+            if getattr(span, "kind", None) is not SpanKind.SERVER:
+                return "kind"
+            if getattr(span, "parent", None) is not None:
+                return "parent"
+            context = getattr(span, "context", None) or span.get_span_context()
+            trace_state = getattr(context, "trace_state", None)
+            if trace_state is not None and len(trace_state) > 0:
+                return "trace_state"
+            attributes = dict(span.attributes or {})
+            if not _attributes_conform(attributes):
                 return "attributes"
+            method = attributes["http.request.method"]
+            if method not in _ALLOWED_HTTP_METHODS:
+                return "method"
+            route = attributes["http.route"]
+            if span.name != "%s %s" % (method, route):
+                return "name"
             if getattr(span, "events", None):
                 return "events"
             if getattr(span, "links", None):
@@ -148,7 +191,6 @@ def _validating_exporter(
             resource = getattr(span, "resource", None)
             if dict(getattr(resource, "attributes", {}) or {}) != expected_resource:
                 return "resource"
-            route = dict(span.attributes or {}).get("http.route")
             if route != UNMATCHED_ROUTE_LABEL and route not in allowed_routes():
                 return "route"
             return None
@@ -202,9 +244,23 @@ def configure_gateway_otel(app: Any, *, span_exporter: Optional[Any] = None) -> 
     ``span_exporter`` is a test seam; production always builds the OTLP
     exporter with an EXPLICIT endpoint + headers from the private
     ``GATEWAY_OTEL_*`` variables (measure A) — ambient exporter variables
-    are never read.
+    are never read, and their presence at runtime refuses initialization.
     """
     if span_exporter is None and not _enabled():
+        return False
+    ambient = _ambient_exporter_env_names()
+    if ambient:
+        # A CI grep cannot see variables injected by a restart script or the
+        # live process environment; refuse at runtime instead. Names only —
+        # never the values.
+        try:
+            print(
+                "gateway_otel_bootstrap_refused ambient_exporter_env=%s"
+                % ",".join(ambient),
+                flush=True,
+            )
+        except Exception:
+            pass
         return False
     try:
         from opentelemetry.sdk.resources import Resource
@@ -214,14 +270,12 @@ def configure_gateway_otel(app: Any, *, span_exporter: Optional[Any] = None) -> 
             SimpleSpanProcessor,
         )
         from opentelemetry.trace import SpanKind, StatusCode, Status
+        from opentelemetry.context import Context
 
-        service_name = (
-            os.getenv("GATEWAY_OTEL_SERVICE_NAME", "").strip() or "leadpoet-gateway"
-        )
         # FIXED resource: the plain constructor takes exactly these attributes.
         # The SDK's env-merging factory is deliberately avoided so ambient
         # resource variables can never leak into exported metadata.
-        expected_resource = {"service.name": service_name}
+        expected_resource = {"service.name": SERVICE_NAME}
         resource = Resource(expected_resource)
 
         def _registered_routes() -> set:
@@ -241,13 +295,22 @@ def configure_gateway_otel(app: Any, *, span_exporter: Optional[Any] = None) -> 
             delegate = span_exporter
             make_processor = SimpleSpanProcessor
         else:
+            token = os.getenv("GATEWAY_OTEL_TOKEN", "").strip()
+            if not token:
+                # An empty explicit headers dict would let the pinned exporter
+                # fall back to ambient header variables — require the token.
+                try:
+                    print("gateway_otel_bootstrap_refused token_missing", flush=True)
+                except Exception:
+                    pass
+                return False
+
             from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
                 OTLPSpanExporter,
             )
 
             endpoint = os.getenv("GATEWAY_OTEL_ENDPOINT", "").strip()
-            token = os.getenv("GATEWAY_OTEL_TOKEN", "").strip()
-            headers = {"Authorization": "Bearer " + token} if token else {}
+            headers = {"Authorization": "Bearer " + token}
             # Explicit arguments only: the destination exists solely inside
             # this exporter object, never in ambient environment variables.
             delegate = OTLPSpanExporter(endpoint=endpoint, headers=headers)
@@ -274,6 +337,9 @@ def configure_gateway_otel(app: Any, *, span_exporter: Optional[Any] = None) -> 
             span = tracer.start_span(
                 "%s %s" % (request.method, route),
                 kind=SpanKind.SERVER,
+                # A fresh root context: never adopt a caller-supplied parent
+                # or trace state.
+                context=Context(),
                 start_time=start_ns,
             )
             # Only method / route template / status / duration — nothing else.

--- a/tests/test_gateway_otel_bootstrap.py
+++ b/tests/test_gateway_otel_bootstrap.py
@@ -101,12 +101,9 @@ def test_unmatched_route_uses_fixed_label_never_client_path():
     assert "EXAMPLE.COM" not in haystack
 
 
-def test_validator_drops_span_with_extra_attribute():
-    """Fail-closed: a span carrying a non-approved attribute is dropped
-    entirely — not stripped, not partially exported."""
+def _validator_harness(exp, scope="gateway.http"):
+    """Provider + tracer wired through the fail-closed validating exporter."""
     from gateway.observability.otel_bootstrap import _validating_exporter
-
-    exp = InMemorySpanExporter()
     from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -119,93 +116,134 @@ def test_validator_drops_span_with_extra_attribute():
     )
     provider = TracerProvider(resource=Resource(expected_resource))
     provider.add_span_processor(SimpleSpanProcessor(validating))
-    tracer = provider.get_tracer("gateway.http")
+    return provider.get_tracer(scope)
 
-    def _base_attrs():
-        return {
-            "http.request.method": "GET",
-            "http.route": "/ok",
-            "http.response.status_code": 200,
-            "duration_ms": 1.5,
-        }
+
+def _emit_span(tracer, *, name=None, attrs=None, kind=None, parented=False,
+               event=None):
+    """Emit one finished span shaped like the middleware's, with overrides."""
+    from opentelemetry.context import Context
+    from opentelemetry.trace import SpanKind
+
+    base = {
+        "http.request.method": "GET",
+        "http.route": "/ok",
+        "http.response.status_code": 200,
+        "duration_ms": 1.5,
+    }
+    if attrs is not None:
+        base = attrs
+    span_name = name if name is not None else "%s %s" % (
+        base.get("http.request.method", "GET"), base.get("http.route", "/ok")
+    )
+    kwargs = {"kind": kind if kind is not None else SpanKind.SERVER}
+    if not parented:
+        kwargs["context"] = Context()  # fresh root context
+    span = tracer.start_span(span_name, **kwargs)
+    for k, v in base.items():
+        span.set_attribute(k, v)
+    if event is not None:
+        span.add_event(*event)
+    span.end()
+
+
+def test_validator_drops_nonconforming_attribute_sets():
+    """Fail-closed: a span with a non-approved attribute set is dropped
+    entirely — not stripped, not partially exported."""
+    exp = InMemorySpanExporter()
+    tracer = _validator_harness(exp)
 
     # Conforming span → exported.
-    with tracer.start_as_current_span("GET /ok") as span:
-        for k, v in _base_attrs().items():
-            span.set_attribute(k, v)
+    _emit_span(tracer)
     assert len(exp.get_finished_spans()) == 1
     exp.clear()
 
+    base = {
+        "http.request.method": "GET",
+        "http.route": "/ok",
+        "http.response.status_code": 200,
+        "duration_ms": 1.5,
+    }
+
     # Extra attribute → dropped, nothing exported.
-    with tracer.start_as_current_span("GET /ok") as span:
-        for k, v in _base_attrs().items():
-            span.set_attribute(k, v)
-        span.set_attribute("user.email", "leak@example.com")
-    assert exp.get_finished_spans() == ()
-
+    _emit_span(tracer, attrs={**base, "user.email": "leak@example.com"})
     # Missing attribute → dropped.
-    with tracer.start_as_current_span("GET /ok") as span:
-        attrs = _base_attrs()
-        attrs.pop("duration_ms")
-        for k, v in attrs.items():
-            span.set_attribute(k, v)
-    assert exp.get_finished_spans() == ()
-
+    _emit_span(tracer, attrs={k: v for k, v in base.items() if k != "duration_ms"})
     # Wrong type (status as string) → dropped.
-    with tracer.start_as_current_span("GET /ok") as span:
-        attrs = _base_attrs()
-        attrs["http.response.status_code"] = "200"
-        for k, v in attrs.items():
-            span.set_attribute(k, v)
-    assert exp.get_finished_spans() == ()
-
-    # Event attached → dropped (events could carry exception messages).
-    with tracer.start_as_current_span("GET /ok") as span:
-        for k, v in _base_attrs().items():
-            span.set_attribute(k, v)
-        span.add_event("exception", {"exception.message": "secret traceback"})
-    assert exp.get_finished_spans() == ()
-
+    _emit_span(tracer, attrs={**base, "http.response.status_code": "200"})
+    # Event attached → dropped (events can carry exception messages).
+    _emit_span(tracer, event=("exception", {"exception.message": "secret tb"}))
     # Unregistered route label → dropped.
-    with tracer.start_as_current_span("GET /other") as span:
-        attrs = _base_attrs()
-        attrs["http.route"] = "/not-registered"
-        for k, v in attrs.items():
-            span.set_attribute(k, v)
+    _emit_span(tracer, attrs={**base, "http.route": "/not-registered"})
     assert exp.get_finished_spans() == ()
 
     # Fixed /_unmatched label → allowed.
-    with tracer.start_as_current_span("GET /_unmatched") as span:
-        attrs = _base_attrs()
-        attrs["http.route"] = "/_unmatched"
-        for k, v in attrs.items():
-            span.set_attribute(k, v)
+    _emit_span(tracer, attrs={**base, "http.route": "/_unmatched"})
     assert len(exp.get_finished_spans()) == 1
 
 
-def test_validator_drops_span_from_foreign_scope():
-    """A span produced under any other instrumentation scope (e.g. a library
-    that acquired this provider) is never exported."""
-    from gateway.observability.otel_bootstrap import _validating_exporter
-    from opentelemetry.sdk.resources import Resource
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+def test_validator_drops_nonconforming_span_envelopes():
+    """The COMPLETE envelope is validated: name, method, kind, parent/trace
+    state, and instrumentation scope — not just the attribute dict."""
+    from opentelemetry.trace import SpanKind
 
     exp = InMemorySpanExporter()
-    expected_resource = {"service.name": "leadpoet-gateway"}
-    validating = _validating_exporter(
-        exp, allowed_routes=lambda: {"/ok"}, expected_resource=expected_resource
-    )
-    provider = TracerProvider(resource=Resource(expected_resource))
-    provider.add_span_processor(SimpleSpanProcessor(validating))
-    foreign = provider.get_tracer("some.library")
+    tracer = _validator_harness(exp)
 
-    with foreign.start_as_current_span("GET /ok") as span:
-        span.set_attribute("http.request.method", "GET")
-        span.set_attribute("http.route", "/ok")
-        span.set_attribute("http.response.status_code", 200)
-        span.set_attribute("duration_ms", 1.0)
+    base = {
+        "http.request.method": "GET",
+        "http.route": "/ok",
+        "http.response.status_code": 200,
+        "duration_ms": 1.5,
+    }
+
+    # Arbitrary span name → dropped (must equal "<method> <route>").
+    _emit_span(tracer, name="user query for leak@example.com")
+    # Non-standard (client-controlled) HTTP method string → dropped.
+    _emit_span(tracer, attrs={**base, "http.request.method": "BREW"})
+    # Wrong span kind (INTERNAL) → dropped.
+    _emit_span(tracer, kind=SpanKind.INTERNAL)
     assert exp.get_finished_spans() == ()
+
+    # Parented span (adopted caller context) → dropped.
+    with tracer.start_as_current_span("outer", kind=SpanKind.SERVER):
+        _emit_span(tracer, parented=True)
+    exported = [s.name for s in exp.get_finished_spans()]
+    assert "GET /ok" not in exported
+    exp.clear()
+
+    # Foreign instrumentation scope (e.g. a library that acquired this
+    # provider) → dropped even with a perfect envelope otherwise.
+    foreign = _validator_harness(exp, scope="some.library")
+    _emit_span(foreign)
+    assert exp.get_finished_spans() == ()
+
+
+def test_bootstrap_refuses_ambient_exporter_env(monkeypatch, capsys):
+    """Runtime refusal: any ambient standard exporter variable present in the
+    process environment blocks initialization entirely — a CI grep cannot see
+    vars injected by a restart script or the live process env."""
+    monkeypatch.setenv(
+        "OTEL_EXPORTER" + "_OTLP_HEADERS", "x-secret=abc"
+    )  # split literal keeps the repo-wide env-var guard meaningful
+    exp = InMemorySpanExporter()
+    app, installed = _app(exp)
+    assert installed is False
+    out = capsys.readouterr().out
+    assert "gateway_otel_bootstrap_refused" in out
+    assert "abc" not in out  # names only, never values
+    TestClient(app).get("/research-lab/allocations/attested/1")
+    assert exp.get_finished_spans() == ()
+
+
+def test_production_path_requires_nonempty_token(monkeypatch, capsys):
+    """Without a token the pinned exporter's empty headers dict would fall
+    back to ambient header variables — initialization must refuse instead."""
+    monkeypatch.setenv("GATEWAY_OTEL_ENABLED", "1")
+    monkeypatch.setenv("GATEWAY_OTEL_ENDPOINT", "https://collector.invalid/v1/traces")
+    monkeypatch.delenv("GATEWAY_OTEL_TOKEN", raising=False)
+    assert configure_gateway_otel(FastAPI()) is False
+    assert "token_missing" in capsys.readouterr().out
 
 
 def test_resource_is_fixed_and_ignores_ambient_resource_env(monkeypatch):

--- a/tests/test_gateway_otel_bootstrap.py
+++ b/tests/test_gateway_otel_bootstrap.py
@@ -1,0 +1,82 @@
+"""The optional gateway OTel bootstrap must be off by default and, when on,
+must emit only infra metadata — never ids, query strings, bodies, or secrets.
+
+This guards the data-governance boundary: the gateway may ship operational
+telemetry (request rate/latency/errors) to an external backend, but it must
+never leak concrete path ids, query parameters, request bodies, or any
+training/LLM content into a span.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from gateway.observability.otel_bootstrap import configure_gateway_otel
+
+
+def _app(exporter=None):
+    app = FastAPI()
+
+    @app.get("/research-lab/allocations/attested/{epoch}")
+    def _alloc(epoch: int):
+        return {"epoch": epoch}
+
+    @app.get("/health")
+    def _health():
+        return {"ok": True}
+
+    installed = configure_gateway_otel(app, span_exporter=exporter)
+    return app, installed
+
+
+def test_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("GATEWAY_OTEL_ENABLED", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    assert configure_gateway_otel(FastAPI()) is False
+
+
+def test_emits_only_infra_metadata_no_id_or_query_leak():
+    exp = InMemorySpanExporter()
+    app, installed = _app(exp)
+    assert installed is True
+
+    resp = TestClient(app).get(
+        "/research-lab/allocations/attested/24124?secret=abc123"
+    )
+    assert resp.status_code == 200
+
+    spans = exp.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+
+    # Present: method, route template, status, duration.
+    assert span.attributes["http.request.method"] == "GET"
+    assert span.attributes["http.response.status_code"] == 200
+    assert "duration_ms" in span.attributes
+    assert span.attributes["http.route"].startswith("/research-lab")
+
+    # Absent: the concrete epoch id and the query string must NOT appear
+    # anywhere in the span name or attribute values.
+    haystack = span.name + " " + " ".join(
+        "%s=%s" % (k, v) for k, v in span.attributes.items()
+    )
+    assert "24124" not in haystack       # concrete path id never leaks
+    assert "secret" not in haystack      # query key never leaks
+    assert "abc123" not in haystack      # query value never leaks
+
+    # Only the four intended attribute keys are present.
+    assert set(span.attributes.keys()) <= {
+        "http.request.method",
+        "http.route",
+        "http.response.status_code",
+        "duration_ms",
+    }
+
+
+def test_health_route_is_suppressed():
+    exp = InMemorySpanExporter()
+    app, _ = _app(exp)
+    TestClient(app).get("/health")
+    assert exp.get_finished_spans() == ()  # no telemetry for health probes

--- a/tests/test_gateway_otel_bootstrap.py
+++ b/tests/test_gateway_otel_bootstrap.py
@@ -33,7 +33,7 @@ def _app(exporter=None):
 
 def test_disabled_by_default(monkeypatch):
     monkeypatch.delenv("GATEWAY_OTEL_ENABLED", raising=False)
-    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("GATEWAY_OTEL_ENDPOINT", raising=False)
     assert configure_gateway_otel(FastAPI()) is False
 
 
@@ -80,3 +80,146 @@ def test_health_route_is_suppressed():
     app, _ = _app(exp)
     TestClient(app).get("/health")
     assert exp.get_finished_spans() == ()  # no telemetry for health probes
+
+
+def test_unmatched_route_uses_fixed_label_never_client_path():
+    """A 404 path is client-controlled; the exported label must be the fixed
+    ``/_unmatched`` literal, never any segment of the request path."""
+    exp = InMemorySpanExporter()
+    app, _ = _app(exp)
+    resp = TestClient(app).get("/attacker-controlled/EMAIL@EXAMPLE.COM")
+    assert resp.status_code == 404
+
+    spans = exp.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.attributes["http.route"] == "/_unmatched"
+    haystack = span.name + " " + " ".join(
+        "%s=%s" % (k, v) for k, v in span.attributes.items()
+    )
+    assert "attacker-controlled" not in haystack
+    assert "EXAMPLE.COM" not in haystack
+
+
+def test_validator_drops_span_with_extra_attribute():
+    """Fail-closed: a span carrying a non-approved attribute is dropped
+    entirely — not stripped, not partially exported."""
+    from gateway.observability.otel_bootstrap import _validating_exporter
+
+    exp = InMemorySpanExporter()
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    expected_resource = {"service.name": "leadpoet-gateway"}
+    validating = _validating_exporter(
+        exp,
+        allowed_routes=lambda: {"/ok"},
+        expected_resource=expected_resource,
+    )
+    provider = TracerProvider(resource=Resource(expected_resource))
+    provider.add_span_processor(SimpleSpanProcessor(validating))
+    tracer = provider.get_tracer("gateway.http")
+
+    def _base_attrs():
+        return {
+            "http.request.method": "GET",
+            "http.route": "/ok",
+            "http.response.status_code": 200,
+            "duration_ms": 1.5,
+        }
+
+    # Conforming span → exported.
+    with tracer.start_as_current_span("GET /ok") as span:
+        for k, v in _base_attrs().items():
+            span.set_attribute(k, v)
+    assert len(exp.get_finished_spans()) == 1
+    exp.clear()
+
+    # Extra attribute → dropped, nothing exported.
+    with tracer.start_as_current_span("GET /ok") as span:
+        for k, v in _base_attrs().items():
+            span.set_attribute(k, v)
+        span.set_attribute("user.email", "leak@example.com")
+    assert exp.get_finished_spans() == ()
+
+    # Missing attribute → dropped.
+    with tracer.start_as_current_span("GET /ok") as span:
+        attrs = _base_attrs()
+        attrs.pop("duration_ms")
+        for k, v in attrs.items():
+            span.set_attribute(k, v)
+    assert exp.get_finished_spans() == ()
+
+    # Wrong type (status as string) → dropped.
+    with tracer.start_as_current_span("GET /ok") as span:
+        attrs = _base_attrs()
+        attrs["http.response.status_code"] = "200"
+        for k, v in attrs.items():
+            span.set_attribute(k, v)
+    assert exp.get_finished_spans() == ()
+
+    # Event attached → dropped (events could carry exception messages).
+    with tracer.start_as_current_span("GET /ok") as span:
+        for k, v in _base_attrs().items():
+            span.set_attribute(k, v)
+        span.add_event("exception", {"exception.message": "secret traceback"})
+    assert exp.get_finished_spans() == ()
+
+    # Unregistered route label → dropped.
+    with tracer.start_as_current_span("GET /other") as span:
+        attrs = _base_attrs()
+        attrs["http.route"] = "/not-registered"
+        for k, v in attrs.items():
+            span.set_attribute(k, v)
+    assert exp.get_finished_spans() == ()
+
+    # Fixed /_unmatched label → allowed.
+    with tracer.start_as_current_span("GET /_unmatched") as span:
+        attrs = _base_attrs()
+        attrs["http.route"] = "/_unmatched"
+        for k, v in attrs.items():
+            span.set_attribute(k, v)
+    assert len(exp.get_finished_spans()) == 1
+
+
+def test_validator_drops_span_from_foreign_scope():
+    """A span produced under any other instrumentation scope (e.g. a library
+    that acquired this provider) is never exported."""
+    from gateway.observability.otel_bootstrap import _validating_exporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    exp = InMemorySpanExporter()
+    expected_resource = {"service.name": "leadpoet-gateway"}
+    validating = _validating_exporter(
+        exp, allowed_routes=lambda: {"/ok"}, expected_resource=expected_resource
+    )
+    provider = TracerProvider(resource=Resource(expected_resource))
+    provider.add_span_processor(SimpleSpanProcessor(validating))
+    foreign = provider.get_tracer("some.library")
+
+    with foreign.start_as_current_span("GET /ok") as span:
+        span.set_attribute("http.request.method", "GET")
+        span.set_attribute("http.route", "/ok")
+        span.set_attribute("http.response.status_code", 200)
+        span.set_attribute("duration_ms", 1.0)
+    assert exp.get_finished_spans() == ()
+
+
+def test_resource_is_fixed_and_ignores_ambient_resource_env(monkeypatch):
+    """The provider resource is built from a fixed dict; ambient resource
+    variables must not appear in exported span resources."""
+    monkeypatch.setenv(
+        "OTEL_RESOURCE" + "_ATTRIBUTES", "leak.key=leak-value"
+    )  # split literal keeps the repo-wide env-var guard meaningful
+    exp = InMemorySpanExporter()
+    app, installed = _app(exp)
+    assert installed is True
+    TestClient(app).get("/research-lab/allocations/attested/1")
+    spans = exp.get_finished_spans()
+    assert len(spans) == 1
+    resource_attrs = dict(spans[0].resource.attributes)
+    assert resource_attrs == {"service.name": "leadpoet-gateway"}
+    assert "leak.key" not in resource_attrs

--- a/tests/test_otel_boundary_guard.py
+++ b/tests/test_otel_boundary_guard.py
@@ -154,6 +154,31 @@ def test_bootstrap_uses_only_namespaced_gateway_variables() -> None:
     )
 
 
+def test_bootstrap_requires_token_and_refuses_ambient_exporter_env() -> None:
+    source = _read(BOOTSTRAP)
+    assert "token_missing" in source and "if not token" in source, (
+        "an empty explicit headers dict lets the pinned exporter fall back "
+        "to ambient header variables — a non-empty token must be required"
+    )
+    assert "_ambient_exporter_env_names" in source and (
+        "gateway_otel_bootstrap_refused" in source
+    ), (
+        "a CI grep cannot see env vars injected by a restart script or the "
+        "live process environment — the bootstrap must refuse initialization "
+        "at runtime when ambient exporter variables are present"
+    )
+
+
+def test_bootstrap_service_name_is_a_constant() -> None:
+    source = _read(BOOTSTRAP)
+    assert re.search(r'^SERVICE_NAME = "leadpoet-gateway"$', source, re.M), (
+        "the service identity must be a fixed constant"
+    )
+    assert "GATEWAY_OTEL_SERVICE_NAME" not in source, (
+        "the service name must not be an arbitrary environment value"
+    )
+
+
 def test_bootstrap_builds_a_fixed_resource() -> None:
     source = _read(BOOTSTRAP)
     assert "Resource.create(" not in source, (

--- a/tests/test_otel_boundary_guard.py
+++ b/tests/test_otel_boundary_guard.py
@@ -1,0 +1,177 @@
+"""CI guard: the OpenTelemetry boundary is code-enforced, not discipline.
+
+The gateway's telemetry is a single, explicit, infra-only exporter in
+``gateway/observability/otel_bootstrap.py`` (private ``GATEWAY_OTEL_*``
+variables, explicit exporter arguments, allowlisted span attributes). This
+guard fails the build the moment any change crosses that boundary, so drift
+is caught at PR time instead of in production:
+
+1. no auto-instrumentation packages (``opentelemetry-instrumentation-*`` /
+   ``opentelemetry-distro``) in requirements;
+2. no launch path uses the ``opentelemetry-instrument`` wrapper;
+3. nothing sets the GLOBAL tracer provider;
+4. the standard ``OTEL_EXPORTER_*`` / ``OTEL_SERVICE_NAME`` /
+   ``OTEL_RESOURCE_ATTRIBUTES`` variables appear nowhere (the destination
+   and resource must stay explicit and namespaced);
+5. OTLP exporter imports exist ONLY inside the bootstrap module (so Langfuse
+   or any other integration can never acquire an OTLP exporter);
+6. the bootstrap builds a FIXED resource and never uses the SDK's
+   env-merging resource factory.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP = "gateway/observability/otel_bootstrap.py"
+THIS_GUARD = "tests/test_otel_boundary_guard.py"
+
+
+def _tracked_files() -> list[str]:
+    output = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def _read(relative: str) -> str:
+    try:
+        return (REPO_ROOT / relative).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def test_no_auto_instrumentation_packages_in_requirements() -> None:
+    offenders = []
+    for relative in _tracked_files():
+        if not relative.endswith(("requirements.txt", "requirements.lock")):
+            continue
+        for line in _read(relative).splitlines():
+            requirement = line.split("#", 1)[0].strip().lower()
+            if requirement.startswith("opentelemetry-instrumentation") or (
+                requirement.startswith("opentelemetry-distro")
+            ):
+                offenders.append(f"{relative}: {line.strip()}")
+    assert not offenders, (
+        "Auto-instrumentation must never enter the dependency set — it would "
+        "instrument DB/HTTP/LLM paths ambiently. Offending lines: "
+        f"{offenders}"
+    )
+
+
+def test_no_launch_path_uses_opentelemetry_instrument() -> None:
+    offenders = []
+    for relative in _tracked_files():
+        if relative == THIS_GUARD:
+            continue
+        if not relative.endswith((".sh", ".bash", "Dockerfile", ".yml", ".yaml", ".py")) and (
+            "Dockerfile" not in relative
+        ):
+            continue
+        if "opentelemetry-instrument" in _read(relative):
+            offenders.append(relative)
+    assert not offenders, (
+        "The opentelemetry-instrument launcher wraps the whole process in "
+        f"ambient auto-instrumentation. Offending files: {offenders}"
+    )
+
+
+def test_nothing_sets_the_global_tracer_provider() -> None:
+    pattern = re.compile(r"set_tracer_provider\s*\(")
+    offenders = []
+    for relative in _tracked_files():
+        if not relative.endswith(".py") or relative == THIS_GUARD:
+            continue
+        if relative.startswith("tests/"):
+            continue
+        if pattern.search(_read(relative)):
+            offenders.append(relative)
+    assert not offenders, (
+        "Setting the GLOBAL tracer provider lets any library emit spans "
+        "through our exporter. The gateway uses a dedicated local provider "
+        f"only. Offending files: {offenders}"
+    )
+
+
+def test_standard_otlp_env_vars_appear_nowhere() -> None:
+    pattern = re.compile(
+        r"OTEL_EXPORTER_|(?<!GATEWAY_)OTEL_SERVICE_NAME|OTEL_RESOURCE_ATTRIBUTES"
+    )
+    offenders = []
+    for relative in _tracked_files():
+        if relative == THIS_GUARD:
+            continue
+        if not relative.endswith(
+            (".py", ".sh", ".bash", ".yml", ".yaml", ".md", ".env", ".example", "Dockerfile")
+        ) and "Dockerfile" not in relative:
+            continue
+        if pattern.search(_read(relative)):
+            offenders.append(relative)
+    assert not offenders, (
+        "The standard OTLP variables must stay UNSET and unreferenced so any "
+        "stray exporter or auto-instrumentation has no destination. The "
+        "gateway destination is passed explicitly from GATEWAY_OTEL_*. "
+        f"Offending files: {offenders}"
+    )
+
+
+def test_otlp_exporter_imports_only_in_bootstrap() -> None:
+    pattern = re.compile(r"opentelemetry\.exporter")
+    offenders = []
+    for relative in _tracked_files():
+        if not relative.endswith(".py"):
+            continue
+        if relative in (BOOTSTRAP, THIS_GUARD):
+            continue
+        if relative.startswith("tests/"):
+            continue
+        if pattern.search(_read(relative)):
+            offenders.append(relative)
+    assert not offenders, (
+        "OTLP exporters may exist ONLY inside the gateway bootstrap module — "
+        "no other integration (including Langfuse) may acquire one. "
+        f"Offending files: {offenders}"
+    )
+
+
+def test_bootstrap_uses_only_namespaced_gateway_variables() -> None:
+    source = _read(BOOTSTRAP)
+    assert "GATEWAY_OTEL_ENDPOINT" in source
+    assert "GATEWAY_OTEL_TOKEN" in source
+    # The bootstrap must pass the destination explicitly, never ambiently.
+    assert re.search(r"OTLPSpanExporter\(\s*endpoint=", source), (
+        "the exporter must be constructed with an explicit endpoint argument"
+    )
+    assert "OTLPSpanExporter()" not in source, (
+        "a bare OTLPSpanExporter() would read ambient OTEL_* variables"
+    )
+
+
+def test_bootstrap_builds_a_fixed_resource() -> None:
+    source = _read(BOOTSTRAP)
+    assert "Resource.create(" not in source, (
+        "the env-merging resource factory reads ambient resource variables; "
+        "the bootstrap must build the resource from a fixed attribute dict"
+    )
+    assert re.search(r"Resource\(\s*expected_resource\s*\)", source), (
+        "the provider resource must be the exact fixed attribute dict that "
+        "the fail-closed validator checks against"
+    )
+
+
+def test_no_client_controlled_route_fallback() -> None:
+    source = _read(BOOTSTRAP)
+    assert "/_unmatched" in source, (
+        "unresolved routes must map to the fixed /_unmatched label so a "
+        "client-controlled path segment is never exported"
+    )
+    assert "url.path.split" not in source, (
+        "the route label must never be derived from the raw request path"
+    )


### PR DESCRIPTION
Adds an **opt-in, infra-only** OpenTelemetry request span for the gateway host process, with the telemetry boundary **code-enforced** rather than discipline-enforced.

## What a span contains — and all it can ever contain
`http.request.method`, `http.route` (route *template*, never the concrete path), `http.response.status_code`, `duration_ms`. No bodies, query strings, headers, DB statements, model I/O, prompts, or completions. Health/liveness routes are suppressed.

## Boundary enforcement (three measures)

**A — Explicit destination, private namespace, fixed resource.** The exporter is built with explicit `endpoint=`/`headers=` arguments from `GATEWAY_OTEL_ENDPOINT` / `GATEWAY_OTEL_TOKEN`. A non-empty token is **required** (an empty explicit headers dict would let the pinned exporter fall back to ambient header variables), and initialization is **refused at runtime** if any ambient standard exporter variable is present in the process environment — the exporter also consults those for TLS certificates, client keys, timeout, and compression, and a CI grep cannot see variables injected by a restart script or the live process env (refusal logs variable names only, never values). The service name is a fixed constant, not an environment value. The provider resource is a fixed attribute dict — the SDK's env-merging resource factory is never used, so ambient resource variables cannot leak.

**B — CI boundary guard** (`tests/test_otel_boundary_guard.py`): the build fails if auto-instrumentation packages enter requirements, any launch path uses the process-wrapping launcher, anything sets the global tracer provider, standard ambient exporter/resource variables appear anywhere in the repo, an OTLP exporter is imported outside the bootstrap module, the bootstrap stops building a fixed resource, the route fallback becomes client-derived, the token requirement or runtime ambient refusal is removed, or the service name stops being a constant.

**C — Fail-closed complete-envelope validator** (not a mutating processor): a span is exported only if it has the `gateway.http` instrumentation scope with no version/schema metadata, `SERVER` kind, a root context (no parent, empty trace state — spans are emitted with a fresh root context so caller context is never adopted), exactly the four approved attributes with approved types, a standard HTTP method, a span name equal to exactly `<method> <route>`, no events/links/status descriptions, the fixed resource, and a registered route template or the literal `/_unmatched`. Non-conforming spans are dropped entirely and counted in a warning that omits the rejected values. Unresolved routes always export the fixed `/_unmatched` label — a client-controlled path segment is never exported.

## Isolation
Dedicated (non-global) tracer provider — Langfuse and every other library untouched. Gateway host only, never the attested enclaves; no new dependencies, so no PCR0 change. Complete no-op unless both `GATEWAY_OTEL_ENABLED` and `GATEWAY_OTEL_ENDPOINT` are set; wiring failures are swallowed.

These controls stop accidental leakage; operational hardening (ingest-only rotated token, scoped repository access, written retention / no-training / deletion terms with the vendor) is documented in `TELEMETRY.md` as still required.

## Testing
- `tests/test_otel_boundary_guard.py` — 10 repo-wide guard checks, all green.
- `tests/test_gateway_otel_bootstrap.py` — off-by-default, no id/query leak, health suppression, `/_unmatched` fallback (client path never exported), attribute drop matrix (extra/missing attribute, wrong type, event attached, unregistered route), envelope drop matrix (arbitrary span name, non-standard method, wrong kind, parented span, foreign instrumentation scope), runtime ambient-env refusal (names-only logging), token-required refusal, fixed resource ignores ambient resource env. All green.
- Protected-workflow manifest check green; touched modules compile clean.
