### PR TITLE
Fix city lookup case normalization

### DIFF
--- a/gateway/utils/geo_normalize.py
+++ b/gateway/utils/geo_normalize.py
@@ -28,8 +28,14 @@ with open(_geo_path, 'r', encoding='utf-8') as _f:
 # Build sets for O(1) validation lookups
 VALID_COUNTRIES_SET = set(_geo_data['countries'])
 US_STATES_SET = set(_geo_data['us_states'].keys())
-US_CITIES_BY_STATE = {state: set(cities) for state, cities in _geo_data['us_states'].items()}
-CITIES_BY_COUNTRY = {country: set(cities) for country, cities in _geo_data['cities'].items()}
+US_CITIES_BY_STATE = {
+    state: {city.lower() for city in cities}
+    for state, cities in _geo_data['us_states'].items()
+}
+CITIES_BY_COUNTRY = {
+    country: {city.lower() for city in cities}
+    for country, cities in _geo_data['cities'].items()
+}
 STATE_ABBR_TO_NAME = _geo_data['state_abbr']
 
 # Build proper case mapping for US states (lowercase -> Proper Case)

--- a/tests/test_geo_normalize_city_case.py
+++ b/tests/test_geo_normalize_city_case.py
@@ -1,0 +1,31 @@
+from gateway.utils.geo_normalize import (
+    CITIES_BY_COUNTRY,
+    US_CITIES_BY_STATE,
+    validate_location,
+)
+
+
+def test_city_lookup_keys_match_lowercase_validation_normalization() -> None:
+    assert all(
+        city == city.lower()
+        for cities in US_CITIES_BY_STATE.values()
+        for city in cities
+    )
+    assert all(
+        city == city.lower()
+        for cities in CITIES_BY_COUNTRY.values()
+        for city in cities
+    )
+
+
+def test_mixed_case_lookup_cities_validate() -> None:
+    assert validate_location(
+        city="Holland",
+        state="Ohio",
+        country="United States",
+    ) == (True, None)
+    assert validate_location(
+        city="Lebanon",
+        state="Ohio",
+        country="United States",
+    ) == (True, None)


### PR DESCRIPTION
## Summary

- lowercase US and international city lookup values when building validation sets
- add regression coverage for the lookup invariant and representative mixed-case source records
- restore the narrowly scoped fix from closed PR #7 on current `main`

## Root cause

`validate_location()` normalizes city inputs to lowercase, but the JSON-derived lookup sets retained mixed-case source entries. Those entries could therefore never match even though they existed in the lookup data.

## Impact

Mixed-case source records such as Holland and Lebanon in Ohio now validate correctly, while city/state and city/country membership checks remain strict.

## Verification

- `/opt/homebrew/bin/pytest -q tests/test_geo_normalize_city_case.py` — 2 passed
- `/opt/homebrew/bin/pytest -q tests/test_pre_checks_geography.py` — 36 passed
- `git diff --check` — passed

<!-- codex-rebase-verification:start -->
## Current rebase and gate status (2026-07-25)
- Rebased conflict-free onto current `origin/main` `b1a10d167c41b67ee539f26a000e8a9780a2d6f0`; exact head `7608aa830a404abc8ba133f18684032844a19f0f`.
- Code-level verification: 38 focused geography tests passed; Deploy Checks run 709 passed for this exact head.
- Exact N-1-to-N gateway/validator rehearsal: unexercised (advisory).
- No merge, deployment, restart, or production write was performed. Review, branch-protection, block-position, and restart-in-progress gates still apply before any merge.
<!-- codex-rebase-verification:end -->
