### PR TITLE
Support exact-commit V2 restarts and rollback

### DIFF
--- a/docs/gateway_git_deployment_runbook.md
+++ b/docs/gateway_git_deployment_runbook.md
@@ -11,12 +11,16 @@ bash /home/ec2-user/gw_restart.sh
 The restart selects one commit from `GITHUB_REPO_URL` and `GITHUB_BRANCH`,
 stops the existing processes, fast-forwards the checkout to that exact commit,
 and then runs the existing cleanup, PCR0, enclave, dependency, process launch,
-and health workflow. It does not add a validator-side deployment gate.
+and health workflow. Normal unpinned gateway and validator restarts remain
+independent; an explicit exact-commit validator restart adds the paired
+same-release gate described below.
 
-`GATEWAY_DEPLOY_COMMIT` is an operator-only, one-invocation rollback control.
-Persistent copies in Secrets Manager or the cached/runtime environment are
-ignored and are not inherited by the relaunched gateway. Normal restarts
-therefore always follow the fetched head of `GITHUB_BRANCH`.
+`--commit <full-sha>` is the canonical operator-only, one-invocation release
+selector. `GATEWAY_DEPLOY_COMMIT` remains accepted for installed-launcher
+compatibility during an N-1-to-N handoff. Persistent copies in Secrets Manager
+or the cached/runtime environment are ignored and are not inherited by the
+relaunched gateway. Normal restarts therefore always follow the fetched head of
+`GITHUB_BRANCH`.
 
 ## One-Time Cutover
 
@@ -139,17 +143,30 @@ Resume using the existing operator workflow only after the normal checks pass:
 
 ## Rollback
 
-Use the `target_sha` from `gateway-last-good.json`. The SHA must be a full
-40-character commit reachable from the configured branch and must support the
-Git restart protocol.
+Rollback is a paired gateway-and-validator deployment. A gateway-only
+`gateway-last-good.json` record is not sufficient evidence that the same
+validator release completed successfully. Select one full 40-character commit
+that:
 
-```bash
-cd /home/ec2-user
-GATEWAY_DEPLOY_COMMIT=<last-good-40-character-sha> \
-  bash /home/ec2-user/gw_restart.sh
-```
+- Is reachable from `origin/main`.
+- Is at or after the stateful V2 compatibility floor.
+- Has one immutable release channel containing matching gateway and validator
+  manifests.
+- Has passed the exact reverse restart rehearsal from the currently installed
+  launcher.
+
+Restart the gateway first with `gw_restart.sh --commit <full-sha>`. Require its
+normal build-info, V2 authority, attestation, and authenticated allocation
+handoff checks to pass. Only then restart the validator with
+`validator_restart.sh --commit <the-same-full-sha>`.
+
+The pinned validator restart fails before shutdown unless the public gateway
+reports the same commit through V2 authority health, build-info, and immutable
+release evidence. A normal unpinned validator restart retains its independent
+gateway-startup behavior.
 
 Rollback runs the same enclave rebuild and restart workflow. It does not reuse
 newer EIFs or bypass PCR0, attestation, import, or health checks. A commit from
-before this migration is intentionally rejected; use the retained flat restart
-backup only for initial cutover recovery.
+before the stateful V2 compatibility floor is intentionally rejected. A
+subsequent roll-forward must run the exact forward rehearsal from the rolled
+back commit before production use.

--- a/docs/v2_deployment_verification_checklist.md
+++ b/docs/v2_deployment_verification_checklist.md
@@ -43,15 +43,35 @@ production.
 python3 scripts/run_local_restart_rehearsal.py \
   --from-sha <currently-deployed-sha> \
   --candidate-sha HEAD \
+  --transition forward \
   --scope exact \
   --component all
 ```
+
+If the candidate changes either production restart launcher, release
+selection, compatibility-floor enforcement, or the rehearsal harness, also run
+the exact reverse transition before pushing:
+
+```bash
+python3 scripts/run_local_restart_rehearsal.py \
+  --from-sha HEAD \
+  --candidate-sha <supported-previous-release-sha> \
+  --transition rollback \
+  --scope exact \
+  --component all
+```
+
+Then rerun the forward transition from that supported previous release to the
+same frozen candidate. The three commands must use one unchanged candidate SHA.
 
 The rehearsal must produce all of the following:
 
 - [ ] `PYTHON37_FINALIZATION_PROBE_SUCCESS`
 - [ ] `REHEARSAL_SUCCESS component=gateway`
 - [ ] `REHEARSAL_SUCCESS component=validator`
+- [ ] Exact rollback succeeds when the change affects restart or release
+  selection.
+- [ ] Exact roll-forward succeeds again from the rollback target.
 - [ ] Every contract stage passes.
 - [ ] Zero rejected contract events.
 - [ ] Zero `internal_substitution` events. An adapted repository module,

--- a/gw_restart.sh
+++ b/gw_restart.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 GATEWAY_GIT_DEPLOY_PROTOCOL="1"
+V2_DEPLOYMENT_COMPATIBILITY_FLOOR_SHA="bd71fdda2aca4e17d07b3e55f56a66f7bd1bbdc3"
 LEADPOET_REPO_ROOT="${LEADPOET_REPO_ROOT:-/home/ec2-user/leadpoet_repo}"
 GATEWAY_ROOT="${GATEWAY_ROOT:-$LEADPOET_REPO_ROOT/gateway}"
 GATEWAY_LOG_ROOT="${GATEWAY_LOG_ROOT:-/home/ec2-user/gateway}"
@@ -49,6 +50,50 @@ GATEWAY_DEPLOY_COMPLETED=0
 GATEWAY_PREFLIGHT_TREE=""
 GATEWAY_HOST_MEMORY_GUARD_PATH="${GATEWAY_HOST_MEMORY_GUARD_PATH:-$LEADPOET_REPO_ROOT/gateway/tee/host_memory_guard_v2.py}"
 LEADPOET_DOCKER_OPERATION_LOCK_FILE="${LEADPOET_DOCKER_OPERATION_LOCK_FILE:-/home/ec2-user/.config/leadpoet/docker-operation-v2.lock}"
+REQUESTED_GATEWAY_DEPLOY_COMMIT="${GATEWAY_DEPLOY_COMMIT:-}"
+unset GATEWAY_DEPLOY_COMMIT
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --commit)
+      if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+        echo "ERROR: --commit requires a full 40-character SHA" >&2
+        exit 2
+      fi
+      if [ -n "$REQUESTED_GATEWAY_DEPLOY_COMMIT" ] \
+          && [ "$REQUESTED_GATEWAY_DEPLOY_COMMIT" != "$2" ]; then
+        echo "ERROR: --commit conflicts with GATEWAY_DEPLOY_COMMIT" >&2
+        exit 2
+      fi
+      REQUESTED_GATEWAY_DEPLOY_COMMIT="$2"
+      shift 2
+      ;;
+    --commit=*)
+      requested_commit="${1#--commit=}"
+      if [ -z "$requested_commit" ]; then
+        echo "ERROR: --commit requires a full 40-character SHA" >&2
+        exit 2
+      fi
+      if [ -n "$REQUESTED_GATEWAY_DEPLOY_COMMIT" ] \
+          && [ "$REQUESTED_GATEWAY_DEPLOY_COMMIT" != "$requested_commit" ]; then
+        echo "ERROR: --commit conflicts with GATEWAY_DEPLOY_COMMIT" >&2
+        exit 2
+      fi
+      REQUESTED_GATEWAY_DEPLOY_COMMIT="$requested_commit"
+      shift
+      ;;
+    *)
+      echo "ERROR: unsupported gateway restart argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+if [ -n "$REQUESTED_GATEWAY_DEPLOY_COMMIT" ] \
+    && ! [[ "$REQUESTED_GATEWAY_DEPLOY_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: --commit must be a lowercase full 40-character SHA" >&2
+  exit 2
+fi
+
 V2_CREDENTIAL_ENVELOPES=(
   "$GATEWAY_V2_CONFIG_DIR/artifact_master_key.json"
   "$GATEWAY_V2_CONFIG_DIR/openrouter.json"
@@ -909,11 +954,17 @@ PREPARED_GATEWAY_SHA="$(
   python3 "$GATEWAY_GIT_HELPER" prepare \
     --repo-root "$LEADPOET_REPO_ROOT" \
     --env-file "$GATEWAY_ENV_FILE" \
+    --deploy-commit "$REQUESTED_GATEWAY_DEPLOY_COMMIT" \
     --plan-file "$GATEWAY_DEPLOY_PLAN_FILE" \
     --manifest-file "$GATEWAY_DEPLOYMENT_MANIFEST" \
     --last-good-file "$GATEWAY_LAST_GOOD_MANIFEST"
 )"
 echo "Prepared gateway commit: $PREPARED_GATEWAY_SHA"
+if ! git -C "$LEADPOET_REPO_ROOT" merge-base --is-ancestor \
+    "$V2_DEPLOYMENT_COMPATIBILITY_FLOOR_SHA" "$PREPARED_GATEWAY_SHA"; then
+  echo "ERROR: selected gateway commit predates the supported stateful V2 rollback floor" >&2
+  exit 1
+fi
 
 echo "Materializing the prepared commit for pre-shutdown V2 tooling"
 GATEWAY_PREFLIGHT_TREE="$(mktemp -d /tmp/gateway-v2-preflight.XXXXXX)"

--- a/scripts/run_local_restart_rehearsal.py
+++ b/scripts/run_local_restart_rehearsal.py
@@ -60,27 +60,63 @@ def _git_file(commit_sha: str, path: str) -> bytes:
     return result.stdout
 
 
-def _image_tag(candidate_sha: str) -> str:
+def _is_ancestor(ancestor: str, descendant: str) -> bool:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=str(REPO_ROOT),
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if result.returncode not in (0, 1):
+        raise SystemExit("unable to resolve restart rehearsal Git ancestry")
+    return result.returncode == 0
+
+
+def _resolve_transition(
+    from_sha: str,
+    candidate_sha: str,
+    requested: str,
+) -> str:
+    forward = _is_ancestor(from_sha, candidate_sha)
+    rollback = (
+        from_sha != candidate_sha
+        and _is_ancestor(candidate_sha, from_sha)
+    )
+    if requested == "auto":
+        if forward:
+            return "forward"
+        if rollback:
+            return "rollback"
+        raise SystemExit("restart rehearsal commits are unrelated")
+    if requested == "forward" and not forward:
+        raise SystemExit("forward rehearsal target does not descend from --from-sha")
+    if requested == "rollback" and not rollback:
+        raise SystemExit("rollback rehearsal target is not an ancestor of --from-sha")
+    return requested
+
+
+def _image_tag(harness_sha: str) -> str:
     digest = hashlib.sha256()
-    digest.update(b"candidate_sha")
-    digest.update(candidate_sha.encode("ascii"))
+    digest.update(b"harness_sha")
+    digest.update(harness_sha.encode("ascii"))
     digest.update(b"requirements.txt")
-    digest.update(_git_file(candidate_sha, "requirements.txt"))
+    digest.update(_git_file(harness_sha, "requirements.txt"))
     for path in COMMITTED_HARNESS_PATHS:
         digest.update(path.encode("utf-8"))
-        digest.update(_git_file(candidate_sha, path))
+        digest.update(_git_file(harness_sha, path))
     return f"{IMAGE_REPOSITORY}:{digest.hexdigest()[:16]}"
 
 
-def _build_image(tag: str, *, candidate_sha: str) -> None:
+def _build_image(tag: str, *, harness_sha: str) -> None:
     with tempfile.TemporaryDirectory(prefix="leadpoet-restart-image-") as raw:
         context = Path(raw)
         (context / "requirements.txt").write_bytes(
-            _git_file(candidate_sha, "requirements.txt")
+            _git_file(harness_sha, "requirements.txt")
         )
         (context / "Dockerfile").write_bytes(
             _git_file(
-                candidate_sha,
+                harness_sha,
                 "tests/restart_rehearsal/Dockerfile",
             )
         )
@@ -88,7 +124,7 @@ def _build_image(tag: str, *, candidate_sha: str) -> None:
         harness.mkdir()
         for path in COMMITTED_HARNESS_PATHS[1:]:
             (harness / Path(path).name).write_bytes(
-                _git_file(candidate_sha, path)
+                _git_file(harness_sha, path)
             )
         _run(
             [
@@ -104,11 +140,11 @@ def _build_image(tag: str, *, candidate_sha: str) -> None:
         )
 
 
-def _verify_driver_identity(candidate_sha: str) -> None:
+def _verify_driver_identity(harness_sha: str) -> None:
     path = "scripts/run_local_restart_rehearsal.py"
-    if Path(__file__).resolve().read_bytes() != _git_file(candidate_sha, path):
+    if Path(__file__).resolve().read_bytes() != _git_file(harness_sha, path):
         raise SystemExit(
-            "restart rehearsal driver differs from the frozen candidate SHA"
+            "restart rehearsal driver differs from the frozen harness SHA"
         )
 
 
@@ -128,6 +164,7 @@ def _run_component(
     component: str,
     from_sha: str,
     candidate_sha: str,
+    transition: str,
     weight_readiness_scenario: str = "transient_503_recovery",
     scope: str = "exact",
 ) -> None:
@@ -158,6 +195,8 @@ def _run_component(
         f"REHEARSAL_FROM_SHA={from_sha}",
         "--env",
         f"REHEARSAL_CANDIDATE_SHA={candidate_sha}",
+        "--env",
+        f"REHEARSAL_TRANSITION={transition}",
         "--env",
         (
             "REHEARSAL_WEIGHT_READINESS_SCENARIO="
@@ -212,6 +251,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument("--candidate-sha", default="HEAD")
     parser.add_argument(
+        "--transition",
+        choices=("auto", "forward", "rollback"),
+        default="auto",
+    )
+    parser.add_argument(
         "--component",
         choices=("all", "gateway", "validator"),
         default="all",
@@ -231,12 +275,17 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     from_sha = _git_sha(args.from_sha)
     candidate_sha = _git_sha(args.candidate_sha)
-    _run(["git", "merge-base", "--is-ancestor", from_sha, candidate_sha])
-    _verify_driver_identity(candidate_sha)
+    transition = _resolve_transition(
+        from_sha,
+        candidate_sha,
+        args.transition,
+    )
+    harness_sha = candidate_sha if transition == "forward" else from_sha
+    _verify_driver_identity(harness_sha)
 
-    tag = _image_tag(candidate_sha)
+    tag = _image_tag(harness_sha)
     if args.rebuild_image or not _image_exists(tag):
-        _build_image(tag, candidate_sha=candidate_sha)
+        _build_image(tag, harness_sha=harness_sha)
 
     components = (
         ("gateway", "validator") if args.component == "all" else (args.component,)
@@ -264,7 +313,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(
                 f"Running isolated {component} restart rehearsal "
                 f"{from_sha[:12]} -> {candidate_sha[:12]} "
-                f"scenario={scenario}",
+                f"transition={transition} scenario={scenario}",
                 flush=True,
             )
             _run_component(
@@ -272,6 +321,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 component=component,
                 from_sha=from_sha,
                 candidate_sha=candidate_sha,
+                transition=transition,
                 weight_readiness_scenario=scenario,
                 scope=args.scope.replace("-", "_"),
             )

--- a/tests/restart_rehearsal/contract_adapter.py
+++ b/tests/restart_rehearsal/contract_adapter.py
@@ -606,7 +606,31 @@ def command_curl(argv: list[str]) -> int:
             return 97
     if url.endswith("/build-info"):
         print(json.dumps({"git_commit": _candidate_sha()}, sort_keys=True))
-    elif url.endswith(("/health", "/health/v2-authority", "/research-lab/status", "/attest")):
+    elif url.endswith("/health/v2-authority"):
+        print(
+            json.dumps(
+                {
+                    "schema_version": "leadpoet.gateway_v2_authority_health.v2",
+                    "status": "ready",
+                    "commit_sha": _candidate_sha(),
+                },
+                sort_keys=True,
+            )
+        )
+    elif re.search(r"/weights/v2/release-evidence/[0-9a-f]{40}$", url):
+        print(
+            json.dumps(
+                {
+                    "schema_version": "leadpoet.auditor_release_evidence.v2",
+                    "commit_sha": _candidate_sha(),
+                    "release_channel_version_id": "rehearsal-version",
+                    "release_channel_get_url": "https://release.invalid/get",
+                    "release_channel_head_url": "https://release.invalid/head",
+                },
+                sort_keys=True,
+            )
+        )
+    elif url.endswith(("/health", "/research-lab/status", "/attest")):
         print(json.dumps({"status": "ok"}, sort_keys=True))
     else:
         return _fail("curl", argv, "unknown HTTP endpoint")

--- a/tests/restart_rehearsal/run_inside.sh
+++ b/tests/restart_rehearsal/run_inside.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 FROM_SHA="${REHEARSAL_FROM_SHA:?REHEARSAL_FROM_SHA is required}"
 CANDIDATE_SHA="${REHEARSAL_CANDIDATE_SHA:?REHEARSAL_CANDIDATE_SHA is required}"
+TRANSITION="${REHEARSAL_TRANSITION:?REHEARSAL_TRANSITION is required}"
 COMPONENT="${REHEARSAL_COMPONENT:?REHEARSAL_COMPONENT is required}"
 WEIGHT_READINESS_SCENARIO="${REHEARSAL_WEIGHT_READINESS_SCENARIO:-transient_503_recovery}"
 REHEARSAL_SCOPE="${REHEARSAL_SCOPE:-exact}"
@@ -43,11 +44,25 @@ git config --global --add safe.directory '*'
 
 git -C /source cat-file -e "$FROM_SHA^{commit}"
 git -C /source cat-file -e "$CANDIDATE_SHA^{commit}"
-git -C /source merge-base --is-ancestor "$FROM_SHA" "$CANDIDATE_SHA"
+case "$TRANSITION" in
+  forward)
+    git -C /source merge-base --is-ancestor "$FROM_SHA" "$CANDIDATE_SHA"
+    ;;
+  rollback)
+    test "$FROM_SHA" != "$CANDIDATE_SHA"
+    git -C /source merge-base --is-ancestor "$CANDIDATE_SHA" "$FROM_SHA"
+    ;;
+  *)
+    echo "ERROR: unsupported restart transition: $TRANSITION" >&2
+    exit 1
+    ;;
+esac
 
 git init --bare -q /srv/origin.git
 git --git-dir=/srv/origin.git fetch -q /source \
   "$CANDIDATE_SHA:refs/heads/main"
+git --git-dir=/srv/origin.git fetch -q /source \
+  "$FROM_SHA:refs/heads/rehearsal-deployed"
 
 mkdir -p \
   /home/ec2-user/.config/leadpoet \
@@ -90,20 +105,36 @@ if [ "$COMPONENT" = "gateway" ]; then
     >/home/ec2-user/gw_restart.sh
   chmod 700 /home/ec2-user/gw_restart.sh
 
-  echo "REHEARSAL_START component=gateway from=$FROM_SHA candidate=$CANDIDATE_SHA scenario=$WEIGHT_READINESS_SCENARIO scope=$REHEARSAL_SCOPE"
+  echo "REHEARSAL_START component=gateway from=$FROM_SHA candidate=$CANDIDATE_SHA transition=$TRANSITION scenario=$WEIGHT_READINESS_SCENARIO scope=$REHEARSAL_SCOPE"
   set +e
-  env \
-    HOME=/home/ec2-user \
-    LEADPOET_REPO_ROOT=/home/ec2-user/leadpoet_repo \
-    GATEWAY_ROOT=/home/ec2-user/leadpoet_repo/gateway \
-    GATEWAY_LOG_ROOT=/home/ec2-user/gateway \
-    GATEWAY_LOG_FILE=/home/ec2-user/gateway/gateway.log \
-    GATEWAY_HOST_RESTART_SCRIPT=/home/ec2-user/gw_restart.sh \
-    GATEWAY_TEE_EIF_ROOT=/home/ec2-user/tee \
-    GATEWAY_PYTHON_BIN=/home/ec2-user/venv311/bin/python3 \
-    GATEWAY_TEE_TOPOLOGY_MODE=full \
-    RESEARCH_LAB_TEE_PROTOCOL=v2 \
-    bash /home/ec2-user/gw_restart.sh
+  if [ "$TRANSITION" = "rollback" ]; then
+    env \
+      HOME=/home/ec2-user \
+      LEADPOET_REPO_ROOT=/home/ec2-user/leadpoet_repo \
+      GATEWAY_ROOT=/home/ec2-user/leadpoet_repo/gateway \
+      GATEWAY_LOG_ROOT=/home/ec2-user/gateway \
+      GATEWAY_LOG_FILE=/home/ec2-user/gateway/gateway.log \
+      GATEWAY_HOST_RESTART_SCRIPT=/home/ec2-user/gw_restart.sh \
+      GATEWAY_TEE_EIF_ROOT=/home/ec2-user/tee \
+      GATEWAY_PYTHON_BIN=/home/ec2-user/venv311/bin/python3 \
+      GATEWAY_TEE_TOPOLOGY_MODE=full \
+      RESEARCH_LAB_TEE_PROTOCOL=v2 \
+      bash /home/ec2-user/gw_restart.sh --commit "$CANDIDATE_SHA"
+  else
+    env \
+      HOME=/home/ec2-user \
+      GATEWAY_DEPLOY_COMMIT="$CANDIDATE_SHA" \
+      LEADPOET_REPO_ROOT=/home/ec2-user/leadpoet_repo \
+      GATEWAY_ROOT=/home/ec2-user/leadpoet_repo/gateway \
+      GATEWAY_LOG_ROOT=/home/ec2-user/gateway \
+      GATEWAY_LOG_FILE=/home/ec2-user/gateway/gateway.log \
+      GATEWAY_HOST_RESTART_SCRIPT=/home/ec2-user/gw_restart.sh \
+      GATEWAY_TEE_EIF_ROOT=/home/ec2-user/tee \
+      GATEWAY_PYTHON_BIN=/home/ec2-user/venv311/bin/python3 \
+      GATEWAY_TEE_TOPOLOGY_MODE=full \
+      RESEARCH_LAB_TEE_PROTOCOL=v2 \
+      bash /home/ec2-user/gw_restart.sh
+  fi
   RESTART_STATUS=$?
   set -e
 
@@ -159,13 +190,24 @@ else
   printf '%s\n' '{"ss58Address":"5DummyColdkey"}' \
     >/home/ec2-user/.bittensor/wallets/validator_72/coldkeypub.txt
 
-  echo "REHEARSAL_START component=validator from=$FROM_SHA candidate=$CANDIDATE_SHA"
-  env \
-    HOME=/home/ec2-user \
-    VALIDATOR_ROOT=/home/ec2-user/leadpoet/leadpoet \
-    VALIDATOR_PYTHON_BIN=/home/ec2-user/venv311/bin/python3 \
-    VALIDATOR_DOCKER_MIN_FREE_BYTES=1000000000 \
-    bash /home/ec2-user/leadpoet/leadpoet/validator_restart.sh
+  echo "REHEARSAL_START component=validator from=$FROM_SHA candidate=$CANDIDATE_SHA transition=$TRANSITION"
+  if [ "$TRANSITION" = "rollback" ]; then
+    env \
+      HOME=/home/ec2-user \
+      VALIDATOR_ROOT=/home/ec2-user/leadpoet/leadpoet \
+      VALIDATOR_PYTHON_BIN=/home/ec2-user/venv311/bin/python3 \
+      VALIDATOR_DOCKER_MIN_FREE_BYTES=1000000000 \
+      bash /home/ec2-user/leadpoet/leadpoet/validator_restart.sh \
+        --commit "$CANDIDATE_SHA"
+  else
+    env \
+      HOME=/home/ec2-user \
+      VALIDATOR_DEPLOY_COMMIT="$CANDIDATE_SHA" \
+      VALIDATOR_ROOT=/home/ec2-user/leadpoet/leadpoet \
+      VALIDATOR_PYTHON_BIN=/home/ec2-user/venv311/bin/python3 \
+      VALIDATOR_DOCKER_MIN_FREE_BYTES=1000000000 \
+      bash /home/ec2-user/leadpoet/leadpoet/validator_restart.sh
+  fi
 
   test "$(git -C /home/ec2-user/leadpoet/leadpoet rev-parse HEAD)" = "$CANDIDATE_SHA"
   test "$(

--- a/tests/restart_rehearsal/test_rehearsal_integrity.py
+++ b/tests/restart_rehearsal/test_rehearsal_integrity.py
@@ -12,7 +12,7 @@ from tests.restart_rehearsal.verify_evidence import verify_rehearsal_integrity
 COMMIT = "1" * 40
 
 
-def test_rehearsal_driver_must_match_frozen_candidate(
+def test_rehearsal_driver_must_match_frozen_harness_commit(
     monkeypatch,
     tmp_path,
 ) -> None:
@@ -28,8 +28,41 @@ def test_rehearsal_driver_must_match_frozen_candidate(
     rehearsal._verify_driver_identity(COMMIT)
 
     driver.write_bytes(b"dirty driver\n")
-    with pytest.raises(SystemExit, match="differs from the frozen candidate"):
+    with pytest.raises(SystemExit, match="differs from the frozen harness"):
         rehearsal._verify_driver_identity(COMMIT)
+
+
+def test_rehearsal_resolves_forward_and_rollback_transitions(monkeypatch) -> None:
+    relationships = {
+        ("from", "target"): True,
+        ("target", "from"): False,
+        ("newer", "older"): False,
+        ("older", "newer"): True,
+    }
+    monkeypatch.setattr(
+        rehearsal,
+        "_is_ancestor",
+        lambda ancestor, descendant: relationships.get(
+            (ancestor, descendant),
+            False,
+        ),
+    )
+
+    assert rehearsal._resolve_transition("from", "target", "auto") == "forward"
+    assert rehearsal._resolve_transition("newer", "older", "auto") == "rollback"
+    assert (
+        rehearsal._resolve_transition("newer", "older", "rollback")
+        == "rollback"
+    )
+    with pytest.raises(SystemExit, match="does not descend"):
+        rehearsal._resolve_transition("newer", "older", "forward")
+
+
+def test_rehearsal_rejects_unrelated_transition(monkeypatch) -> None:
+    monkeypatch.setattr(rehearsal, "_is_ancestor", lambda *_args: False)
+
+    with pytest.raises(SystemExit, match="unrelated"):
+        rehearsal._resolve_transition("from", "target", "auto")
 
 
 def test_exact_rehearsal_rejects_repository_module_substitution() -> None:

--- a/tests/test_gateway_git_restart_wiring.py
+++ b/tests/test_gateway_git_restart_wiring.py
@@ -20,6 +20,46 @@ def _ordered_offsets(text: str, markers: tuple[str, ...]) -> list[int]:
     return offsets
 
 
+def test_gateway_restart_accepts_only_one_exact_commit_argument() -> None:
+    script = (ROOT / "gw_restart.sh").read_text(encoding="utf-8")
+
+    assert 'REQUESTED_GATEWAY_DEPLOY_COMMIT="${GATEWAY_DEPLOY_COMMIT:-}"' in script
+    assert 'requested_commit="${1#--commit=}"' in script
+    assert "unsupported gateway restart argument" in script
+    assert (
+        '[[ "$REQUESTED_GATEWAY_DEPLOY_COMMIT" =~ ^[0-9a-f]{40}$ ]]'
+        in script
+    )
+    assert '--deploy-commit "$REQUESTED_GATEWAY_DEPLOY_COMMIT"' in script
+
+    invalid = subprocess.run(
+        ["bash", str(ROOT / "gw_restart.sh"), "--commit", "abc123"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert invalid.returncode == 2
+    assert "lowercase full 40-character SHA" in invalid.stderr
+    assert "Hydrating gateway env" not in invalid.stdout
+
+    conflict = subprocess.run(
+        [
+            "bash",
+            str(ROOT / "gw_restart.sh"),
+            "--commit",
+            "2" * 40,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        env={**os.environ, "GATEWAY_DEPLOY_COMMIT": "1" * 40},
+    )
+    assert conflict.returncode == 2
+    assert "--commit conflicts with GATEWAY_DEPLOY_COMMIT" in conflict.stderr
+
+
 def test_gateway_restart_activates_git_between_shutdown_and_existing_workflow() -> None:
     script = (ROOT / "gw_restart.sh").read_text(encoding="utf-8")
     _ordered_offsets(

--- a/tests/test_production_restart_safety.py
+++ b/tests/test_production_restart_safety.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import replace
 from pathlib import Path
+import re
+import subprocess
 import sys
 from types import SimpleNamespace
 
@@ -34,6 +36,33 @@ def _snapshot(epoch_block: int) -> SubnetEpochSnapshot:
         tempo=360,
         blocks_since_last_step=epoch_block,
         observed_at="2026-07-18T00:00:00Z",
+    )
+
+
+def test_gateway_and_validator_share_stateful_v2_rollback_floor() -> None:
+    gateway = (ROOT / "gw_restart.sh").read_text(encoding="utf-8")
+    validator = (ROOT / "validator_restart.sh").read_text(encoding="utf-8")
+    pattern = re.compile(
+        r'V2_DEPLOYMENT_COMPATIBILITY_FLOOR_SHA="([0-9a-f]{40})"'
+    )
+    gateway_floor = pattern.search(gateway)
+    validator_floor = pattern.search(validator)
+
+    assert gateway_floor is not None
+    assert validator_floor is not None
+    assert gateway_floor.group(1) == validator_floor.group(1)
+    assert "predates the supported stateful V2 rollback floor" in gateway
+    assert "predates the supported stateful V2 rollback floor" in validator
+    subprocess.run(
+        [
+            "git",
+            "merge-base",
+            "--is-ancestor",
+            gateway_floor.group(1),
+            "HEAD",
+        ],
+        cwd=ROOT,
+        check=True,
     )
 
 
@@ -245,7 +274,11 @@ def test_validator_restart_does_not_require_a_live_gateway() -> None:
     assert 'gateway_authority_status = "not_aligned"' in deploy
     assert '"gateway_authority_status": gateway_authority_status' in deploy
     assert 'raise SystemExit("VALIDATOR_V2_GATEWAY_URL is missing")' not in deploy
-    assert "gateway V2 authority is not ready" not in deploy
+    assert (
+        'os.environ.get("VALIDATOR_EXACT_RELEASE_PINNED") == "1"'
+        in deploy
+    )
+    assert "pinned gateway V2 authority is not ready" in deploy
 
 
 def test_validator_secret_environment_overrides_local_fallback_files() -> None:

--- a/tests/test_validator_restart_wrapper_v2.py
+++ b/tests/test_validator_restart_wrapper_v2.py
@@ -1,4 +1,6 @@
+import os
 from pathlib import Path
+import subprocess
 
 
 def test_restart_preserves_all_tracked_diffs_before_pull():
@@ -23,6 +25,73 @@ def test_restart_allows_only_one_invocation_pinned_ancestor_commit():
     )
     assert 'git checkout --detach "$REQUESTED_VALIDATOR_DEPLOY_COMMIT"' in script
     assert '"VALIDATOR_DEPLOY_COMMIT",' in script
+
+
+def test_restart_accepts_exact_commit_argument_and_rejects_conflicts():
+    script = Path("validator_restart.sh").read_text(encoding="utf-8")
+
+    assert 'requested_commit="${1#--commit=}"' in script
+    assert "unsupported validator restart argument" in script
+    assert (
+        '[[ "$REQUESTED_VALIDATOR_DEPLOY_COMMIT" =~ ^[0-9a-f]{40}$ ]]'
+        in script
+    )
+
+    invalid = subprocess.run(
+        ["bash", "validator_restart.sh", "--commit", "abc123"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert invalid.returncode == 2
+    assert "lowercase full 40-character SHA" in invalid.stderr
+    assert "Pulling latest GitHub main" not in invalid.stdout
+
+    conflict = subprocess.run(
+        ["bash", "validator_restart.sh", "--commit", "2" * 40],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        env={**os.environ, "VALIDATOR_DEPLOY_COMMIT": "1" * 40},
+    )
+    assert conflict.returncode == 2
+    assert "--commit conflicts with VALIDATOR_DEPLOY_COMMIT" in conflict.stderr
+
+
+def test_pinned_restart_requires_same_gateway_release_before_shutdown():
+    script = Path("validator_restart.sh").read_text(encoding="utf-8")
+    deploy = Path(
+        "validator_models/containerizing/deploy_dynamic.sh"
+    ).read_text(encoding="utf-8")
+
+    prestart_verify = script.index(
+        'echo "Checking same-SHA gateway alignment before stopping validator"'
+    )
+    release_ready = script.index(
+        'if [ "$VALIDATOR_V2_RELEASE_READY" != "1" ]'
+    )
+    shutdown = script.index('echo "Stopping validator processes and containers"')
+    start = script.index('echo "Starting validator"')
+    poststart_verify = script.index(
+        'echo "Rechecking same-SHA gateway alignment after validator startup"'
+    )
+    assert release_ready < prestart_verify < shutdown < start < poststart_verify
+    assert script.count("verify_pinned_gateway_release") == 3
+    for endpoint in (
+        "/health/v2-authority",
+        "/build-info",
+        "/weights/v2/release-evidence/",
+    ):
+        assert endpoint in script
+    assert 'export VALIDATOR_EXACT_RELEASE_PINNED=1' in script
+    assert (
+        '-e VALIDATOR_EXACT_RELEASE_PINNED="${VALIDATOR_EXACT_RELEASE_PINNED:-0}"'
+        in deploy
+    )
+    assert 'git -C "$REPO_DIR" symbolic-ref -q HEAD' in deploy
+    assert "pinned gateway V2 authority is not ready" in deploy
 
 
 def test_restart_loads_one_canonical_cutover_manifest():

--- a/validator_models/containerizing/deploy_dynamic.sh
+++ b/validator_models/containerizing/deploy_dynamic.sh
@@ -79,6 +79,24 @@ if [ "$HEAD_SHA" != "$VALIDATOR_V2_DEPLOY_COMMIT" ]; then
     echo "   approved=$VALIDATOR_V2_DEPLOY_COMMIT observed=$HEAD_SHA" >&2
     exit 1
 fi
+if [ -z "${VALIDATOR_EXACT_RELEASE_PINNED+x}" ]; then
+    if git -C "$REPO_DIR" symbolic-ref -q HEAD >/dev/null 2>&1; then
+        VALIDATOR_EXACT_RELEASE_PINNED=0
+    else
+        # The N-1 wrapper already pins by detaching HEAD. Inferring the marker
+        # here makes the first exact-commit upgrade enforce the new alignment
+        # gate even though the installed launcher predates this variable.
+        VALIDATOR_EXACT_RELEASE_PINNED=1
+    fi
+fi
+case "$VALIDATOR_EXACT_RELEASE_PINNED" in
+    0|1) ;;
+    *)
+        echo "❌ ERROR: VALIDATOR_EXACT_RELEASE_PINNED must be 0 or 1" >&2
+        exit 1
+        ;;
+esac
+export VALIDATOR_EXACT_RELEASE_PINNED
 echo "✅ Exact validator commit remains active: $HEAD_SHA"
 echo ""
 
@@ -400,6 +418,7 @@ start_container() {
       -e LEADPOET_WRAPPER_ACTIVE=1 \
       -e VALIDATOR_RUNTIME_GENERATION="$VALIDATOR_RUNTIME_GENERATION" \
       -e VALIDATOR_V2_DEPLOY_COMMIT="$VALIDATOR_V2_DEPLOY_COMMIT" \
+      -e VALIDATOR_EXACT_RELEASE_PINNED="${VALIDATOR_EXACT_RELEASE_PINNED:-0}" \
       -e GITHUB_SHA="$VALIDATOR_V2_DEPLOY_COMMIT" \
       -e GIT_COMMIT="$VALIDATOR_V2_DEPLOY_COMMIT" \
       -e VALIDATOR_V2_GATEWAY_URL="${VALIDATOR_V2_GATEWAY_URL:-}" \
@@ -803,6 +822,20 @@ if gateway_url:
             gateway_authority_status = "not_aligned"
 else:
     gateway_authority_error_type = "gateway_url_not_configured"
+
+if (
+    os.environ.get("VALIDATOR_EXACT_RELEASE_PINNED") == "1"
+    and gateway_authority_status != "ready"
+):
+    raise SystemExit(
+        "pinned gateway V2 authority is not ready on the validator release commit: "
+        + gateway_authority_status
+        + (
+            " (" + gateway_authority_error_type + ")"
+            if gateway_authority_error_type
+            else ""
+        )
+    )
 
 network = os.environ.get("SUBTENSOR_NETWORK", "finney")
 netuid = int(os.environ.get("NETUID", "71"))

--- a/validator_restart.sh
+++ b/validator_restart.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+V2_DEPLOYMENT_COMPATIBILITY_FLOOR_SHA="bd71fdda2aca4e17d07b3e55f56a66f7bd1bbdc3"
 VALIDATOR_ROOT="${VALIDATOR_ROOT:-/home/ec2-user/leadpoet/leadpoet}"
 VALIDATOR_ENV_FILE="${VALIDATOR_ENV_FILE:-/home/ec2-user/.config/leadpoet/validator.env}"
 LEADPOET_VALIDATOR_ENV_SECRET_ID="${LEADPOET_VALIDATOR_ENV_SECRET_ID:-leadpoet/prod/validator/env}"
@@ -29,6 +30,112 @@ VALIDATOR_WALLET_NAME="${VALIDATOR_WALLET_NAME:-validator_72}"
 VALIDATOR_WALLET_HOTKEY="${VALIDATOR_WALLET_HOTKEY:-default}"
 REQUESTED_VALIDATOR_DEPLOY_COMMIT="${VALIDATOR_DEPLOY_COMMIT:-}"
 unset VALIDATOR_DEPLOY_COMMIT
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --commit)
+      if [ "$#" -lt 2 ] || [ -z "${2:-}" ]; then
+        echo "ERROR: --commit requires a full 40-character SHA" >&2
+        exit 2
+      fi
+      if [ -n "$REQUESTED_VALIDATOR_DEPLOY_COMMIT" ] \
+          && [ "$REQUESTED_VALIDATOR_DEPLOY_COMMIT" != "$2" ]; then
+        echo "ERROR: --commit conflicts with VALIDATOR_DEPLOY_COMMIT" >&2
+        exit 2
+      fi
+      REQUESTED_VALIDATOR_DEPLOY_COMMIT="$2"
+      shift 2
+      ;;
+    --commit=*)
+      requested_commit="${1#--commit=}"
+      if [ -z "$requested_commit" ]; then
+        echo "ERROR: --commit requires a full 40-character SHA" >&2
+        exit 2
+      fi
+      if [ -n "$REQUESTED_VALIDATOR_DEPLOY_COMMIT" ] \
+          && [ "$REQUESTED_VALIDATOR_DEPLOY_COMMIT" != "$requested_commit" ]; then
+        echo "ERROR: --commit conflicts with VALIDATOR_DEPLOY_COMMIT" >&2
+        exit 2
+      fi
+      REQUESTED_VALIDATOR_DEPLOY_COMMIT="$requested_commit"
+      shift
+      ;;
+    *)
+      echo "ERROR: unsupported validator restart argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+if [ -n "$REQUESTED_VALIDATOR_DEPLOY_COMMIT" ] \
+    && ! [[ "$REQUESTED_VALIDATOR_DEPLOY_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: --commit must be a lowercase full 40-character SHA" >&2
+  exit 2
+fi
+
+verify_pinned_gateway_release() {
+  local gateway_health gateway_build_info gateway_release_evidence
+  echo "Verifying the pinned gateway release is active on ${VALIDATOR_DEPLOY_SHA}"
+  gateway_health="$(
+    curl --fail --silent --show-error \
+      --connect-timeout 5 --max-time 35 \
+      "${VALIDATOR_V2_GATEWAY_URL%/}/health/v2-authority"
+  )"
+  gateway_build_info="$(
+    curl --fail --silent --show-error \
+      --connect-timeout 5 --max-time 35 \
+      "${VALIDATOR_V2_GATEWAY_URL%/}/build-info"
+  )"
+  gateway_release_evidence="$(
+    curl --fail --silent --show-error \
+      --connect-timeout 5 --max-time 35 \
+      "${VALIDATOR_V2_GATEWAY_URL%/}/weights/v2/release-evidence/${VALIDATOR_DEPLOY_SHA}"
+  )"
+  "$VALIDATOR_PYTHON_BIN" - \
+    "$VALIDATOR_DEPLOY_SHA" \
+    "$gateway_health" \
+    "$gateway_build_info" \
+    "$gateway_release_evidence" <<'PY'
+import json
+import sys
+
+expected_commit = str(sys.argv[1] or "").lower()
+
+
+def load_json(raw, label):
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError):
+        raise SystemExit("pinned gateway %s is invalid JSON" % label)
+    if not isinstance(value, dict):
+        raise SystemExit("pinned gateway %s is not an object" % label)
+    return value
+
+
+health = load_json(sys.argv[2], "V2 authority")
+if (
+    health.get("status") != "ready"
+    or str(health.get("commit_sha") or "").lower() != expected_commit
+):
+    raise SystemExit("pinned gateway V2 authority is not ready on the selected commit")
+
+build_info = load_json(sys.argv[3], "build-info")
+if str(build_info.get("git_commit") or "").lower() != expected_commit:
+    raise SystemExit("pinned gateway build-info differs from the selected commit")
+
+release = load_json(sys.argv[4], "release evidence")
+if (
+    release.get("schema_version") != "leadpoet.auditor_release_evidence.v2"
+    or str(release.get("commit_sha") or "").lower() != expected_commit
+):
+    raise SystemExit("pinned gateway release evidence differs from the selected commit")
+
+print(json.dumps({
+    "status": "pinned_gateway_release_aligned",
+    "commit_sha": expected_commit,
+}, sort_keys=True))
+PY
+}
+
 VALIDATOR_ENV_EXPORT="$(mktemp /tmp/validator_env_export.XXXXXX)"
 SECRET_TMP="$(mktemp /tmp/validator_secret_env.XXXXXX)"
 
@@ -56,6 +163,12 @@ if [ -n "$REQUESTED_VALIDATOR_DEPLOY_COMMIT" ]; then
   fi
   if ! git merge-base --is-ancestor "$REQUESTED_VALIDATOR_DEPLOY_COMMIT" origin/main; then
     echo "ERROR: VALIDATOR_DEPLOY_COMMIT is not reachable from origin/main" >&2
+    exit 1
+  fi
+  if ! git merge-base --is-ancestor \
+      "$V2_DEPLOYMENT_COMPATIBILITY_FLOOR_SHA" \
+      "$REQUESTED_VALIDATOR_DEPLOY_COMMIT"; then
+    echo "ERROR: selected validator commit predates the supported stateful V2 rollback floor" >&2
     exit 1
   fi
   git checkout --detach "$REQUESTED_VALIDATOR_DEPLOY_COMMIT"
@@ -126,6 +239,7 @@ skip_keys = {
     "AWS_SECURITY_TOKEN",
     "AWS_PROFILE",
     "VALIDATOR_DEPLOY_COMMIT",
+    "VALIDATOR_EXACT_RELEASE_PINNED",
 }
 exports = []
 for raw_line in raw.replace("\x00", "\n").splitlines():
@@ -262,6 +376,11 @@ export VALIDATOR_V2_DEPLOY_COMMIT="$VALIDATOR_DEPLOY_SHA"
 export GITHUB_SHA="$VALIDATOR_DEPLOY_SHA"
 export GIT_COMMIT="$VALIDATOR_DEPLOY_SHA"
 export LEADPOET_WRAPPER_ACTIVE=1
+if [ -n "$REQUESTED_VALIDATOR_DEPLOY_COMMIT" ]; then
+  export VALIDATOR_EXACT_RELEASE_PINNED=1
+else
+  export VALIDATOR_EXACT_RELEASE_PINNED=0
+fi
 
 case "$VALIDATOR_USE_CAPTURED_RESTART_START" in
   0|1) ;;
@@ -348,6 +467,11 @@ print(json.dumps({
 PY
   echo "Validator remains untouched. Complete the V2 bootstrap ceremony, then rerun this restart." >&2
   exit 75
+fi
+
+if [ "$VALIDATOR_EXACT_RELEASE_PINNED" = "1" ]; then
+  echo "Checking same-SHA gateway alignment before stopping validator"
+  verify_pinned_gateway_release
 fi
 
 echo "Refreshing public validator hotkey measurements for the selected release"
@@ -558,6 +682,10 @@ if [ "$(docker inspect -f '{{.State.Running}}' leadpoet-validator-main)" != "tru
   echo "ERROR: validator coordinator failed its final restart-wrapper check" >&2
   docker logs --tail 160 leadpoet-validator-main >&2 || true
   exit 1
+fi
+if [ "$VALIDATOR_EXACT_RELEASE_PINNED" = "1" ]; then
+  echo "Rechecking same-SHA gateway alignment after validator startup"
+  verify_pinned_gateway_release
 fi
 leadpoet_release_docker_operation_lock_v2
 if [ "$VALIDATOR_USE_CAPTURED_RESTART_START" = "1" ]; then


### PR DESCRIPTION
## Summary

- add `--commit <full-sha>` to the gateway and validator restart launchers while preserving the one-invocation environment pins for N-1 compatibility
- reject commits outside `origin/main` ancestry or before the shared stateful-V2 compatibility floor
- require explicit pinned validator restarts to verify the gateway is serving the same commit before shutdown and again after startup
- extend the isolated restart harness to model forward, rollback, and subsequent roll-forward transitions
- document the paired gateway-first rollback procedure and verification requirements

## Why

Restarts previously selected the latest `main` commit. If that commit was still awaiting attestation, operators could miss the weight window even when an older compatible commit was already attested. The same limitation prevented a controlled rollback to an older supported V2 release.

## Safety properties

- explicit pins require lowercase full 40-character SHAs
- the target must be reachable from `origin/main`
- targets before the stateful V2 rollback floor are rejected
- all existing release-channel, PCR0, attestation, credential, readiness, and allocation-handoff gates remain in place
- normal unpinned restarts retain their existing latest-commit and gateway-independent behavior
- rollback remains a paired gateway/validator operation on one SHA

## Validation

- shell syntax and Python compilation passed
- focused restart/harness suite: 52 passed
- combined restart, release, lineage, weight, and auditor suite: 307 passed
- complete repository suite: 3,854 passed, 1 skipped; 52 failures and 13 errors remain outside the modified paths, dominated by sandbox socket restrictions and pre-existing/version-sensitive full-stack tests
- the exact Docker resource probe passed for Linux/amd64, read-only source mount, network isolation, 16-CPU quota, and 128 GiB memory cgroup

## Known release-gate limitation

For frozen commit `7efa72335955f34e499884a96737211f0ae755b3`, the pinned Amazon Linux rehearsal image built successfully and the Python 3.7 finalization probe passed. The subsequent N-1 gateway launch failed closed in the existing exact-rehearsal adapter because its `pgrep` and `df` command adapters were classified as forbidden repository substitutions. Gateway completion, validator completion, rollback, and roll-forward therefore remain **unexercised** for this SHA. This draft PR is for review only and must not be treated as safe to deploy or merge until those exact rehearsals complete and their evidence is attached.
