### PR TITLE
Fix nondeterministic V2 receipt pagination before gateway shutdown

### DIFF
--- a/gateway/research_lab/attested_v2_store.py
+++ b/gateway/research_lab/attested_v2_store.py
@@ -302,10 +302,15 @@ async def _select_by_values(
     *,
     field: str,
     values: Iterable[str],
+    key_fields: tuple[str, ...],
 ) -> list[dict[str, Any]]:
+    """Select bounded value chunks in one stable, unique row order."""
+
     normalized = sorted({str(value) for value in values})
     if len(normalized) > _MAX_GRAPH_ROWS:
         raise AttestedV2StoreError("V2 receipt graph exceeds row limit")
+    if not key_fields or len(set(key_fields)) != len(key_fields):
+        raise AttestedV2StoreError("V2 durable row key fields are invalid")
     rows = []
     for offset in range(0, len(normalized), _GRAPH_QUERY_CHUNK):
         chunk = normalized[offset : offset + _GRAPH_QUERY_CHUNK]
@@ -313,6 +318,7 @@ async def _select_by_values(
             await select_all(
                 table,
                 filters=((field, "in", chunk),),
+                order_by=tuple((key_field, False) for key_field in key_fields),
                 max_rows=_MAX_GRAPH_ROWS,
             )
         )
@@ -345,6 +351,7 @@ async def _existing_exact_rows(
         table,
         field=key_field,
         values=expected_by_key,
+        key_fields=(key_field,),
     )
     existing: set[str] = set()
     for stored in stored_rows:
@@ -394,6 +401,7 @@ async def _existing_exact_relations(
         table,
         field=owner_field,
         values=owners,
+        key_fields=key_fields,
     )
     existing: set[tuple[str, ...]] = set()
     for stored in stored_rows:
@@ -628,6 +636,7 @@ async def load_receipt_graphs_v2(
             RECEIPT_TABLE,
             field="receipt_hash",
             values=requested,
+            key_fields=("receipt_hash",),
         )
         by_hash: dict[str, Mapping[str, Any]] = {}
         for row in rows:
@@ -642,6 +651,7 @@ async def load_receipt_graphs_v2(
             EDGE_TABLE,
             field="child_receipt_hash",
             values=requested,
+            key_fields=("child_receipt_hash", "parent_receipt_hash"),
         )
         edge_pairs = set()
         for row in edge_rows:
@@ -684,6 +694,7 @@ async def load_receipt_graphs_v2(
         BOOT_TABLE,
         field="boot_identity_hash",
         values=boot_hashes,
+        key_fields=("boot_identity_hash",),
     )
     boots = {}
     for row in boot_rows:
@@ -708,6 +719,7 @@ async def load_receipt_graphs_v2(
         RECEIPT_TRANSPORT_TABLE,
         field="receipt_hash",
         values=receipt_hashes,
+        key_fields=("receipt_hash", "attempt_hash"),
     )
     link_pairs = set()
     attempt_hashes = set()
@@ -723,6 +735,7 @@ async def load_receipt_graphs_v2(
         TRANSPORT_TABLE,
         field="attempt_hash",
         values=attempt_hashes,
+        key_fields=("attempt_hash",),
     )
     attempts = {}
     for row in attempt_rows:
@@ -742,6 +755,7 @@ async def load_receipt_graphs_v2(
         HOST_OPERATION_TABLE,
         field="receipt_hash",
         values=receipt_hashes,
+        key_fields=("request_hash",),
     )
     host_operations_by_receipt: dict[str, list[dict[str, Any]]] = {}
     seen_requests = set()
@@ -1324,6 +1338,11 @@ async def load_business_artifact_graphs_v2(
                     ("artifact_kind", kind),
                     ("artifact_ref", "in", chunk),
                 ),
+                order_by=(
+                    ("artifact_kind", False),
+                    ("artifact_ref", False),
+                    ("artifact_hash", False),
+                ),
                 max_rows=_MAX_GRAPH_ROWS,
                 allow_partial=False,
             )
@@ -1441,6 +1460,11 @@ async def load_business_artifact_graphs_by_ref_v2(
                 filters=(
                     ("artifact_kind", kind),
                     ("artifact_ref", "in", chunk),
+                ),
+                order_by=(
+                    ("artifact_kind", False),
+                    ("artifact_ref", False),
+                    ("artifact_hash", False),
                 ),
                 max_rows=_MAX_GRAPH_ROWS,
                 allow_partial=False,

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -92,12 +92,12 @@
       "symbol": "load_business_artifact_graph_v2"
     },
     {
-      "ast_sha256": "sha256:2c527f66167c194960b9d048552d3cfa6aeb2d439368ec22aa063f04f2fc44d3",
+      "ast_sha256": "sha256:c71495d4a2845ca21291138293034bddcb17dd9f3a057d2e06f000f806368eba",
       "path": "gateway/research_lab/attested_v2_store.py",
       "symbol": "load_business_artifact_graphs_by_ref_v2"
     },
     {
-      "ast_sha256": "sha256:041e564331dadabb64ead09538fb31c9bda66ce523116069c58c2ff121934f51",
+      "ast_sha256": "sha256:51484f80584c8c2481cc16cd2be3568758b0df8ed10e083de6455cfeba9e833f",
       "path": "gateway/research_lab/attested_v2_store.py",
       "symbol": "load_business_artifact_graphs_v2"
     },
@@ -107,7 +107,7 @@
       "symbol": "load_receipt_graph_v2"
     },
     {
-      "ast_sha256": "sha256:5635e475ab1968d2bd624020842b91a8159728e18832acae5475c64690c3e835",
+      "ast_sha256": "sha256:086cfce4890ecc9753c4b2efa41c2c8ab042f66c2040a023cb2255b07142ee17",
       "path": "gateway/research_lab/attested_v2_store.py",
       "symbol": "load_receipt_graphs_v2"
     },
@@ -1107,7 +1107,7 @@
       "symbol": "validate_source_add_reward_record"
     }
   ],
-  "manifest_hash": "sha256:a6f4ae064f02b2a9b6e6de09a2e0e65580788647c7022cfe5de85cff73fa5bad",
+  "manifest_hash": "sha256:a64be3a048d47228683116aedf5e3e389125c9f3905133dc542e549dba545c0d",
   "protected_source_commit": "5987a8344b69379fad871fa84058631afb39c3c0",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/verify_weight_submission_ready_v2.py
+++ b/gateway/tee/verify_weight_submission_ready_v2.py
@@ -89,6 +89,44 @@ def _validate_handoff(
     }
 
 
+async def verify_weight_submission_storage_readable_v2(
+    *,
+    epoch: int | None = None,
+    netuid: int | None = None,
+) -> dict[str, Any]:
+    """Read the complete durable authority path without repairing or launching."""
+
+    from gateway.research_lab.maintenance import (
+        _resolve_maintenance_epoch,
+        champion_v2_cutover_readiness_report,
+    )
+
+    effective_epoch = await _resolve_maintenance_epoch(epoch)
+    if netuid is None:
+        from gateway.config import BITTENSOR_NETUID
+
+        effective_netuid = int(BITTENSOR_NETUID)
+    else:
+        effective_netuid = int(netuid)
+    readiness = await champion_v2_cutover_readiness_report(
+        epoch=effective_epoch,
+        netuid=effective_netuid,
+    )
+    return {
+        "schema_version": "leadpoet.weight_submission_storage_readiness.v2",
+        "status": "readable",
+        "epoch": effective_epoch,
+        "netuid": effective_netuid,
+        "authority_ready": readiness.get("ready") is True,
+        "receipt_coverage": float(readiness.get("receipt_coverage") or 0.0),
+        "historical_classification_coverage": float(
+            readiness.get("historical_classification_coverage")
+            or readiness.get("historical_settlement_coverage")
+            or 0.0
+        ),
+    }
+
+
 async def verify_weight_submission_ready_v2(
     *,
     repair: bool,
@@ -266,7 +304,9 @@ async def verify_weight_submission_ready_v2(
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--repair", action="store_true")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--repair", action="store_true")
+    mode.add_argument("--storage-read-preflight", action="store_true")
     parser.add_argument("--gateway-url")
     parser.add_argument("--epoch", type=int)
     parser.add_argument("--netuid", type=int)
@@ -275,16 +315,27 @@ def _parser() -> argparse.ArgumentParser:
 
 
 def main() -> int:
-    args = _parser().parse_args()
-    result = asyncio.run(
-        verify_weight_submission_ready_v2(
-            repair=bool(args.repair),
-            gateway_url=args.gateway_url,
-            epoch=args.epoch,
-            netuid=args.netuid,
-            http_timeout_seconds=args.http_timeout_seconds,
+    parser = _parser()
+    args = parser.parse_args()
+    if args.storage_read_preflight:
+        if args.gateway_url:
+            parser.error("--storage-read-preflight cannot use --gateway-url")
+        result = asyncio.run(
+            verify_weight_submission_storage_readable_v2(
+                epoch=args.epoch,
+                netuid=args.netuid,
+            )
         )
-    )
+    else:
+        result = asyncio.run(
+            verify_weight_submission_ready_v2(
+                repair=bool(args.repair),
+                gateway_url=args.gateway_url,
+                epoch=args.epoch,
+                netuid=args.netuid,
+                http_timeout_seconds=args.http_timeout_seconds,
+            )
+        )
     print(json.dumps(result, sort_keys=True))
     return 0
 

--- a/gw_restart.sh
+++ b/gw_restart.sh
@@ -1141,6 +1141,22 @@ if ! install_gateway_python_dependencies; then
   exit 1
 fi
 
+echo "Preflighting durable V2 validator weight authority before production shutdown"
+GATEWAY_DEPLOY_STAGE="validator_weight_input_storage_preflight"
+export GATEWAY_DEPLOY_STAGE
+if ! (
+    set -a
+    . "$ENV_CLONE"
+    set +a
+    run_prepared_gateway_module \
+      gateway.tee.verify_weight_submission_ready_v2 \
+      --storage-read-preflight
+  ); then
+  echo "ERROR: durable V2 validator weight authority is not readable" >&2
+  echo "Gateway remains running; production shutdown has not started." >&2
+  exit 1
+fi
+
 echo "Validating the prepared V2 release before production shutdown"
   GATEWAY_DEPLOY_STAGE="v2_pre_shutdown_preflight"
   export GATEWAY_DEPLOY_STAGE

--- a/tests/restart_rehearsal/contract_adapter.py
+++ b/tests/restart_rehearsal/contract_adapter.py
@@ -1002,7 +1002,11 @@ def _module_stage_artifacts(argv: list[str]) -> int:
 
 
 def _module_weight_ready(argv: list[str]) -> int:
-    if "--repair" not in argv and not _arg_value(argv, "--gateway-url"):
+    if (
+        "--repair" not in argv
+        and "--storage-read-preflight" not in argv
+        and not _arg_value(argv, "--gateway-url")
+    ):
         return _fail("python-module", argv, "weight readiness mode is unknown")
     result = subprocess.run(
         [

--- a/tests/restart_rehearsal/verify_evidence.py
+++ b/tests/restart_rehearsal/verify_evidence.py
@@ -317,7 +317,7 @@ def main() -> int:
             if row.get("kind") == "weight-readiness-supabase"
         ]
         expected_supabase_runs = (
-            2 if scenario == "transient_503_recovery" else 1
+            3 if scenario == "transient_503_recovery" else 2
         )
         if (
             len(supabase_rows) != expected_supabase_runs
@@ -358,6 +358,11 @@ def main() -> int:
         repair_rows = [
             row for row in weight_rows if row.get("stage") == "repair"
         ]
+        storage_preflight_rows = [
+            row
+            for row in weight_rows
+            if row.get("stage") == "storage_preflight"
+        ]
         boundaries = [
             row
             for row in rows
@@ -368,6 +373,14 @@ def main() -> int:
             for row in rows
             if row.get("kind") == "weight-readiness-persistence"
         ]
+        if (
+            not storage_preflight_rows
+            or storage_preflight_rows[0].get("status") != "started"
+            or storage_preflight_rows[-1].get("status") != "ok"
+        ):
+            raise SystemExit(
+                "pre-shutdown weight storage preflight did not pass"
+            )
         if not repair_rows or repair_rows[0].get("status") != "started":
             raise SystemExit("real weight repair did not start")
 
@@ -458,6 +471,7 @@ def main() -> int:
             [
                 "module:gateway.tee.release_channel_v2",
                 "module:gateway.tee.prepare_gateway_envelopes_v2",
+                "weight:storage_preflight",
                 "module:gateway.tee.restart_preflight_v2",
                 "nitro:build",
                 "nitro:run",

--- a/tests/restart_rehearsal/weight_readiness_runner.py
+++ b/tests/restart_rehearsal/weight_readiness_runner.py
@@ -417,7 +417,11 @@ def _install_boundaries(stage: str, scenario: str) -> None:
     direct_calls = {"count": 0}
 
     async def resolve(_epoch):
-        resolved_epoch = EPOCH if stage == "repair" else POST_LAUNCH_EPOCH
+        resolved_epoch = (
+            EPOCH
+            if stage in {"storage_preflight", "repair"}
+            else POST_LAUNCH_EPOCH
+        )
         _event(
             "weight-readiness-boundary",
             boundary="chain_epoch",
@@ -565,7 +569,9 @@ def main() -> int:
     )
     passthrough = sys.argv[1:]
     stage = (
-        "repair"
+        "storage_preflight"
+        if "--storage-read-preflight" in passthrough
+        else "repair"
         if "--repair" in passthrough
         else "http_handoff"
         if "--gateway-url" in passthrough

--- a/tests/test_attested_v2_store.py
+++ b/tests/test_attested_v2_store.py
@@ -394,6 +394,63 @@ def _persisted_rows(graph):
 
 
 @pytest.mark.asyncio
+async def test_v2_edge_value_query_orders_multi_page_results_by_primary_key(
+    monkeypatch,
+):
+    children = [f"child-{index:02d}" for index in range(42)]
+    edge_rows = [
+        {
+            "child_receipt_hash": child,
+            "parent_receipt_hash": f"parent-{child}-{parent:02d}",
+        }
+        for child in children
+        for parent in range(28)
+    ]
+    edge_rows.extend(
+        {
+            "child_receipt_hash": child,
+            "parent_receipt_hash": f"parent-{child}-28",
+        }
+        for child in children[:16]
+    )
+    assert len(edge_rows) == 1192
+
+    async def _select_all(
+        table,
+        *,
+        filters,
+        order_by,
+        max_rows,
+        **_kwargs,
+    ):
+        assert table == attested_v2_store.EDGE_TABLE
+        assert filters == (("child_receipt_hash", "in", children),)
+        assert order_by == (
+            ("child_receipt_hash", False),
+            ("parent_receipt_hash", False),
+        )
+        assert max_rows == 10000
+        return list(reversed(edge_rows))
+
+    monkeypatch.setattr(attested_v2_store, "select_all", _select_all)
+
+    selected = await attested_v2_store._select_by_values(
+        attested_v2_store.EDGE_TABLE,
+        field="child_receipt_hash",
+        values=children,
+        key_fields=("child_receipt_hash", "parent_receipt_hash"),
+    )
+
+    assert len(selected) == 1192
+    assert len(
+        {
+            (row["child_receipt_hash"], row["parent_receipt_hash"])
+            for row in selected
+        }
+    ) == 1192
+
+
+@pytest.mark.asyncio
 async def test_v2_graph_persistence_batch_verifies_existing_ancestry(monkeypatch):
     graph = _graph(with_transport=True, with_parent=True)
     rows = _persisted_rows(graph)

--- a/tests/test_gateway_git_restart_wiring.py
+++ b/tests/test_gateway_git_restart_wiring.py
@@ -142,6 +142,10 @@ def test_gateway_restart_forces_instance_role_for_runtime_aws_calls() -> None:
 
 def test_gateway_restart_repairs_and_proves_automatic_weight_input() -> None:
     script = (ROOT / "gw_restart.sh").read_text(encoding="utf-8")
+    storage_preflight = script.index("--storage-read-preflight")
+    shutdown = script.index(
+        'echo "Stopping existing gateway and Research Lab worker processes"'
+    )
     runtime_ready = script.index(
         '"$GATEWAY_PYTHON_BIN" -m gateway.tee.verify_v2_runtime_ready'
     )
@@ -170,7 +174,9 @@ def test_gateway_restart_repairs_and_proves_automatic_weight_input() -> None:
 
     assert "GATEWAY_WEIGHT_INPUT_HTTP_TIMEOUT_SECONDS=360" in script
     assert (
-        runtime_ready
+        storage_preflight
+        < shutdown
+        < runtime_ready
         < cutover
         < repair
         < launch
@@ -182,6 +188,32 @@ def test_gateway_restart_repairs_and_proves_automatic_weight_input() -> None:
     assert 'GATEWAY_DEPLOY_STAGE="validator_weight_input_repair"' in script
     assert (
         'GATEWAY_DEPLOY_STAGE="validator_weight_input_http_check"' in script
+    )
+
+
+def test_gateway_weight_storage_preflight_uses_target_before_shutdown() -> None:
+    script = (ROOT / "gw_restart.sh").read_text(encoding="utf-8")
+    dependencies = script.index(
+        'GATEWAY_DEPLOY_STAGE="dependency_preflight"'
+    )
+    stage = script.index(
+        'GATEWAY_DEPLOY_STAGE="validator_weight_input_storage_preflight"'
+    )
+    command = script.index("--storage-read-preflight", stage)
+    shutdown = script.index(
+        'echo "Stopping existing gateway and Research Lab worker processes"'
+    )
+    preflight_block = script[stage:shutdown]
+
+    assert dependencies < stage < command < shutdown
+    assert '. "$ENV_CLONE"' in preflight_block
+    assert (
+        "run_prepared_gateway_module \\\n"
+        "      gateway.tee.verify_weight_submission_ready_v2"
+        in preflight_block
+    )
+    assert "Gateway remains running; production shutdown has not started." in (
+        preflight_block
     )
 
 

--- a/tests/test_weight_submission_readiness_v2.py
+++ b/tests/test_weight_submission_readiness_v2.py
@@ -31,6 +31,50 @@ async def test_standalone_maintenance_epoch_uses_direct_capable_resolver(
 
 
 @pytest.mark.asyncio
+async def test_storage_read_preflight_exercises_full_authority_read_without_repair(
+    monkeypatch,
+):
+    calls = []
+
+    async def resolve(epoch):
+        calls.append(("resolve", epoch))
+        return 24153
+
+    async def report(**kwargs):
+        calls.append(("report", kwargs))
+        return {
+            "ready": False,
+            "receipt_coverage": 1.0,
+            "historical_classification_coverage": 0.75,
+        }
+
+    monkeypatch.setattr(maintenance, "_resolve_maintenance_epoch", resolve)
+    monkeypatch.setattr(
+        maintenance,
+        "champion_v2_cutover_readiness_report",
+        report,
+    )
+
+    result = await readiness.verify_weight_submission_storage_readable_v2(
+        netuid=71,
+    )
+
+    assert result == {
+        "schema_version": "leadpoet.weight_submission_storage_readiness.v2",
+        "status": "readable",
+        "epoch": 24153,
+        "netuid": 71,
+        "authority_ready": False,
+        "receipt_coverage": 1.0,
+        "historical_classification_coverage": 0.75,
+    }
+    assert calls == [
+        ("resolve", None),
+        ("report", {"epoch": 24153, "netuid": 71}),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_weight_readiness_repairs_then_validates_exact_handoff(
     monkeypatch,
 ):


### PR DESCRIPTION
## Root cause

The V2 receipt-graph loader used Supabase `range()` pagination without a stable row order. The production authority graph returned 1,192 edge rows for one 42-child batch, so the query crossed the 1,000-row page boundary. Independently evaluated pages could overlap and the fail-closed duplicate detector then reported clean durable data as duplicated.

The gateway restart ran this traversal only after stopping the existing gateway. A transient false duplicate therefore stranded the gateway before `gateway.main` launched.

## Changes

- order every paginated V2 graph relation by its complete durable primary key, including `(child_receipt_hash, parent_receipt_hash)` for receipt edges
- order business-artifact lineage reads by their composite primary key
- add a read-only full authority-storage traversal against the prepared candidate commit
- run that traversal before production shutdown, leaving the existing gateway running if durable authority cannot be read
- include the new preflight in exact restart-rehearsal evidence and ordering checks
- add a regression fixture matching the production 42-child / 1,192-edge shape

## Verification

- 81 focused V2 store, weight-readiness, and gateway wiring tests passed with production netuid 71
- 38 broader restart safety, Docker coordination, release preflight, and exact-commit tests passed
- 13 restart-rehearsal integrity tests passed
- `bash -n gw_restart.sh` passed
- affected Python modules compiled successfully
- live read-only Supabase verification returned ordered pages of 1,000 and 192 rows, 1,192 distinct edge pairs, and zero cross-page overlap

## Release status

- GitHub Actions: passed (`Unit and Workflow Tests (3.11)` and `Docker Build Smoke Tests`)
- exact candidate commit: `b12b7ed4b236f7d97ff5c86c43f9f46cb949243a`
- exact installed N-1-to-N gateway and validator rehearsal: skipped so far (advisory, disclosed)
- attestation for this commit: not yet complete
- production gateway/validator restart: not performed or authorized by this PR
- merge and restart timing gates still apply; do not merge during official blocks 200–300 or while either restart is running
