### PR TITLE
Reuse the persisted allocation for anonymous callers

### DIFF
--- a/gateway/research_lab/api.py
+++ b/gateway/research_lab/api.py
@@ -3053,9 +3053,22 @@ async def get_research_lab_live_allocation(
             netuid=BITTENSOR_NETUID,
             persist_snapshot=persist_snapshot,
         )
-    except ValueError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except asyncio.CancelledError:
+        raise
     except Exception as exc:
+        # This endpoint has no build task to report its failures, so the reason
+        # for a 500 has to be recorded here or it is lost with the response.
+        logger.error(
+            "research_lab_live_allocation_build_failed epoch=%s "
+            "persist_snapshot=%s error_type=%s error=%s",
+            int(epoch),
+            bool(persist_snapshot),
+            type(exc).__name__,
+            str(exc)[:240],
+            exc_info=True,
+        )
+        if isinstance(exc, ValueError):
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
         raise HTTPException(status_code=500, detail=f"Research Lab allocation unavailable: {str(exc)[:200]}") from exc
 
 
@@ -3096,6 +3109,22 @@ def _allocation_handoff_cache_get(
 ) -> Optional[dict[str, Any]]:
     key = _allocation_cache_key(epoch, persist_snapshot)
     entry = _ALLOCATION_HANDOFF_CACHE.get(key)
+    if entry is None and not persist_snapshot:
+        # The cache is keyed by (epoch, persist_snapshot), so an anonymous
+        # caller used to miss a persisting build's entry and launch a second
+        # full rebuild of the same epoch: another multi-minute pass over the
+        # ancestry tables and another ~9 MiB handoff, contending for the exact
+        # database pool and enclave the validator needs inside its submission
+        # window. persist_snapshot only gates the emission-snapshot write (see
+        # allocations.build_research_lab_allocation_bundle); it never changes
+        # the returned document, so the persisted build's handoff is the same
+        # answer and is safe to reuse here.
+        #
+        # This direction only. Serving an authenticated caller from a read-only
+        # entry would skip the snapshot persistence it is entitled to, which
+        # test_read_only_cache_cannot_suppress_authenticated_persistence pins.
+        key = _allocation_cache_key(epoch, True)
+        entry = _ALLOCATION_HANDOFF_CACHE.get(key)
     if entry is None:
         return None
     expires_at, handoff = entry
@@ -3226,6 +3255,16 @@ async def _build_and_cache_attested_allocation(
             detail=f"Research Lab attested allocation unavailable: {str(exc)[:200]}",
         ) from exc
     if attestation.get("status") != "matched":
+        # Not an exception, so the build task's failure callback never sees it:
+        # without this line a 503 inside the submission window leaves nothing
+        # behind but an access-log status code.
+        logger.error(
+            "research_lab_attested_allocation_not_ready epoch=%s "
+            "persist_snapshot=%s status=%s",
+            int(epoch),
+            bool(persist_snapshot),
+            attestation.get("status", "unknown"),
+        )
         raise HTTPException(
             status_code=503,
             detail=f"Research Lab attested allocation is not ready: {attestation.get('status', 'unknown')}",

--- a/gateway/research_lab/api.py
+++ b/gateway/research_lab/api.py
@@ -3255,9 +3255,11 @@ async def _build_and_cache_attested_allocation(
             detail=f"Research Lab attested allocation unavailable: {str(exc)[:200]}",
         ) from exc
     if attestation.get("status") != "matched":
-        # Not an exception, so the build task's failure callback never sees it:
-        # without this line a 503 inside the submission window leaves nothing
-        # behind but an access-log status code.
+        # The HTTPException raised below IS surfaced by the build task's
+        # failure callback, but only generically (error_type=HTTPException).
+        # The attestation status that caused it is not, so record it here:
+        # a 503 inside the submission window should be greppable by the
+        # status that produced it, not just by an access-log code.
         logger.error(
             "research_lab_attested_allocation_not_ready epoch=%s "
             "persist_snapshot=%s status=%s",

--- a/tests/test_allocation_endpoint_cache.py
+++ b/tests/test_allocation_endpoint_cache.py
@@ -228,3 +228,95 @@ async def test_cache_is_bounded_by_max_epochs(monkeypatch):
 
     assert len(api._ALLOCATION_HANDOFF_CACHE) <= 4
     assert not api._ALLOCATION_BUILD_TASKS
+
+
+@pytest.mark.asyncio
+async def test_anonymous_request_reuses_the_persisted_build(monkeypatch):
+    """An anonymous poll must not rebuild an epoch the validator already built.
+
+    The cache is keyed by (epoch, persist_snapshot), so an anonymous caller used
+    to miss the persisting build's entry and launch a second full rebuild of the
+    same epoch — another multi-minute pass over the ancestry tables and another
+    ~9 MiB handoff, contending for the database pool and enclave the validator
+    needs inside its submission window.
+    """
+
+    counter = {"n": 0}
+
+    async def guard(config, epoch, key):
+        return key == "validator-key"
+
+    _install(monkeypatch, build=_matched_build(counter), guard=guard)
+
+    authenticated = await api.get_research_lab_attested_allocation(
+        11,
+        x_leadpoet_internal_key="validator-key",
+    )
+    assert counter["n"] == 1
+
+    anonymous = await api.get_research_lab_attested_allocation(11)
+
+    assert anonymous == authenticated == {"handoff_for": 11}
+    assert counter["n"] == 1  # reused, not rebuilt
+
+
+@pytest.mark.asyncio
+async def test_expired_persisted_entry_is_not_served_to_anonymous_callers(
+    monkeypatch,
+):
+    counter = {"n": 0}
+
+    async def guard(config, epoch, key):
+        return key == "validator-key"
+
+    _install(monkeypatch, build=_matched_build(counter), guard=guard)
+    monkeypatch.setattr(api, "_ALLOCATION_CACHE_TTL_SECONDS", 0.05)
+
+    await api.get_research_lab_attested_allocation(
+        12,
+        x_leadpoet_internal_key="validator-key",
+    )
+    assert counter["n"] == 1
+    time.sleep(0.1)  # let the persisted entry expire
+
+    await api.get_research_lab_attested_allocation(12)
+    assert counter["n"] == 2  # expiry still applies across the reuse path
+
+
+@pytest.mark.asyncio
+async def test_not_ready_attestation_is_logged_before_failing(monkeypatch, caplog):
+    """A 503 is not an exception, so the build task's callback never sees it."""
+
+    async def unmatched_build(**kwargs):
+        kwargs["attestation_out"].update({"status": "pending"})
+        return {"bundle_type": "live", "epoch": kwargs["epoch"]}
+
+    _install(monkeypatch, build=unmatched_build)
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(Exception):
+            await api.get_research_lab_attested_allocation(13)
+
+    assert "research_lab_attested_allocation_not_ready" in caplog.text
+    assert "status=pending" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_live_allocation_failure_is_logged_before_failing(monkeypatch, caplog):
+    async def failing_build(**kwargs):
+        raise RuntimeError("coordinator enclave unavailable")
+
+    monkeypatch.setattr(api.ResearchLabGatewayConfig, "from_env", _config)
+    monkeypatch.setattr(api, "build_research_lab_allocation_bundle", failing_build)
+
+    async def guard(config, epoch, key):
+        return False
+
+    monkeypatch.setattr(api, "_allocation_epoch_guard_and_persistence", guard)
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(Exception):
+            await api.get_research_lab_live_allocation(14)
+
+    assert "research_lab_live_allocation_build_failed" in caplog.text
+    assert "RuntimeError" in caplog.text


### PR DESCRIPTION
Stacked work now retargeted to `main` (PR #44 is merged as `df061e5e`).

## Status: hardening, not an incident fix

**This PR would not have prevented epochs 24151 or 24152.** Gateway access logs for 24151 show all four allocation requests came from the authenticated primary validator (`100.59.201.156`): three `500`s followed by a late `200`. There were **zero anonymous requests** to `/research-lab/allocations/attested/24151`. The direct fix for that failure is already on `main` via #44 (cancellation-shielded server-owned build, singleflight reuse, 90-minute TTL, validator prewarm at epoch block 180).

An earlier revision of this description attributed the failure partly to auditor/monitoring polling of this endpoint. That is not supported by the logs: auditors poll `/weights/v2/published/{netuid}/{epoch}` and `/weights/v2/release-evidence/{commit}`, never the allocation endpoint. The only anonymous callers observed were `127.0.0.1` operator probes during incident diagnosis.

## Why it is still worth carrying

1. **Duplicate rebuilds are now unabortable.** #44 wraps the build in `asyncio.shield`, and build tasks are keyed by `(epoch, persist_snapshot)`. So an anonymous request that misses the validator's persisted entry starts a *second* full build of the same epoch — a multi-minute pass over the ancestry receipt tables producing another ~9.18 MiB handoff (measured live) — and that duplicate now runs to completion even after its client disconnects. Before #44 a disconnect could cancel it.
2. **Operator probing during incidents is real.** It is exactly what produced the `127.0.0.1` requests above, and it happens when the window is already the scarce resource.
3. **The in-process readiness gate takes the anonymous path.** `gateway/tee/verify_weight_submission_ready_v2.py` calls `get_research_lab_attested_allocation(..., x_leadpoet_internal_key=None)`. It runs in its own process during `gw_restart.sh`, so this PR does not change its behavior — but it confirms the anonymous path is a first-class production path, not a hypothetical one.

## What changed

1. **Anonymous callers reuse the persisted entry.** `_allocation_handoff_cache_get` falls back from `(epoch, False)` to `(epoch, True)`. `persist_snapshot` only guards the `create_research_lab_emission_allocation_snapshot(...)` side-effect write in `build_research_lab_allocation_bundle` (`gateway/research_lab/allocations.py:188`); the returned document is built independently and is identical either way, so the persisted build's handoff is the same answer.

   Reuse is **one-directional**: an authenticated caller is never served from a read-only entry, which would skip the snapshot persistence it is entitled to. `test_read_only_cache_cannot_suppress_authenticated_persistence` pins that. Expiry still applies across the reuse path.

2. **Two silent failure paths now log.** The live allocation endpoint has no build task at all, so a 500 there previously left nothing behind but a response body. The attested endpoint's not-ready branch raises `HTTPException`, which #44's done-callback *does* capture generically as `error_type=HTTPException` — what it does not surface is the attestation `status` value, which this logs explicitly.

## Verification

- `tests/test_allocation_endpoint_cache.py` — 14 passed (#44's 10 plus 4 new: reuse, expiry-still-applies, both log paths).
- `python3 -m py_compile gateway/research_lab/api.py` — passed.
- Gateway-only: touches `gateway/research_lab/api.py` and its tests. No validator runtime file, no protected-workflow manifest impact. Requires a gateway restart to take effect; no validator restart.

## Not addressed

The ~9.18 MiB handoff (measured live) sits above the **8 MiB** `MAX_RPC_REQUEST_FRAME_BYTES` ceiling in `validator_tee/enclave/tee_service.py:68`. A previous revision of this description misnamed that constant as `MAX_RPC_REQUEST_BYTES` (which is 64 MiB in both `gateway/tee/tee_service.py` and `gateway/utils/tee_client.py`) and asserted the ceiling caused the missing bundles for epochs 24145-24147. That attribution is withdrawn: the gateway process was down from 06:53Z to 08:49Z on 2026-07-25, which covers 24146 and 24147. The size headroom is a real and growing risk that needs its own design — dedup and reconstruct, never stripping `transport_attempts`, which are re-validated in-enclave — but it is not the proven cause of those misses.

Separately, and outside this PR: because the restart readiness gate builds anonymously in its own process and the app then rebuilds authenticated, every gateway restart pays that multi-minute allocation build twice.

## Gates

Draft. The N-1-to-N gateway/validator rehearsal has **not** been run for this SHA. Restart-timing rules apply. Recommend landing this only after #44 is deployed and verified, since every push to `main` restarts the ~18-minute Attested V2 Release build.
