### PR TITLE
Prewarm authoritative allocation before weight window

### DIFF
--- a/gateway/research_lab/api.py
+++ b/gateway/research_lab/api.py
@@ -167,6 +167,7 @@ from .source_add_workflow import (
 )
 from research_lab.improvement_engine.fix_generator import sanitized_miner_opportunity
 from research_lab.improvement_engine.scanner import scan_for_issues
+from leadpoet_canonical.constants import EPOCH_LENGTH
 
 
 logger = logging.getLogger(__name__)
@@ -3074,8 +3075,14 @@ _AllocationCacheKey = tuple[int, bool]
 _ALLOCATION_HANDOFF_CACHE: "OrderedDict[_AllocationCacheKey, tuple[float, dict[str, Any]]]" = (
     OrderedDict()
 )
-_ALLOCATION_BUILD_LOCKS: dict[_AllocationCacheKey, asyncio.Lock] = {}
-_ALLOCATION_CACHE_TTL_SECONDS = 300.0
+_ALLOCATION_BUILD_TASKS: dict[
+    _AllocationCacheKey,
+    asyncio.Task[dict[str, Any]],
+] = {}
+# Finney targets roughly 12-second blocks. Retain a successful handoff for
+# longer than one 360-block epoch so a preparation completed before the weight
+# window survives until block 300, including normal finality/block-time drift.
+_ALLOCATION_CACHE_TTL_SECONDS = float(EPOCH_LENGTH * 15)
 _ALLOCATION_CACHE_MAX_EPOCHS = 16
 
 
@@ -3112,19 +3119,53 @@ def _allocation_handoff_cache_put(
     _ALLOCATION_HANDOFF_CACHE.move_to_end(key)
     while len(_ALLOCATION_HANDOFF_CACHE) > _ALLOCATION_CACHE_MAX_EPOCHS:
         evicted, _ = _ALLOCATION_HANDOFF_CACHE.popitem(last=False)
-        _ALLOCATION_BUILD_LOCKS.pop(evicted, None)
+        completed = _ALLOCATION_BUILD_TASKS.get(evicted)
+        if completed is not None and completed.done():
+            _ALLOCATION_BUILD_TASKS.pop(evicted, None)
 
 
-def _allocation_build_lock(
+def _allocation_build_task(
+    *,
+    config: "ResearchLabGatewayConfig",
     epoch: int,
     persist_snapshot: bool,
-) -> asyncio.Lock:
+) -> asyncio.Task[dict[str, Any]]:
     key = _allocation_cache_key(epoch, persist_snapshot)
-    lock = _ALLOCATION_BUILD_LOCKS.get(key)
-    if lock is None:
-        lock = asyncio.Lock()
-        _ALLOCATION_BUILD_LOCKS[key] = lock
-    return lock
+    task = _ALLOCATION_BUILD_TASKS.get(key)
+    if task is not None:
+        return task
+    task = asyncio.create_task(
+        _build_and_cache_attested_allocation(
+            config=config,
+            epoch=int(epoch),
+            persist_snapshot=bool(persist_snapshot),
+        )
+    )
+    _ALLOCATION_BUILD_TASKS[key] = task
+
+    def clear(completed: asyncio.Task[dict[str, Any]]) -> None:
+        if _ALLOCATION_BUILD_TASKS.get(key) is completed:
+            _ALLOCATION_BUILD_TASKS.pop(key, None)
+        if completed.cancelled():
+            logger.warning(
+                "research_lab_allocation_build_cancelled epoch=%s persist_snapshot=%s",
+                int(epoch),
+                bool(persist_snapshot),
+            )
+            return
+        error = completed.exception()
+        if error is not None:
+            logger.warning(
+                "research_lab_allocation_build_failed epoch=%s "
+                "persist_snapshot=%s error_type=%s error=%s",
+                int(epoch),
+                bool(persist_snapshot),
+                type(error).__name__,
+                str(error)[:240],
+            )
+
+    task.add_done_callback(clear)
+    return task
 
 
 @router.get("/allocations/attested/{epoch}")
@@ -3149,21 +3190,17 @@ async def get_research_lab_attested_allocation(
     )
     if cached_handoff is not None:
         return cached_handoff
-    # Serialize builds per epoch so concurrent polls and retries wait for one
-    # rebuild instead of launching contending ones. Re-check the cache after
-    # acquiring the lock: the first builder populates it for everyone waiting.
-    async with _allocation_build_lock(int(epoch), persist_snapshot):
-        cached_handoff = _allocation_handoff_cache_get(
-            int(epoch),
-            persist_snapshot,
-        )
-        if cached_handoff is not None:
-            return cached_handoff
-        return await _build_and_cache_attested_allocation(
+    # Shield the complete build-and-cache task from client disconnects. The
+    # previous lock only serialized live requests: when a validator timed out,
+    # request cancellation released the lock before the finished authority
+    # could be assembled and cached, so the next retry started over.
+    return await asyncio.shield(
+        _allocation_build_task(
             config=config,
             epoch=int(epoch),
             persist_snapshot=persist_snapshot,
         )
+    )
 
 
 async def _build_and_cache_attested_allocation(

--- a/leadpoet_canonical/__init__.py
+++ b/leadpoet_canonical/__init__.py
@@ -50,6 +50,7 @@ __version__ = "1.0.0"
 # Import key constants for convenience (other modules should import from constants directly)
 from leadpoet_canonical.constants import (
     EPOCH_LENGTH,
+    ALLOCATION_PREPARATION_BLOCK,
     WEIGHT_SUBMISSION_BLOCK,
     MAX_BLOCK_DRIFT,
     VERSION_KEY,
@@ -64,6 +65,7 @@ __all__ = [
     "__version__",
     # Core constants
     "EPOCH_LENGTH",
+    "ALLOCATION_PREPARATION_BLOCK",
     "WEIGHT_SUBMISSION_BLOCK",
     "MAX_BLOCK_DRIFT",
     "VERSION_KEY",
@@ -72,4 +74,3 @@ __all__ = [
     "TRUST_LEVEL_FULL_NITRO",
     "TRUST_LEVEL_SIGNATURE_ONLY",
 ]
-

--- a/leadpoet_canonical/constants.py
+++ b/leadpoet_canonical/constants.py
@@ -25,6 +25,11 @@ EPOCH_LENGTH = 360
 # current-epoch auditor mirroring.
 WEIGHT_SUBMISSION_BLOCK = 300
 
+# Begin the expensive, deterministic Research Lab allocation preparation well
+# before the submission window. This does not authorize or publish weights; it
+# only gives the primary time to reconstruct and validate durable ancestry.
+ALLOCATION_PREPARATION_BLOCK = 180
+
 # Maximum allowed drift between gateway-observed block and submission block
 # Submissions with larger drift are rejected to prevent replay attacks
 MAX_BLOCK_DRIFT = 30

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -108,7 +108,10 @@ from leadpoet_canonical.weight_computation import (
     research_lab_uid_weights_from_allocation as canonical_research_lab_uid_weights_from_allocation,
     weight_config_hash as canonical_weight_config_hash,
 )
-from leadpoet_canonical.constants import WEIGHT_SUBMISSION_BLOCK
+from leadpoet_canonical.constants import (
+    ALLOCATION_PREPARATION_BLOCK,
+    WEIGHT_SUBMISSION_BLOCK,
+)
 from leadpoet_verifier.economics import DEFAULT_RESEARCH_LAB_EMISSION_PERCENT
 
 
@@ -3868,6 +3871,11 @@ class Validator(BaseValidatorNeuron):
     async def _research_lab_pre_weight_submission_guard(self, current_epoch: int) -> dict:
         """Fetch the sole V2 allocation authority before final-weight computation."""
 
+        cached = getattr(self, "_research_lab_allocation_guard_cache", {}).get(
+            int(current_epoch)
+        )
+        if isinstance(cached, dict) and cached.get("verified") is True:
+            return cached
         try:
             from leadpoet_canonical.allocation_handoff_v2 import (
                 validate_allocation_handoff_v2,
@@ -3912,7 +3920,7 @@ class Validator(BaseValidatorNeuron):
                 f"champions={float(allocation_doc.get('champion_alpha_percent') or 0):.4f}%, "
                 f"queued={float(allocation_doc.get('queued_champion_alpha_percent') or 0):.4f}%)"
             )
-            return {
+            result = {
                 "abort_chain_submission": False,
                 "verified": True,
                 "allocation_component": component,
@@ -3930,6 +3938,14 @@ class Validator(BaseValidatorNeuron):
                     "passed": True,
                 },
             }
+            # Keep only the current epoch. The allocation authority is
+            # deterministic for an epoch, and retaining the fully verified
+            # handoff prevents block-300 submission from downloading and
+            # validating the same multi-megabyte ancestry again.
+            self._research_lab_allocation_guard_cache = {
+                int(current_epoch): result
+            }
+            return result
         except Exception as exc:
             bt.logging.error(
                 "Authoritative V2 Research Lab allocation failed closed: "
@@ -3944,6 +3960,34 @@ class Validator(BaseValidatorNeuron):
                 "allocation_verification": None,
                 "evaluation_verification": None,
             }
+
+    async def _prepare_research_lab_allocation(
+        self,
+        current_epoch: int,
+        *,
+        wait: bool,
+    ) -> Optional[dict]:
+        """Start one epoch preparation task and optionally wait for its result."""
+
+        epoch = int(current_epoch)
+        tasks = getattr(self, "_research_lab_allocation_preparation_tasks", {})
+        task = tasks.get(epoch)
+        if task is None:
+            task = asyncio.create_task(
+                self._research_lab_pre_weight_submission_guard(epoch)
+            )
+            # Retain only the current epoch so stale multi-megabyte handoffs do
+            # not accumulate in a long-lived validator process.
+            tasks = {epoch: task}
+            self._research_lab_allocation_preparation_tasks = tasks
+        if not wait and not task.done():
+            return None
+        result = await asyncio.shield(task)
+        if result.get("abort_chain_submission"):
+            # A failed preparation is retryable. Successful results stay in
+            # the epoch cache and are reused when the submission window opens.
+            tasks.pop(epoch, None)
+        return result
 
     async def _publish_and_set_weights(
         self,
@@ -4388,6 +4432,21 @@ class Validator(BaseValidatorNeuron):
             current_epoch = epoch_state.workflow_epoch_id
             blocks_into_epoch = epoch_state.epoch_block
             
+            if epoch_state.deadline_reached(ALLOCATION_PREPARATION_BLOCK):
+                prepared = await self._prepare_research_lab_allocation(
+                    current_epoch,
+                    wait=False,
+                )
+                if (
+                    isinstance(prepared, dict)
+                    and prepared.get("abort_chain_submission")
+                ):
+                    bt.logging.warning(
+                        "Authoritative V2 Research Lab allocation preparation "
+                        f"not ready for epoch {current_epoch}; retrying before "
+                        f"block {WEIGHT_SUBMISSION_BLOCK}"
+                    )
+
             if not epoch_state.deadline_reached(WEIGHT_SUBMISSION_BLOCK):
                 return False
             
@@ -4403,7 +4462,11 @@ class Validator(BaseValidatorNeuron):
                 # This is the PRIMARY guard against duplicate submissions
                 return True
 
-            research_lab_guard = await self._research_lab_pre_weight_submission_guard(current_epoch)
+            research_lab_guard = await self._prepare_research_lab_allocation(
+                current_epoch,
+                wait=True,
+            )
+            assert research_lab_guard is not None
             if research_lab_guard.get("abort_chain_submission"):
                 print(f"   ❌ Research Lab pre-submission guard blocked weights: {research_lab_guard.get('reason')}")
                 return False

--- a/tests/test_allocation_endpoint_cache.py
+++ b/tests/test_allocation_endpoint_cache.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 import pytest
 
 from gateway.research_lab import api
+from leadpoet_canonical.constants import EPOCH_LENGTH
 
 
 def _config():
@@ -32,10 +33,10 @@ def _config():
 @pytest.fixture(autouse=True)
 def _clear_allocation_cache():
     api._ALLOCATION_HANDOFF_CACHE.clear()
-    api._ALLOCATION_BUILD_LOCKS.clear()
+    api._ALLOCATION_BUILD_TASKS.clear()
     yield
     api._ALLOCATION_HANDOFF_CACHE.clear()
-    api._ALLOCATION_BUILD_LOCKS.clear()
+    api._ALLOCATION_BUILD_TASKS.clear()
 
 
 def _install(monkeypatch, *, build, guard=None, handoff=None):
@@ -99,6 +100,27 @@ async def test_concurrent_requests_build_once(monkeypatch):
 
     assert all(r == {"handoff_for": 9} for r in results)
     assert counter["n"] == 1  # 12 concurrent pollers, exactly one build
+
+
+@pytest.mark.asyncio
+async def test_client_cancellation_does_not_cancel_build_or_cache(monkeypatch):
+    counter = {"n": 0}
+    _install(monkeypatch, build=_matched_build(counter, delay=0.1))
+
+    disconnected = asyncio.create_task(
+        api.get_research_lab_attested_allocation(10)
+    )
+    await asyncio.sleep(0.02)
+    disconnected.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await disconnected
+
+    # The server-owned task finishes independently and populates the cache.
+    await asyncio.sleep(0.12)
+    recovered = await api.get_research_lab_attested_allocation(10)
+
+    assert recovered == {"handoff_for": 10}
+    assert counter["n"] == 1
 
 
 @pytest.mark.asyncio
@@ -191,6 +213,10 @@ async def test_cache_entry_expires_after_ttl(monkeypatch):
     assert counter["n"] == 2  # rebuilt after expiry
 
 
+def test_default_cache_lifetime_spans_a_full_target_epoch():
+    assert api._ALLOCATION_CACHE_TTL_SECONDS >= EPOCH_LENGTH * 12
+
+
 @pytest.mark.asyncio
 async def test_cache_is_bounded_by_max_epochs(monkeypatch):
     counter = {"n": 0}
@@ -201,4 +227,4 @@ async def test_cache_is_bounded_by_max_epochs(monkeypatch):
         await api.get_research_lab_attested_allocation(epoch)
 
     assert len(api._ALLOCATION_HANDOFF_CACHE) <= 4
-    assert len(api._ALLOCATION_BUILD_LOCKS) <= 4  # evicted locks are dropped too
+    assert not api._ALLOCATION_BUILD_TASKS

--- a/tests/test_validator_epoch_weight_flow.py
+++ b/tests/test_validator_epoch_weight_flow.py
@@ -16,6 +16,10 @@ from Leadpoet.utils.subnet_epoch import (
     validate_validator_shared_epoch_file,
 )
 from Leadpoet.validator import reward as reward_module
+from leadpoet_canonical.constants import (
+    ALLOCATION_PREPARATION_BLOCK,
+    WEIGHT_SUBMISSION_BLOCK,
+)
 import neurons.validator as validator_module
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -122,6 +126,133 @@ def test_gateway_already_submitted_path_checks_weight_submission_before_return()
     assert snippet.index("await self._check_weight_submission_for_processed_epoch(") < snippet.index(
         "self._last_processed_epoch = current_epoch"
     )
+
+
+def test_allocation_preparation_precedes_weight_submission_window():
+    assert 0 < ALLOCATION_PREPARATION_BLOCK < WEIGHT_SUBMISSION_BLOCK
+
+    source = VALIDATOR_SOURCE.read_text(encoding="utf-8")
+    snippet = _between(
+        source,
+        "async def _submit_weights_at_epoch_end_locked(self):",
+        "# ═══════════════════════════════════════════════════════════════════\n"
+        "            # CRITICAL: Check if we've already submitted weights for this epoch",
+    )
+    preparation = snippet.index(
+        "epoch_state.deadline_reached(ALLOCATION_PREPARATION_BLOCK)"
+    )
+    submission = snippet.index(
+        "epoch_state.deadline_reached(WEIGHT_SUBMISSION_BLOCK)"
+    )
+    assert preparation < submission
+
+
+def test_verified_allocation_guard_is_reused_within_epoch(
+    monkeypatch,
+):
+    from leadpoet_canonical import allocation_handoff_v2
+    from research_lab import validator_integration
+    from validator_tee.host import gateway_weight_inputs_v2
+
+    validator = validator_module.Validator.__new__(validator_module.Validator)
+    validator.config = SimpleNamespace(netuid=71)
+    calls = []
+    normalized = {
+        "bundle": {"epoch": 123},
+        "root_receipt_hash": "sha256:" + "1" * 64,
+        "receipt_graph": {"root_receipt_hash": "sha256:" + "1" * 64},
+    }
+    component = {
+        "allocation_hash": "sha256:" + "2" * 64,
+        "allocation_doc": {
+            "allocation_hash": "sha256:" + "2" * 64,
+        },
+    }
+
+    def fetch(*_args, **_kwargs):
+        calls.append("fetch")
+        return {"handoff": True}
+
+    monkeypatch.setenv("VALIDATOR_V2_GATEWAY_URL", "https://gateway.example")
+    monkeypatch.setattr(
+        gateway_weight_inputs_v2,
+        "_gateway_endpoint",
+        lambda value: value,
+    )
+    monkeypatch.setattr(
+        validator_integration,
+        "fetch_research_lab_attested_allocation_bundle",
+        fetch,
+    )
+    monkeypatch.setattr(
+        allocation_handoff_v2,
+        "validate_allocation_handoff_v2",
+        lambda *_args, **_kwargs: normalized,
+    )
+    monkeypatch.setattr(
+        validator_integration.ResearchLabValidatorFlags,
+        "from_mapping",
+        lambda _value: object(),
+    )
+    monkeypatch.setattr(
+        validator_integration,
+        "verify_research_lab_allocation_bundle",
+        lambda *_args, **_kwargs: {"passed": True, "errors": []},
+    )
+    monkeypatch.setattr(
+        validator_integration,
+        "build_research_lab_allocation_component",
+        lambda *_args, **_kwargs: component,
+    )
+
+    async def run():
+        first = await validator._research_lab_pre_weight_submission_guard(123)
+        second = await validator._research_lab_pre_weight_submission_guard(123)
+        return first, second
+
+    first, second = asyncio.run(run())
+
+    assert first is second
+    assert first["verified"] is True
+    assert calls == ["fetch"]
+
+
+def test_allocation_preparation_runs_in_background_and_is_singleflight():
+    validator = validator_module.Validator.__new__(validator_module.Validator)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = []
+
+    async def guard(epoch):
+        calls.append(epoch)
+        started.set()
+        await release.wait()
+        return {"verified": True, "abort_chain_submission": False}
+
+    validator._research_lab_pre_weight_submission_guard = guard
+
+    async def run():
+        background = await validator._prepare_research_lab_allocation(
+            321,
+            wait=False,
+        )
+        assert background is None
+        await started.wait()
+        release.set()
+        prepared = await validator._prepare_research_lab_allocation(
+            321,
+            wait=True,
+        )
+        reused = await validator._prepare_research_lab_allocation(
+            321,
+            wait=True,
+        )
+        return prepared, reused
+
+    prepared, reused = asyncio.run(run())
+
+    assert prepared is reused
+    assert calls == [321]
 
 
 def test_reward_transition_waits_for_finalized_subnet_epoch(monkeypatch):

--- a/validator_tee/enclave/protected_workflows_v2.json
+++ b/validator_tee/enclave/protected_workflows_v2.json
@@ -187,7 +187,7 @@
       "symbol": "Validator._recover_weight_publication_journal_v2"
     },
     {
-      "ast_sha256": "sha256:12040d31ec559f9d2e30c6268dcabc0d221559dd61a9b6c3edc07ccfb8678c9c",
+      "ast_sha256": "sha256:1ac9e7c83ec49fb2d5185b49cef5642d89132fb5368321aaae52a3f14210d0cb",
       "path": "neurons/validator.py",
       "symbol": "Validator._research_lab_pre_weight_submission_guard"
     },
@@ -302,7 +302,7 @@
       "symbol": "normalize_weight_protocol"
     }
   ],
-  "manifest_hash": "sha256:ff611c07ab16e2be767716ff3eb48dc68fa51dfe31adf7ffd1177d7d5b4a70f1",
-  "protected_source_commit": "e14125ca73282bb338a0d62439f092573ae766ab",
+  "manifest_hash": "sha256:b56f384724729569c997846483731849c071439e7e3c17925429c251f1515094",
+  "protected_source_commit": "632b2f2e3cd379b52132837f2b164b89f3135db7",
   "schema_version": "leadpoet.validator_protected_workflows.v2"
 }


### PR DESCRIPTION
## Root cause

Settlement epoch 24151 reached the primary validator's authoritative Research Lab allocation guard at block 300, but the gateway had to reconstruct a growing multi-megabyte receipt ancestry. Repeated 500/timeout retries did not return a verified allocation until epoch block 339. The remaining authoritative input, publication, and boundary-evidence stages then crossed the epoch boundary. The primary correctly refused a stale chain submission, and auditors saw 404 until the bundle was published too late to mirror it.

The endpoint's documented one-build-per-epoch protection had two gaps: its successful-result cache expired after five minutes, and client cancellation could release request-level coordination before the completed authority was assembled and cached.

## Changes

- Start the primary's deterministic Research Lab allocation preparation at epoch block 180 without authorizing or publishing weights early.
- Run preparation in a validator-owned background singleflight task and reuse the fully verified handoff at block 300.
- Retain successful gateway handoffs for longer than one target epoch.
- Shield the complete gateway build-and-cache task from client disconnect cancellation.
- Preserve authenticated/read-only cache separation, failure retry, stale-epoch refusal, and all existing chain/publication gates.

## Verification

- `pytest -q tests/test_allocation_endpoint_cache.py` — 10 passed.
- `pytest -q tests/test_validator_protected_workflows_v2.py` — 4 passed after regenerating the protected AST manifest against code commit `632b2f2e`.
- `python3 -m py_compile` for all six changed Python files — passed.
- `git diff --check` — passed.
- Added regression coverage for client cancellation, full-epoch cache lifetime, validator background singleflight, verified-result reuse, and preparation-before-submission ordering.
- GitHub Actions run `30160545592` — green: 3,974 tests passed, 1 skipped, 202 subtests passed; Python 3.7 validator-enclave finalization and Python 3.12 auditor verification passed.
- Gateway and validator Docker image smoke builds both passed.
- Local collection of `tests/test_validator_epoch_weight_flow.py` was blocked by the workstation's Bittensor v11 install (`bittensor.Synapse` was removed); the pinned Bittensor 10.5.0 GitHub suite covered that runtime successfully.

## Release gates

- Draft only; do not merge until required CI/review and timing/restart gates pass.
- Exact installed N-1-to-N gateway and validator rehearsal: skipped so far (recommended, not a merge/release hard gate).
- No merge, gateway restart, validator restart, deployment, Supabase mutation, or chain write was performed.
