### PR TITLE
Use leadpoet-lab for Research Lab sourcing models

### DIFF
--- a/gateway/research_lab/admin.py
+++ b/gateway/research_lab/admin.py
@@ -542,8 +542,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     sync_repo_head = sub.add_parser(
         "sync-active-model-to-repo-head",
-        help="Sync active private model lineage to the signed current.json for private repo main; "
-        "dry-run reports repo/head/current active SHA state",
+        help=(
+            "Sync active private model lineage to the signed current.json for "
+            "the configured source branch; dry-run reports repo/head/current "
+            "active SHA state"
+        ),
     )
     sync_repo_head.add_argument("--actor-ref", default=default_actor_ref())
     sync_repo_head.add_argument("--dry-run", dest="dry_run", action="store_true", default=True)
@@ -551,7 +554,10 @@ def build_parser() -> argparse.ArgumentParser:
     sync_repo_head.add_argument(
         "--wait-for-current-json",
         action="store_true",
-        help="Poll current.json until it matches repo main before writing",
+        help=(
+            "Poll current.json until it matches the configured source branch "
+            "before writing"
+        ),
     )
     sync_repo_head.add_argument("--timeout-seconds", type=int, default=None)
     sync_repo_head.add_argument("--poll-seconds", type=int, default=None)

--- a/gateway/research_lab/config.py
+++ b/gateway/research_lab/config.py
@@ -163,6 +163,11 @@ DEFAULT_PROVIDER_COST_UNKNOWN_ENDPOINT_POLICY = "default_5_credits"
 STALE_PARENT_REBASE_REPAIR_MODEL_ID = "anthropic/claude-opus-4.8"
 STALE_PARENT_REBASE_REPAIR_TIMEOUT_SECONDS = 1200
 DEFAULT_PRIVATE_REPO_URL = ""
+DEFAULT_PRIVATE_REPO_BRANCH = "leadpoet-lab"
+DEFAULT_PRIVATE_MODEL_MANIFEST_URI = (
+    "s3://leadpoet-private-model-artifacts-493765492819/"
+    "research-lab/sourcing-model/branches/leadpoet-lab/current.json"
+)
 DEFAULT_PRIVATE_TEST_CMD = r"""
 python3 - <<'PY'
 import research_lab_adapter
@@ -199,7 +204,7 @@ cleanup_candidate_image() {
 }
 trap cleanup_candidate_image EXIT
 PLATFORM="${RESEARCH_LAB_PRIVATE_MODEL_DOCKER_PLATFORM:-linux/amd64}"
-PARENT_MANIFEST_URI="${RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI:-s3://leadpoet-private-model-artifacts-493765492819/research-lab/sourcing-model/current.json}"
+PARENT_MANIFEST_URI="${RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI:-s3://leadpoet-private-model-artifacts-493765492819/research-lab/sourcing-model/branches/leadpoet-lab/current.json}"
 MANIFEST_BASE="${PARENT_MANIFEST_URI%/*}"
 MANIFEST_URI="${MANIFEST_BASE}/candidates/${RUN_ID}/${CANDIDATE_INDEX}/${COMMIT_SHA}.json"
 SIGNATURE_URI="${MANIFEST_BASE}/candidates/${RUN_ID}/${CANDIDATE_INDEX}/${COMMIT_SHA}.sig.b64"
@@ -656,11 +661,9 @@ class ResearchLabGatewayConfig:
     conditional_holdout_total_icps: int = 20
     conditional_validation_fresh_icp_count: int = 20
     improvement_threshold_points: float = 1.0
-    private_model_manifest_uri: str = (
-        "s3://leadpoet-private-model-artifacts-493765492819/research-lab/sourcing-model/current.json"
-    )
+    private_model_manifest_uri: str = DEFAULT_PRIVATE_MODEL_MANIFEST_URI
     private_repo_url: str = DEFAULT_PRIVATE_REPO_URL
-    private_repo_branch: str = "main"
+    private_repo_branch: str = DEFAULT_PRIVATE_REPO_BRANCH
     private_patch_applier_cmd: str = ""
     private_test_cmd: str = DEFAULT_PRIVATE_TEST_CMD
     private_build_cmd: str = DEFAULT_PRIVATE_BUILD_CMD
@@ -1260,10 +1263,13 @@ class ResearchLabGatewayConfig:
             improvement_threshold_points=improvement_threshold_points,
             private_model_manifest_uri=os.getenv(
                 "RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI",
-                "s3://leadpoet-private-model-artifacts-493765492819/research-lab/sourcing-model/current.json",
+                DEFAULT_PRIVATE_MODEL_MANIFEST_URI,
             ),
             private_repo_url=os.getenv("RESEARCH_LAB_PRIVATE_REPO_URL", DEFAULT_PRIVATE_REPO_URL),
-            private_repo_branch=os.getenv("RESEARCH_LAB_PRIVATE_REPO_BRANCH", "main") or "main",
+            private_repo_branch=(
+                os.getenv("RESEARCH_LAB_PRIVATE_REPO_BRANCH", DEFAULT_PRIVATE_REPO_BRANCH)
+                or DEFAULT_PRIVATE_REPO_BRANCH
+            ),
             private_patch_applier_cmd=os.getenv("RESEARCH_LAB_PRIVATE_PATCH_APPLIER_CMD", ""),
             private_test_cmd=os.getenv("RESEARCH_LAB_PRIVATE_TEST_CMD", DEFAULT_PRIVATE_TEST_CMD),
             private_build_cmd=os.getenv("RESEARCH_LAB_PRIVATE_BUILD_CMD", DEFAULT_PRIVATE_BUILD_CMD),

--- a/gateway/research_lab/promotion.py
+++ b/gateway/research_lab/promotion.py
@@ -45,10 +45,12 @@ from gateway.research_lab.store import (
 )
 from leadpoet_verifier.economics import build_champion_reward_obligation
 from research_lab.eval import (
+    DEFAULT_PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID,
     PrivateModelArtifactManifest,
     load_private_artifact_manifest,
     sign_digest_with_kms,
     validate_private_model_artifact_manifest,
+    verify_private_artifact_manifest_signature,
 )
 from research_lab.eval.promotion_metric import (
     PromotionGateDecision,
@@ -79,6 +81,9 @@ REPO_HEAD_SYNC_ENABLED_ENV = "RESEARCH_LAB_SYNC_ACTIVE_MODEL_TO_REPO_HEAD"
 REPO_HEAD_MANIFEST_WAIT_SECONDS_ENV = "RESEARCH_LAB_REPO_HEAD_MANIFEST_WAIT_SECONDS"
 REPO_HEAD_MANIFEST_POLL_SECONDS_ENV = "RESEARCH_LAB_REPO_HEAD_MANIFEST_POLL_SECONDS"
 REPO_HEAD_GIT_TIMEOUT_SECONDS_ENV = "RESEARCH_LAB_REPO_HEAD_GIT_TIMEOUT_SECONDS"
+PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID_ENV = (
+    "RESEARCH_LAB_PRIVATE_MODEL_KMS_KEY_ID"
+)
 DEFAULT_REPO_HEAD_MANIFEST_WAIT_SECONDS = 600
 DEFAULT_REPO_HEAD_MANIFEST_POLL_SECONDS = 15
 DEFAULT_REPO_HEAD_GIT_TIMEOUT_SECONDS = 20
@@ -3693,6 +3698,17 @@ def _load_valid_artifact(uri: str) -> PrivateModelArtifactManifest:
     errors = validate_private_model_artifact_manifest(artifact)
     if errors:
         raise RuntimeError("private artifact manifest failed validation: " + "; ".join(errors))
+    signing_key_id = (
+        os.getenv(
+            PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID_ENV,
+            DEFAULT_PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID,
+        ).strip()
+        or DEFAULT_PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID
+    )
+    verify_private_artifact_manifest_signature(
+        artifact,
+        key_id=signing_key_id,
+    )
     return artifact
 
 

--- a/gateway/research_lab/promotion.py
+++ b/gateway/research_lab/promotion.py
@@ -21,7 +21,10 @@ from gateway.research_lab.attested_scoring import (
     compare_promotion_metric,
 )
 from gateway.research_lab.chain import resolve_research_lab_evaluation_epoch
-from gateway.research_lab.config import ResearchLabGatewayConfig
+from gateway.research_lab.config import (
+    DEFAULT_PRIVATE_REPO_BRANCH,
+    ResearchLabGatewayConfig,
+)
 from gateway.research_lab.public_benchmarks import build_public_benchmark_report
 from gateway.research_lab.tee_protocol import legacy_v1_enabled
 from gateway.research_lab.store import (
@@ -380,14 +383,14 @@ class RepoHeadMismatchError(RuntimeError):
 
 
 class RepoHeadManifestNotReadyError(PromotionPausedError):
-    """GitHub main is ahead of the signed current.json manifest."""
+    """The configured source branch is ahead of the signed current.json manifest."""
 
     def __init__(self, *, repo_main_sha: str, current_json_git_sha: str):
         self.repo_main_sha = str(repo_main_sha or "")
         self.current_json_git_sha = str(current_json_git_sha or "")
         super().__init__(
-            "repo_head_manifest_not_ready: private repo main is ahead of current.json "
-            f"(repo_main={self.repo_main_sha[:12]}, current_json={self.current_json_git_sha[:12]}); "
+            "repo_head_manifest_not_ready: configured private repo branch is ahead of current.json "
+            f"(repo_head={self.repo_main_sha[:12]}, current_json={self.current_json_git_sha[:12]}); "
             "daily benchmark deferred so it cannot run a stale active artifact"
         )
 
@@ -722,7 +725,7 @@ async def private_repo_head_alignment_status(
     *,
     current_artifact: PrivateModelArtifactManifest | None = None,
 ) -> dict[str, Any]:
-    """Read-only status for active lineage vs private repo main/current.json."""
+    """Read-only status for active lineage vs the configured source branch."""
 
     if not config.private_repo_url:
         return {
@@ -730,7 +733,7 @@ async def private_repo_head_alignment_status(
             "status": "private_repo_not_configured",
             "active_is_repo_head": False,
         }
-    branch_name = str(config.private_repo_branch or "main")
+    branch_name = str(config.private_repo_branch or DEFAULT_PRIVATE_REPO_BRANCH)
     try:
         repo_main_sha = await asyncio.to_thread(
             _resolve_private_repo_head_sha,
@@ -840,11 +843,12 @@ async def sync_active_model_to_repo_head(
     wait_timeout_seconds: int | None = None,
     poll_seconds: int | None = None,
 ) -> dict[str, Any]:
-    """Make the active lineage row point at private repo main's current.json.
+    """Make the active lineage row point at the configured source branch.
 
-    This is the safety gate for daily rebenchmark: GitHub main is the source of
-    truth for source, S3 current.json is the source of truth for the immutable
-    built/signed image. If they disagree, do not benchmark stale lineage.
+    This is the safety gate for daily rebenchmark: the configured source branch
+    is the source of truth for source, while S3 current.json is the source of
+    truth for the immutable built/signed image. If they disagree, do not
+    benchmark stale lineage.
     """
 
     action = "sync-active-model-to-repo-head"
@@ -865,7 +869,7 @@ async def sync_active_model_to_repo_head(
             "status": "private_repo_not_configured",
             "active_is_repo_head": False,
         }
-    branch_name = str(config.private_repo_branch or "main")
+    branch_name = str(config.private_repo_branch or DEFAULT_PRIVATE_REPO_BRANCH)
     try:
         repo_main_sha = await asyncio.to_thread(
             _resolve_private_repo_head_sha,
@@ -2432,7 +2436,9 @@ class ResearchLabPromotionController:
 
         candidate_id = str(candidate["candidate_id"])
         score_bundle_id = str(score_bundle_row["score_bundle_id"])
-        branch_name = str(self.config.private_repo_branch or "main")
+        branch_name = str(
+            self.config.private_repo_branch or DEFAULT_PRIVATE_REPO_BRANCH
+        )
         repo_ref_hash = canonical_hash(
             {
                 "repo_url": self.config.private_repo_url,

--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -2997,7 +2997,7 @@ class ClaimLostDuringScoring(RuntimeError):
 
 
 class PrivateBaselineRepoHeadChanged(RuntimeError):
-    """Raised at an ICP boundary when repo main advances during a baseline run."""
+    """Raised when the configured source branch advances during a baseline run."""
 
     def __init__(self, *, expected_git_sha: str, repo_main_sha: str, item_index: int, total_icps: int):
         self.expected_git_sha = expected_git_sha
@@ -3007,7 +3007,7 @@ class PrivateBaselineRepoHeadChanged(RuntimeError):
         super().__init__(
             "private baseline repo head changed during run: "
             f"expected={compact_ref(expected_git_sha)} "
-            f"repo_main={compact_ref(repo_main_sha)} "
+            f"repo_head={compact_ref(repo_main_sha)} "
             f"before_icp={item_index}/{total_icps}"
         )
 
@@ -10934,8 +10934,8 @@ class ResearchLabGatewayScoringWorker:
                     ("Worker", self.worker_ref),
                     ("Benchmark date", benchmark_date),
                     ("ICP boundary", f"{item_index}/{total_icps}"),
-                    ("Started repo main", compact_ref(expected)),
-                    ("Current repo main", compact_ref(repo_main_sha)),
+                    ("Started source branch", compact_ref(expected)),
+                    ("Current source branch", compact_ref(repo_main_sha)),
                     ("Action", "failing this attempt so the next pass benchmarks the new artifact"),
                 ),
             )

--- a/gw_restart.sh
+++ b/gw_restart.sh
@@ -1295,6 +1295,7 @@ export AWS_REGION="${AWS_REGION:-us-east-1}"
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 export RESEARCH_LAB_PRIVATE_REPO_BRANCH="leadpoet-lab"
 export RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI="s3://leadpoet-private-model-artifacts-493765492819/research-lab/sourcing-model/branches/leadpoet-lab/current.json"
+export RESEARCH_LAB_PRIVATE_MODEL_KMS_KEY_ID="alias/leadpoet-research-lab-artifact-signing"
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_PROFILE AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
 
 ACTUAL_AWS_ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
@@ -1571,6 +1572,7 @@ export GATEWAY_ENV_FILE="${GATEWAY_ENV_FILE:-/home/ec2-user/.config/leadpoet/gat
 export LEADPOET_GATEWAY_ENV_SECRET_ID="${LEADPOET_GATEWAY_ENV_SECRET_ID:-leadpoet/prod/gateway/env}"
 export RESEARCH_LAB_PRIVATE_REPO_BRANCH="leadpoet-lab"
 export RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI="s3://leadpoet-private-model-artifacts-493765492819/research-lab/sourcing-model/branches/leadpoet-lab/current.json"
+export RESEARCH_LAB_PRIVATE_MODEL_KMS_KEY_ID="alias/leadpoet-research-lab-artifact-signing"
 unset RESEARCH_LAB_EVIDENCE_PROXY_URL RESEARCH_LAB_PROVIDER_OUTCOME_SIDECAR_PATH
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_PROFILE AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
 export LEADPOET_AWS_INSTANCE_ROLE_ONLY=true

--- a/gw_restart.sh
+++ b/gw_restart.sh
@@ -1293,7 +1293,8 @@ enforce_deployment_environment
 validate_runtime_secret_paths
 export AWS_REGION="${AWS_REGION:-us-east-1}"
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
-export RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI="${RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI:-s3://leadpoet-private-model-artifacts-493765492819/research-lab/sourcing-model/current.json}"
+export RESEARCH_LAB_PRIVATE_REPO_BRANCH="leadpoet-lab"
+export RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI="s3://leadpoet-private-model-artifacts-493765492819/research-lab/sourcing-model/branches/leadpoet-lab/current.json"
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_PROFILE AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
 
 ACTUAL_AWS_ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
@@ -1568,7 +1569,8 @@ export AWS_REGION="${AWS_REGION:-us-east-1}"
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 export GATEWAY_ENV_FILE="${GATEWAY_ENV_FILE:-/home/ec2-user/.config/leadpoet/gateway.env}"
 export LEADPOET_GATEWAY_ENV_SECRET_ID="${LEADPOET_GATEWAY_ENV_SECRET_ID:-leadpoet/prod/gateway/env}"
-export RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI="${RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI:-s3://leadpoet-private-model-artifacts-493765492819/research-lab/sourcing-model/current.json}"
+export RESEARCH_LAB_PRIVATE_REPO_BRANCH="leadpoet-lab"
+export RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI="s3://leadpoet-private-model-artifacts-493765492819/research-lab/sourcing-model/branches/leadpoet-lab/current.json"
 unset RESEARCH_LAB_EVIDENCE_PROXY_URL RESEARCH_LAB_PROVIDER_OUTCOME_SIDECAR_PATH
 unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_PROFILE AWS_SESSION_TOKEN AWS_SECURITY_TOKEN
 export LEADPOET_AWS_INSTANCE_ROLE_ONLY=true

--- a/research_lab/eval/__init__.py
+++ b/research_lab/eval/__init__.py
@@ -18,6 +18,7 @@ from .evaluator import (
 )
 from .patches import CandidatePatchManifest, validate_candidate_patch_manifest
 from .private_runtime import (
+    DEFAULT_PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID,
     DockerPrivateModelRunner,
     DockerPrivateModelSpec,
     PrivateModelAdapterSpec,
@@ -29,10 +30,12 @@ from .private_runtime import (
     load_private_artifact_manifest,
     private_model_env_passthrough,
     sign_digest_with_kms,
+    verify_private_artifact_manifest_signature,
 )
 
 __all__ = [
     "CandidatePatchManifest",
+    "DEFAULT_PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID",
     "DockerPrivateModelRunner",
     "DockerPrivateModelSpec",
     "PrivateModelArtifactManifest",
@@ -53,5 +56,6 @@ __all__ = [
     "validate_candidate_patch_manifest",
     "validate_private_model_artifact_manifest",
     "validate_sealed_benchmark_set",
+    "verify_private_artifact_manifest_signature",
     "verify_private_model_artifact_manifest",
 ]

--- a/research_lab/eval/private_runtime.py
+++ b/research_lab/eval/private_runtime.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import base64
 import contextvars
+from functools import lru_cache
 import json
 import logging
 import os
@@ -75,6 +76,9 @@ PROVIDER_COST_ENV_PASSTHROUGH = (
 )
 PROVIDER_COST_EVALUATION_SCOPE_ENV = "RESEARCH_LAB_PROVIDER_COST_EVALUATION_SCOPE"
 DEFAULT_DOCKER_PLATFORM = "linux/amd64"
+DEFAULT_PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID = (
+    "alias/leadpoet-research-lab-artifact-signing"
+)
 DEFAULT_ENV_PASSTHROUGH = (
     "EXA_API_KEY",
     "SCRAPINGDOG_API_KEY",
@@ -603,6 +607,145 @@ def load_private_artifact_manifest(uri: str) -> dict[str, Any]:
     if _contains_secret_material(decoded):
         raise PrivateModelRuntimeError("private model manifest contains raw secret material")
     return dict(decoded)
+
+
+def verify_private_artifact_manifest_signature(
+    manifest: Any,
+    *,
+    key_id: str = DEFAULT_PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID,
+    s3_client: Any = None,
+    kms_client: Any = None,
+) -> dict[str, Any]:
+    """Verify that KMS signed the final, self-consistent manifest hash.
+
+    Successful default-client verifications are cached by immutable manifest
+    hash, signature URI, and key identity. Failures are never cached.
+    """
+
+    manifest_hash = _private_manifest_field(manifest, "manifest_hash")
+    signature_ref = _private_manifest_field(manifest, "signature_ref")
+    resolved_key_id = str(key_id or "").strip()
+    if not manifest_hash.startswith("sha256:") or len(manifest_hash) != 71:
+        raise PrivateModelRuntimeError(
+            "private artifact manifest signature requires a sha256 manifest hash"
+        )
+    if not signature_ref.startswith("s3://"):
+        raise PrivateModelRuntimeError(
+            "private artifact manifest signature_ref must be an s3:// URI"
+        )
+    if not resolved_key_id:
+        raise PrivateModelRuntimeError(
+            "private artifact manifest signing KMS key id is required"
+        )
+    payload = _private_manifest_hash_payload(manifest)
+    expected_manifest_hash = sha256_json(payload)
+    if manifest_hash != expected_manifest_hash:
+        raise PrivateModelRuntimeError(
+            "private artifact manifest hash does not match its payload"
+        )
+    if s3_client is None and kms_client is None:
+        return dict(
+            _verify_private_artifact_manifest_signature_cached(
+                manifest_hash,
+                signature_ref,
+                resolved_key_id,
+            )
+        )
+    return _verify_private_artifact_manifest_signature_uncached(
+        manifest_hash=manifest_hash,
+        signature_ref=signature_ref,
+        key_id=resolved_key_id,
+        s3_client=s3_client,
+        kms_client=kms_client,
+    )
+
+
+def _private_manifest_field(manifest: Any, field: str) -> str:
+    if isinstance(manifest, Mapping):
+        value = manifest.get(field)
+    else:
+        value = getattr(manifest, field, "")
+    return str(value or "").strip()
+
+
+def _private_manifest_hash_payload(manifest: Any) -> dict[str, Any]:
+    if isinstance(manifest, Mapping):
+        payload = dict(manifest)
+    else:
+        to_dict = getattr(manifest, "to_dict", None)
+        if not callable(to_dict):
+            raise PrivateModelRuntimeError(
+                "private artifact manifest must be a mapping or manifest object"
+            )
+        payload = dict(to_dict())
+    payload.pop("manifest_hash", None)
+    return payload
+
+
+@lru_cache(maxsize=256)
+def _verify_private_artifact_manifest_signature_cached(
+    manifest_hash: str,
+    signature_ref: str,
+    key_id: str,
+) -> dict[str, Any]:
+    return _verify_private_artifact_manifest_signature_uncached(
+        manifest_hash=manifest_hash,
+        signature_ref=signature_ref,
+        key_id=key_id,
+    )
+
+
+def _verify_private_artifact_manifest_signature_uncached(
+    *,
+    manifest_hash: str,
+    signature_ref: str,
+    key_id: str,
+    s3_client: Any = None,
+    kms_client: Any = None,
+) -> dict[str, Any]:
+    signature_bucket, signature_key = _parse_s3_uri(signature_ref)
+    if s3_client is None or kms_client is None:
+        try:
+            import boto3
+        except Exception as exc:
+            raise PrivateModelRuntimeError(
+                "boto3 is required to verify private artifact manifests"
+            ) from exc
+        s3_client = s3_client or boto3.client("s3")
+        kms_client = kms_client or boto3.client("kms")
+    try:
+        response = s3_client.get_object(
+            Bucket=signature_bucket,
+            Key=signature_key,
+        )
+        encoded_signature = response["Body"].read()
+        if isinstance(encoded_signature, bytes):
+            encoded_signature = encoded_signature.decode("ascii")
+        signature = base64.b64decode(str(encoded_signature).strip(), validate=True)
+        verification = kms_client.verify(
+            KeyId=key_id,
+            Message=manifest_hash.encode("utf-8"),
+            MessageType="RAW",
+            Signature=signature,
+            SigningAlgorithm="ECDSA_SHA_256",
+        )
+    except Exception as exc:
+        raise PrivateModelRuntimeError(
+            "private artifact manifest KMS signature verification failed"
+        ) from exc
+    if not bool(verification.get("SignatureValid")):
+        raise PrivateModelRuntimeError(
+            "private artifact manifest KMS signature was rejected"
+        )
+    return {
+        "verified": True,
+        "manifest_hash": manifest_hash,
+        "signature_ref": signature_ref,
+        "key_id": str(verification.get("KeyId") or key_id),
+        "signing_algorithm": str(
+            verification.get("SigningAlgorithm") or "ECDSA_SHA_256"
+        ),
+    }
 
 
 def sign_digest_with_kms(

--- a/research_lab/openrouter_telemetry.py
+++ b/research_lab/openrouter_telemetry.py
@@ -58,7 +58,7 @@ INCLUDE_REASONING_ENV = "RESEARCH_LAB_LLM_INCLUDE_REASONING"
 PRIVATE_MODEL_MANIFEST_URI_ENV = "RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI"
 DEFAULT_PRIVATE_MODEL_MANIFEST_URI = (
     "s3://leadpoet-private-model-artifacts-493765492819/"
-    "research-lab/sourcing-model/current.json"
+    "research-lab/sourcing-model/branches/leadpoet-lab/current.json"
 )
 
 _SECRET_PATTERNS = (

--- a/tests/test_config_fixes.py
+++ b/tests/test_config_fixes.py
@@ -11,6 +11,8 @@ import os
 import pytest
 
 from gateway.research_lab.config import (
+    DEFAULT_PRIVATE_MODEL_MANIFEST_URI,
+    DEFAULT_PRIVATE_REPO_BRANCH,
     MIN_IMPROVEMENT_THRESHOLD_POINTS,
     ResearchLabGatewayConfig,
 )
@@ -48,6 +50,43 @@ def test_dataclass_defaults_match_env_parsing_defaults(clean_env):
         if env_value != default_value:
             mismatches[field.name] = {"dataclass": default_value, "from_env": env_value}
     assert not mismatches, f"dataclass defaults diverge from env-parsing defaults: {mismatches}"
+
+
+def test_private_repo_branch_defaults_to_leadpoet_lab_and_allows_override(clean_env):
+    assert DEFAULT_PRIVATE_REPO_BRANCH == "leadpoet-lab"
+    assert DEFAULT_PRIVATE_MODEL_MANIFEST_URI.endswith(
+        "/sourcing-model/branches/leadpoet-lab/current.json"
+    )
+    assert ResearchLabGatewayConfig().private_repo_branch == DEFAULT_PRIVATE_REPO_BRANCH
+    assert (
+        ResearchLabGatewayConfig().private_model_manifest_uri
+        == DEFAULT_PRIVATE_MODEL_MANIFEST_URI
+    )
+    assert (
+        ResearchLabGatewayConfig.from_env().private_repo_branch
+        == DEFAULT_PRIVATE_REPO_BRANCH
+    )
+    assert (
+        ResearchLabGatewayConfig.from_env().private_model_manifest_uri
+        == DEFAULT_PRIVATE_MODEL_MANIFEST_URI
+    )
+
+    clean_env.setenv("RESEARCH_LAB_PRIVATE_REPO_BRANCH", "release-candidate")
+    clean_env.setenv(
+        "RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI",
+        "s3://test-models/release-candidate/current.json",
+    )
+    assert ResearchLabGatewayConfig.from_env().private_repo_branch == "release-candidate"
+    assert (
+        ResearchLabGatewayConfig.from_env().private_model_manifest_uri
+        == "s3://test-models/release-candidate/current.json"
+    )
+
+    clean_env.setenv("RESEARCH_LAB_PRIVATE_REPO_BRANCH", "")
+    assert (
+        ResearchLabGatewayConfig.from_env().private_repo_branch
+        == DEFAULT_PRIVATE_REPO_BRANCH
+    )
 
 
 def test_bug_32_reconciled_contradictions(clean_env):

--- a/tests/test_gateway_git_restart_wiring.py
+++ b/tests/test_gateway_git_restart_wiring.py
@@ -656,3 +656,20 @@ def test_gateway_docker_image_copies_complete_runtime_package_graph() -> None:
         "schemas",
     ):
         assert f"COPY {path}/ ./{path}/" in dockerfile
+
+
+def test_gateway_restart_defaults_research_lab_to_branch_manifest() -> None:
+    script = (ROOT / "gw_restart.sh").read_text(encoding="utf-8")
+    branch_pointer = (
+        "s3://leadpoet-private-model-artifacts-493765492819/"
+        "research-lab/sourcing-model/branches/leadpoet-lab/current.json"
+    )
+
+    assert script.count(
+        'export RESEARCH_LAB_PRIVATE_REPO_BRANCH="leadpoet-lab"'
+    ) == 2
+    assert script.count(
+        f'export RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI="{branch_pointer}"'
+    ) == 2
+    assert 'RESEARCH_LAB_PRIVATE_REPO_BRANCH="${' not in script
+    assert 'RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI="${' not in script

--- a/tests/test_gateway_git_restart_wiring.py
+++ b/tests/test_gateway_git_restart_wiring.py
@@ -671,5 +671,10 @@ def test_gateway_restart_defaults_research_lab_to_branch_manifest() -> None:
     assert script.count(
         f'export RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI="{branch_pointer}"'
     ) == 2
+    assert script.count(
+        'export RESEARCH_LAB_PRIVATE_MODEL_KMS_KEY_ID='
+        '"alias/leadpoet-research-lab-artifact-signing"'
+    ) == 2
     assert 'RESEARCH_LAB_PRIVATE_REPO_BRANCH="${' not in script
     assert 'RESEARCH_LAB_PRIVATE_MODEL_MANIFEST_URI="${' not in script
+    assert 'RESEARCH_LAB_PRIVATE_MODEL_KMS_KEY_ID="${' not in script

--- a/tests/test_openrouter_telemetry.py
+++ b/tests/test_openrouter_telemetry.py
@@ -189,7 +189,8 @@ def test_raw_trace_prefix_has_production_manifest_default(monkeypatch):
     monkeypatch.delenv(ot.PRIVATE_MODEL_MANIFEST_URI_ENV, raising=False)
 
     assert ot.resolved_raw_trace_s3_prefix() == (
-        "s3://leadpoet-private-model-artifacts-493765492819/research-lab/sourcing-model"
+        "s3://leadpoet-private-model-artifacts-493765492819/"
+        "research-lab/sourcing-model/branches/leadpoet-lab"
     )
 
 

--- a/tests/test_private_artifact_signature.py
+++ b/tests/test_private_artifact_signature.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+from typing import Any
+
+import pytest
+
+import gateway.research_lab.promotion as promotion
+from research_lab.canonical import sha256_json
+from research_lab.eval import (
+    DEFAULT_PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID,
+    PrivateModelArtifactManifest,
+    PrivateModelRuntimeError,
+    verify_private_artifact_manifest_signature,
+)
+
+
+class FakeS3:
+    def __init__(self, signature: bytes = b"der-signature") -> None:
+        self.signature = signature
+        self.calls: list[dict[str, Any]] = []
+
+    def get_object(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {
+            "Body": BytesIO(base64.b64encode(self.signature)),
+        }
+
+
+class FakeKms:
+    def __init__(self, *, valid: bool = True) -> None:
+        self.valid = valid
+        self.calls: list[dict[str, Any]] = []
+
+    def verify(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {
+            "SignatureValid": self.valid,
+            "KeyId": "arn:aws:kms:us-east-1:493765492819:key/test",
+            "SigningAlgorithm": "ECDSA_SHA_256",
+        }
+
+
+def artifact_mapping(**overrides: str) -> dict[str, str]:
+    payload = {
+        "model_artifact_hash": "sha256:" + "1" * 64,
+        "git_commit_sha": "2" * 40,
+        "image_digest": (
+            "493765492819.dkr.ecr.us-east-1.amazonaws.com/"
+            "leadpoet/sourcing-model@sha256:" + "3" * 64
+        ),
+        "config_hash": "sha256:" + "4" * 64,
+        "component_registry_version": "components:v1",
+        "scoring_adapter_version": "scorer:v1",
+        "manifest_uri": "s3://artifacts/model.json",
+        "signature_ref": "s3://artifacts/model.sig.b64",
+        "build_id": "build-1",
+    }
+    payload.update(overrides)
+    return {
+        **payload,
+        "manifest_hash": sha256_json(payload),
+    }
+
+
+def test_kms_verifies_the_final_manifest_hash() -> None:
+    manifest = PrivateModelArtifactManifest.from_mapping(artifact_mapping())
+    s3 = FakeS3()
+    kms = FakeKms()
+
+    result = verify_private_artifact_manifest_signature(
+        manifest,
+        s3_client=s3,
+        kms_client=kms,
+    )
+
+    assert result["verified"] is True
+    assert s3.calls == [{"Bucket": "artifacts", "Key": "model.sig.b64"}]
+    assert kms.calls == [
+        {
+            "KeyId": DEFAULT_PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID,
+            "Message": manifest.manifest_hash.encode("utf-8"),
+            "MessageType": "RAW",
+            "Signature": b"der-signature",
+            "SigningAlgorithm": "ECDSA_SHA_256",
+        }
+    ]
+
+
+def test_invalid_kms_signature_fails_closed() -> None:
+    with pytest.raises(
+        PrivateModelRuntimeError,
+        match="KMS signature was rejected",
+    ):
+        verify_private_artifact_manifest_signature(
+            artifact_mapping(),
+            s3_client=FakeS3(),
+            kms_client=FakeKms(valid=False),
+        )
+
+
+def test_manifest_payload_must_match_the_signed_hash() -> None:
+    manifest = artifact_mapping()
+    manifest["build_id"] = "tampered-after-signing"
+    s3 = FakeS3()
+    kms = FakeKms()
+
+    with pytest.raises(
+        PrivateModelRuntimeError,
+        match="manifest hash does not match its payload",
+    ):
+        verify_private_artifact_manifest_signature(
+            manifest,
+            s3_client=s3,
+            kms_client=kms,
+        )
+
+    assert s3.calls == []
+    assert kms.calls == []
+
+
+def test_signature_download_or_kms_error_fails_closed() -> None:
+    class BrokenS3:
+        def get_object(self, **_kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("unavailable")
+
+    with pytest.raises(
+        PrivateModelRuntimeError,
+        match="KMS signature verification failed",
+    ):
+        verify_private_artifact_manifest_signature(
+            artifact_mapping(),
+            s3_client=BrokenS3(),
+            kms_client=FakeKms(),
+        )
+
+
+def test_non_s3_signature_reference_is_rejected() -> None:
+    with pytest.raises(
+        PrivateModelRuntimeError,
+        match="signature_ref must be an s3:// URI",
+    ):
+        verify_private_artifact_manifest_signature(
+            artifact_mapping(signature_ref="kms:signature"),
+            s3_client=FakeS3(),
+            kms_client=FakeKms(),
+        )
+
+
+def test_promotion_loader_requires_signature_verification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = artifact_mapping()
+    verified: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        promotion,
+        "load_private_artifact_manifest",
+        lambda _uri: manifest,
+    )
+
+    def fake_verify(artifact: PrivateModelArtifactManifest, *, key_id: str):
+        verified["manifest_hash"] = artifact.manifest_hash
+        verified["key_id"] = key_id
+        return {"verified": True}
+
+    monkeypatch.setattr(
+        promotion,
+        "verify_private_artifact_manifest_signature",
+        fake_verify,
+    )
+
+    loaded = promotion._load_valid_artifact("s3://artifacts/current.json")
+
+    assert loaded.manifest_hash == manifest["manifest_hash"]
+    assert verified == {
+        "manifest_hash": manifest["manifest_hash"],
+        "key_id": DEFAULT_PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID,
+    }
+
+
+def test_promotion_loader_propagates_signature_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        promotion,
+        "load_private_artifact_manifest",
+        lambda _uri: artifact_mapping(),
+    )
+    monkeypatch.setattr(
+        promotion,
+        "verify_private_artifact_manifest_signature",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            PrivateModelRuntimeError(
+                "private artifact manifest KMS signature was rejected"
+            )
+        ),
+    )
+
+    with pytest.raises(
+        PrivateModelRuntimeError,
+        match="KMS signature was rejected",
+    ):
+        promotion._load_valid_artifact("s3://artifacts/current.json")

--- a/tests/test_promotion_fixes.py
+++ b/tests/test_promotion_fixes.py
@@ -30,6 +30,7 @@ import pytest
 
 import gateway.research_lab.promotion as promotion
 from gateway.research_lab import attested_v2_store, v2_authority
+from gateway.research_lab.config import DEFAULT_PRIVATE_REPO_BRANCH
 from gateway.research_lab.tee_protocol import ResearchLabTeeProtocolError
 import gateway.research_lab.store as store_module
 from gateway.research_lab.promotion import (
@@ -650,11 +651,13 @@ async def test_repo_head_sync_registers_current_json_with_db_safe_doc(store, mon
     }
     store.select_many_results["research_lab_private_model_version_current:active"] = [previous_row]
 
-    monkeypatch.setattr(
-        promotion,
-        "_resolve_private_repo_head_sha",
-        lambda *, repo_url, branch_name: current_artifact.git_commit_sha,
-    )
+    resolved_branch: dict[str, str] = {}
+
+    def _fake_resolve_head(*, repo_url: str, branch_name: str) -> str:
+        resolved_branch["branch_name"] = branch_name
+        return current_artifact.git_commit_sha
+
+    monkeypatch.setattr(promotion, "_resolve_private_repo_head_sha", _fake_resolve_head)
 
     async def _fake_current_manifest(config: Any, **kwargs: Any) -> tuple[FakeArtifact, dict[str, Any]]:
         return current_artifact, {
@@ -670,18 +673,79 @@ async def test_repo_head_sync_registers_current_json_with_db_safe_doc(store, mon
     result = await sync_active_model_to_repo_head(
         _controller_config(
             private_repo_url="git@github.com:tasnimuldatascience/Sourcing_model.git",
-            private_repo_branch="main",
+            private_repo_branch="",
         ),
         actor_ref="test",
         dry_run=False,
     )
 
     assert result["status"] == "synced_active_model_to_repo_head"
+    assert resolved_branch["branch_name"] == DEFAULT_PRIVATE_REPO_BRANCH
     assert len(store.version_writes) == 1
     version_doc = store.version_writes[0]["redacted_version_doc"]
     _assert_db_doc_safe(version_doc)
+    assert version_doc["repo_branch"] == DEFAULT_PRIVATE_REPO_BRANCH
     assert version_doc["image_ref_hash"].startswith("sha256:")
     assert "image_digest" not in json.dumps(version_doc, sort_keys=True, default=str)
+
+
+async def test_private_source_upgrade_defaults_to_leadpoet_lab(store, monkeypatch):
+    commit_events: list[dict[str, Any]] = []
+    pushed: dict[str, Any] = {}
+
+    async def _fake_commit_event(**kwargs: Any) -> dict[str, Any]:
+        commit_events.append(kwargs)
+        return kwargs
+
+    def _fake_push(**kwargs: Any) -> dict[str, Any]:
+        pushed.update(kwargs)
+        return {
+            "status": "pushed",
+            "git_commit_sha": "f" * 40,
+            "target_files": ["sourcing_model/core.py"],
+            "source_diff_hash": "sha256:" + "1" * 64,
+        }
+
+    monkeypatch.setattr(
+        promotion,
+        "create_private_repo_commit_event",
+        _fake_commit_event,
+    )
+    monkeypatch.setattr(promotion, "_push_candidate_source_diff_to_repo", _fake_push)
+
+    artifact = _valid_fake_artifact()
+    controller = ResearchLabPromotionController(
+        _controller_config(
+            auto_commit_enabled=True,
+            private_repo_url="https://github.com/leadpoet/Sourcing_model.git",
+            private_repo_branch="",
+        ),
+        worker_ref="test-worker",
+    )
+    result = await controller._maybe_push_private_repo_candidate(
+        candidate={
+            "candidate_id": "cand-branch",
+            "candidate_source_diff_hash": "sha256:" + "2" * 64,
+            "candidate_build_doc": {},
+            "candidate_model_manifest_doc": {},
+        },
+        score_bundle_row={"score_bundle_id": "bundle-branch"},
+        score_bundle={},
+        active=ActivePrivateModel(artifact=artifact),
+        new_artifact=artifact,
+        active_parent=artifact.model_artifact_hash,
+        candidate_parent=artifact.model_artifact_hash,
+        rolling_window_hash="sha256:" + "3" * 64,
+        improvement_points=2.0,
+        threshold=1.0,
+    )
+
+    assert result["status"] == "pushed"
+    assert pushed["branch_name"] == DEFAULT_PRIVATE_REPO_BRANCH
+    assert commit_events
+    assert {
+        event["branch_name"] for event in commit_events
+    } == {DEFAULT_PRIVATE_REPO_BRANCH}
 
 
 def _bridge_baseline_row(window_hash: str, baseline_bundle_id: str) -> dict[str, Any]:


### PR DESCRIPTION
## What changed

- Make Research Lab read the source head and signed artifact pointer from `Sourcing_model/leadpoet-lab`.
- Push accepted Research Lab sourcing-model upgrades back to `leadpoet-lab`.
- Make the production gateway restart enforce that branch and its branch-specific `current.json`, so a stale `main` environment value cannot override it.
- Cryptographically verify that the final, self-consistent artifact manifest hash was signed by the configured KMS key before accepting an artifact.
- Align telemetry paths and operator messaging with the configured sourcing branch.

## Why

Changes to `Sourcing_model/main` should not automatically move Research Lab model lineage or trigger a rebenchmark. `leadpoet-lab` becomes the selective promotion lane: changes may continue landing on `main`, then chosen updates can be merged into `leadpoet-lab` for Research Lab.

The fail-closed signature check is required because the previously published `054e612...` manifest is internally self-consistent but its KMS signature was generated from an earlier intermediate hash. Without verifying the final hash, Leadpoet could accept a manifest whose signature did not authenticate its published contents.

## Coordinated source fix

- [Sourcing_model PR #6](https://github.com/leadpoet/Sourcing_model/pull/6) builds the manifest once with its final signature URI, signs that exact hash, and verifies the archived manifest/signature before moving either pointer.
- PR #6 must merge to `Sourcing_model/main` first.
- That resulting exact `main` commit must then be fast-forwarded or merged into `Sourcing_model/leadpoet-lab` so its workflow verifies the immutable artifact and advances only the branch-specific pointer.
- The new `leadpoet-lab/current.json` signature must validate before this PR can merge.
- Existing `main` pointer publication remains preserved.

## Verification

- 391/391 broad Research Lab, promotion, restart-wiring, sandbox, and fail-closed tests passed.
- 103/103 mandatory V2 weight and auditor tests passed.
- `bash -n gw_restart.sh`.
- Python compile checks passed for all touched runtime and test modules.
- `git diff --check` passed.
- Rebased onto current `origin/main` at `94f1c923d092d12cbab95ef8d86317420eede621`.

The only warnings were the expected absence of local static AWS access-key variables. Production uses the gateway instance role, and the verification path uses role-backed S3 and KMS clients.

## Pre-merge/deployment gates

- [ ] Merge Sourcing_model PR #6, then advance `leadpoet-lab` to the resulting exact commit.
- [ ] Verify the published `leadpoet-lab/current.json` manifest is self-consistent and its KMS signature is valid.
- [ ] Run the exact isolated N-1-to-N gateway and validator restart rehearsal for candidate `aaef748633cfb5dce87d09f9e408aa8d2bb1d5d0`. It cannot run on this machine because no Docker-compatible x86_64 16-vCPU/128-GiB runtime is available.
- Do not merge during official block 200–300 or while a gateway or validator restart is in progress.

This PR is ready for code review and CI. The unchecked source-publication and exact-rehearsal gates remain required before merge/deployment.
