### PR TITLE
Fix fulfillment source integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,13 @@ Use the correct intent source:
 | GitHub repositories or organizations | `github` |
 | G2, Capterra, TrustRadius, Glassdoor, Trustpilot | `review_site` |
 | Wikipedia | `wikipedia` |
-| Other verifiable dated events | `other` |
+| Government or education sources that do not fit another category | `other` |
+
+Fulfillment validates the declared source against the evidence URL before
+applying its score multiplier. First-party `job_board` evidence must be on the
+lead company's own careers/jobs property; third-party job, news, social,
+review, and reference sources must use a recognized platform. Arbitrary
+third-party or self-published domains are not accepted as `other`.
 
 Reference fulfillment code lives in `miner_models/Main_fulfillment_model/`. It is a starting point, not a guaranteed competitive miner.
 

--- a/gateway/fulfillment/scoring.py
+++ b/gateway/fulfillment/scoring.py
@@ -238,6 +238,11 @@ def _build_failure_detail(
                 if conf == 0 or score == 0:
                     if date_status == "fabricated":
                         parts.append(f"Signal {i+1} ({src}): content not verified against source")
+                    elif date_status == "source_mismatch":
+                        parts.append(
+                            f"Signal {i+1} ({src}): declared source type "
+                            f"does not match a trusted URL for that category"
+                        )
                     elif date_status == "duplicate_domain":
                         parts.append(f"Signal {i+1} ({src}): duplicate source domain")
                     else:
@@ -847,10 +852,13 @@ async def score_fulfillment_lead(
                 signal, icp_prompt, icp_criteria,
                 lead_output.business, lead_output.company_website,
                 api_key=api_key,
-                # company_linkedin only used by v2 verifier path (flag-gated
-                # by INTENT_VERIFIER_V2 inside _score_single_intent_signal);
-                # legacy path ignores it.
                 company_linkedin=getattr(lead_output, "company_linkedin", "") or "",
+                # Fulfillment is adversarial: validate the miner-declared
+                # source category against the URL before its multiplier is
+                # applied, and never let Stage 1 approve without fetching the
+                # exact submitted page for the source-grounded Stage 3 judge.
+                enforce_source_integrity=True,
+                stage1_soft_reject=True,
             )
             print(f"   📊 Raw score={score:.1f}, confidence={confidence}, "
                   f"date_status={date_status}, content_date={content_found_date}, "

--- a/qualification/scoring/intent_verification_three_stage.py
+++ b/qualification/scoring/intent_verification_three_stage.py
@@ -1862,6 +1862,7 @@ async def verify_three_stage(
     stage3_model: Optional[str] = None,
     miner_signal_date: Optional[str] = None,
     evidence_type: Optional[str] = None,
+    declared_source: Optional[str] = None,
     stage1_soft_reject: bool = False,
 ) -> Dict[str, Any]:
     """3-stage intent verification (sonar -> SD/Exa -> sonar-pro).
@@ -1908,6 +1909,7 @@ async def verify_three_stage(
         "signal_type": "intent",
         "claimed_source_urls": [source_url] if source_url else [],
         "_target_signal_text": target_signal_text,
+        "_declared_source": (declared_source or "").strip().lower() or None,
         # Dispatcher in _build_verification_prompt routes on this — TECHSTACK
         # adds PART E (tech-stack anti-patterns), SOCIAL_POSTING adds PART D
         # (author-role check), other values fall through to the default
@@ -2178,8 +2180,12 @@ async def verify_three_stage(
         (r.get("meta") or {}).get("kind") == "linkedin_job"
         for r in (contents.get("results") or [])
     )
-    is_job_board = any(
-        _is_job_board_url(u) for u in (row.get("claimed_source_urls") or [])
+    is_job_board = (
+        row.get("_declared_source") == "job_board"
+        or any(
+            _is_job_board_url(u)
+            for u in (row.get("claimed_source_urls") or [])
+        )
     )
     if is_job_board and not has_linkedin_structured:
         combined_for_gate = "\n".join(

--- a/qualification/scoring/lead_scorer.py
+++ b/qualification/scoring/lead_scorer.py
@@ -61,6 +61,7 @@ from qualification.scoring.pre_checks import run_company_zero_checks
 from qualification.scoring.verification_helpers import (
     is_generic_intent_description,
     check_future_date,
+    check_source_url_mismatch,
     openrouter_chat,
 )
 from qualification.scoring.intent_signal_gate import check_evidence_freshness, judge_intent_signal
@@ -1519,6 +1520,7 @@ async def _score_single_intent_signal(
     trust_signal_date: bool = False,
     stage1_soft_reject: bool = False,
     llm_only_intent_gate: bool = False,
+    enforce_source_integrity: bool = False,
     verdict_out: Optional[List[dict]] = None,
 ) -> Tuple[float, int, str, Optional[str], int]:
     """
@@ -1627,6 +1629,31 @@ async def _score_single_intent_signal(
 
     source_str = signal.source.value if hasattr(signal.source, "value") else str(signal.source)
     source_lower = source_str.lower()
+
+    # Fulfillment-only publisher/category integrity gate. The miner's declared
+    # ``source`` controls its score multiplier, so accepting that label without
+    # validating the URL lets an arbitrary self-published page claim the 1.0x
+    # ``job_board`` multiplier. The Research Lab calls this shared helper with
+    # the default disabled because its source contract and receipts are
+    # evaluated separately; gateway fulfillment opts in explicitly.
+    if enforce_source_integrity:
+        source_mismatch = check_source_url_mismatch(
+            source_str,
+            signal.url,
+            company_website,
+            reject_unknown_third_party=True,
+        )
+        if source_mismatch:
+            logger.warning(
+                "Intent signal rejected: source URL integrity — %s",
+                source_mismatch,
+            )
+            _record_verdict(
+                "rejected_pregate",
+                rejection_reason="source_url_mismatch",
+                source_integrity_error=source_mismatch,
+            )
+            return 0.0, 0, "source_mismatch", None, -1
 
     # The keyword/length genericity pre-gate is a cheap deterministic filter that
     # runs before the three-stage LLM verifier. It has no vocabulary for several
@@ -1784,6 +1811,7 @@ async def _score_single_intent_signal(
                 target_signal_text=target_signal_text,
                 miner_signal_date=(str(signal.date) if signal.date else None),
                 evidence_type=target_evidence_type,
+                declared_source=source_lower,
                 stage1_soft_reject=stage1_soft_reject,
             )
     except Exception as three_stage_error:

--- a/qualification/scoring/verification_helpers.py
+++ b/qualification/scoring/verification_helpers.py
@@ -1112,13 +1112,16 @@ _SOURCE_DOMAIN_ALLOWLIST: Dict[str, frozenset] = {
         "linkedin.com",
         "indeed.com", "glassdoor.com",
         "lever.co", "greenhouse.io", "boards.greenhouse.io",
-        "jobs.lever.co", "apply.workable.com",
+        "jobs.lever.co", "ashbyhq.com",
+        "workable.com", "apply.workable.com",
+        "myworkdayjobs.com",
         "careers.google.com", "jobs.apple.com",
         "builtin.com", "ziprecruiter.com",
         "monster.com", "wellfound.com", "angel.co",
         "dice.com", "simplyhired.com",
         "roberthalf.com", "himalayas.app",
         "remoteok.com", "weworkremotely.com", "flexjobs.com",
+        "startup.jobs", "remoterocketship.com", "salesjobs.com",
     }),
     "news": frozenset({
         "reuters.com", "bloomberg.com", "techcrunch.com",
@@ -1213,16 +1216,55 @@ def _is_known_third_party_domain(domain: str) -> Optional[str]:
     return None
 
 
-def check_source_url_mismatch(source_str: str, url: str) -> Optional[str]:
+def _normalized_url_host(value: str) -> str:
+    """Return a lowercase hostname with a cosmetic ``www.`` removed."""
+    try:
+        clean = (value or "").strip()
+        if clean and not clean.lower().startswith(("http://", "https://")):
+            clean = "https://" + clean
+        host = (urlparse(clean).hostname or "").lower().strip(".")
+    except Exception:
+        return ""
+    return host[4:] if host.startswith("www.") else host
+
+
+def _host_is_same_or_subdomain(host: str, parent: str) -> bool:
+    """Compare hosts without unsafe substring or last-two-label matching."""
+    return bool(host and parent and (host == parent or host.endswith("." + parent)))
+
+
+def _is_government_or_education_domain(domain: str) -> bool:
+    """Allow public registries and education sites in the ``other`` bucket."""
+    labels = [label for label in domain.split(".") if label]
+    if not labels:
+        return False
+    if labels[-1] in {"gov", "government", "edu"}:
+        return True
+    return bool(
+        len(labels) >= 2
+        and len(labels[-1]) == 2
+        and labels[-2] in {"gov", "government", "edu", "ac"}
+    )
+
+
+def check_source_url_mismatch(
+    source_str: str,
+    url: str,
+    company_website: Optional[str] = None,
+    *,
+    reject_unknown_third_party: bool = False,
+) -> Optional[str]:
     """
     Check if the declared source type is plausible given the URL domain.
     
     Returns an error message if there's a clear mismatch, None if OK.
     
-    CRITICAL: If source is "company_website" but the URL is actually a known
-    third-party platform (news site, job board, Wikipedia, etc.), flag it.
-    This catches models that label everything as "company_website" to bypass
-    source type validation.
+    ``company_website`` makes first-party classifications identity-bound:
+    ``company_website`` must use the lead's domain, while ``job_board`` may use
+    either a recognized hiring platform or a careers/jobs property owned by the
+    lead.  With ``reject_unknown_third_party=True`` (the fulfillment policy),
+    the low-trust ``other`` bucket is limited to public-sector/education
+    domains instead of accepting an arbitrary self-published site.
     """
     source_lower = source_str.lower().strip()
     
@@ -1234,15 +1276,54 @@ def check_source_url_mismatch(source_str: str, url: str) -> Optional[str]:
         if url_domain.startswith("www."):
             url_domain = url_domain[4:]
     except Exception:
-        return None
-    
-    # If source is "company_website", verify URL isn't a known third-party platform
-    if source_lower in ("company_website", "other"):
+        return "Source URL could not be parsed"
+
+    if not url_domain:
+        return "Source URL has no hostname"
+
+    company_domain = _normalized_url_host(company_website or "")
+
+    if source_lower == "company_website":
+        if company_domain:
+            if _host_is_same_or_subdomain(url_domain, company_domain):
+                return None
+            return (
+                f"Source declared as 'company_website' but URL domain "
+                f"'{url_domain}' is not the lead company's domain "
+                f"'{company_domain}'"
+            )
         actual_type = _is_known_third_party_domain(url_domain)
         if actual_type:
             return (
                 f"Source declared as '{source_str}' but URL domain '{url_domain}' "
                 f"is a known {actual_type} platform — source type should be '{actual_type}'"
+            )
+        return None
+
+    if source_lower == "other":
+        actual_type = _is_known_third_party_domain(url_domain)
+        if actual_type:
+            return (
+                f"Source declared as '{source_str}' but URL domain '{url_domain}' "
+                f"is a known {actual_type} platform — source type should be '{actual_type}'"
+            )
+        if company_domain and _host_is_same_or_subdomain(
+            url_domain, company_domain
+        ):
+            return (
+                f"Source declared as 'other' but URL domain '{url_domain}' is "
+                f"owned by the lead company — source type should be "
+                f"'company_website'"
+            )
+        if (
+            reject_unknown_third_party
+            and not _is_government_or_education_domain(url_domain)
+        ):
+            return (
+                f"Source declared as 'other' but URL domain '{url_domain}' is "
+                f"an unrecognized third-party publisher; fulfillment evidence "
+                f"must use a recognized platform, a correctly classified lead-"
+                f"owned page, or a government/education source"
             )
         return None
 
@@ -1264,9 +1345,24 @@ def check_source_url_mismatch(source_str: str, url: str) -> Optional[str]:
     if _domain_matches_allowlist(domain, allowed):
         return None
 
+    if (
+        source_lower == "job_board"
+        and company_domain
+        and _host_is_same_or_subdomain(domain, company_domain)
+    ):
+        # Ownership is the deterministic part of the pre-gate. Fulfillment
+        # always fetches the exact page and the declared-source job-body gate
+        # below Stage 2 proves that the owned page is actually a job listing.
+        return None
+
     return (
         f"Source type '{source_str}' declared but URL domain '{domain}' "
         f"is not a recognized {source_str} domain"
+        + (
+            " or a careers/jobs property owned by the lead company"
+            if source_lower == "job_board"
+            else ""
+        )
     )
 
 
@@ -1410,7 +1506,11 @@ async def verify_intent_signal(
         return False, 0, future_err, "fabricated", None
 
     # PRE-CHECK: Source type vs URL domain mismatch
-    mismatch_err = check_source_url_mismatch(source_str, intent_signal.url)
+    mismatch_err = check_source_url_mismatch(
+        source_str,
+        intent_signal.url,
+        company_website,
+    )
     if mismatch_err:
         logger.warning(f"❌ Source/URL mismatch: {mismatch_err}")
         return False, 0, mismatch_err, "fabricated", None

--- a/tests/test_fulfillment_source_integrity.py
+++ b/tests/test_fulfillment_source_integrity.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.qualification.models import ICPPrompt, IntentSignal
+from qualification.scoring.intent_verification_three_stage import (
+    verify_three_stage,
+)
+from qualification.scoring.lead_scorer import _score_single_intent_signal
+from qualification.scoring.verification_helpers import (
+    check_source_url_mismatch,
+)
+
+BEDROCK_URL = (
+    "https://bedrocki.com/"
+    "esri-chile-accelerates-digital-transformation-with-key-hires"
+)
+
+
+def test_arbitrary_article_cannot_claim_trusted_fulfillment_source_types() -> None:
+    company = "https://www.esri.cl/"
+
+    assert check_source_url_mismatch(
+        "job_board",
+        BEDROCK_URL,
+        company,
+        reject_unknown_third_party=True,
+    )
+    assert check_source_url_mismatch(
+        "news",
+        BEDROCK_URL,
+        company,
+        reject_unknown_third_party=True,
+    )
+    assert check_source_url_mismatch(
+        "company_website",
+        BEDROCK_URL,
+        company,
+        reject_unknown_third_party=True,
+    )
+    assert check_source_url_mismatch(
+        "other",
+        BEDROCK_URL,
+        company,
+        reject_unknown_third_party=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "url", "company"),
+    [
+        (
+            "job_board",
+            "https://jobs.lever.co/esri/1234",
+            "https://www.esri.com/",
+        ),
+        (
+            "job_board",
+            "https://careers.esri.com/open-positions/engineer",
+            "https://www.esri.com/",
+        ),
+        (
+            "job_board",
+            "https://www.esri.com/careers/open-positions/engineer",
+            "https://www.esri.com/",
+        ),
+        (
+            "company_website",
+            "https://blog.esri.com/digital-transformation",
+            "https://www.esri.com/",
+        ),
+        (
+            "news",
+            "https://www.reuters.com/technology/esri-expands-2026-07-01/",
+            "https://www.esri.com/",
+        ),
+        (
+            "other",
+            "https://procurement.gov/contracts/esri-award",
+            "https://www.esri.com/",
+        ),
+    ],
+)
+def test_identity_bound_or_recognized_sources_remain_valid(
+    source: str,
+    url: str,
+    company: str,
+) -> None:
+    assert (
+        check_source_url_mismatch(
+            source,
+            url,
+            company,
+            reject_unknown_third_party=True,
+        )
+        is None
+    )
+
+
+def test_first_party_job_category_defers_content_proof_to_exact_page_gate() -> None:
+    assert (
+        check_source_url_mismatch(
+            "job_board",
+            "https://www.esri.com/blog/key-hires",
+            "https://www.esri.com/",
+            reject_unknown_third_party=True,
+        )
+        is None
+    )
+
+
+def test_public_sector_exception_cannot_be_spoofed_by_a_subdomain_label() -> None:
+    assert check_source_url_mismatch(
+        "other",
+        "https://registry.gov.attacker.com/esri-award",
+        "https://www.esri.com/",
+        reject_unknown_third_party=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_active_fulfillment_gate_rejects_before_any_provider_call() -> None:
+    signal = IntentSignal(
+        source="job_board",
+        description=(
+            "Esri Chile is actively hiring for API integration and workflow "
+            "automation roles supporting digital transformation."
+        ),
+        url=BEDROCK_URL,
+        date="2026-06-21",
+        snippet=(
+            "Esri Chile is actively hiring for API integrations, workflow "
+            "automation, and digital transformation roles."
+        ),
+        matched_icp_signal=0,
+    )
+    icp = ICPPrompt(
+        icp_id="icp-source-integrity",
+        industry="Software",
+        sub_industry="Geospatial Software",
+        employee_count="51-200",
+        company_stage="growth",
+        geography="Chile",
+        product_service="workflow automation",
+        intent_signals=["actively hiring integration engineers"],
+    )
+    verdicts: list[dict] = []
+
+    with patch(
+        "qualification.scoring.intent_verification_three_stage.verify_three_stage",
+        new=AsyncMock(),
+    ) as verifier:
+        score, confidence, date_status, found_date, matched_idx = (
+            await _score_single_intent_signal(
+                signal,
+                icp,
+                None,
+                "Esri Chile",
+                company_website="https://www.esri.cl/",
+                company_linkedin="https://www.linkedin.com/company/esri-chile/",
+                enforce_source_integrity=True,
+                stage1_soft_reject=True,
+                verdict_out=verdicts,
+            )
+        )
+
+    verifier.assert_not_awaited()
+    assert (score, confidence, date_status, found_date, matched_idx) == (
+        0.0,
+        0,
+        "source_mismatch",
+        None,
+        -1,
+    )
+    assert len(verdicts) == 1
+    assert verdicts[0]["decision"] == "rejected_pregate"
+    assert verdicts[0]["rejection_reason"] == "source_url_mismatch"
+    assert "not a recognized job_board domain" in (
+        verdicts[0]["source_integrity_error"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_declared_first_party_job_board_requires_job_body() -> None:
+    url = "https://careers.acme.com/team"
+    stage_one = {
+        "answer": {
+            "signal_evaluations": [
+                {
+                    "signal_status": "supported",
+                    "confidence": "high",
+                    "same_entity_check": "pass",
+                    "verification_mode": "source_grounded",
+                    "evidence_urls_used": [url],
+                    "claim_matches_miner_date": "supported",
+                }
+            ],
+        },
+        "model": "test-model",
+        "usage": {},
+    }
+    fetch = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "url": url,
+                    "title": "Meet the Acme team",
+                    "text": (
+                        "Acme celebrates its people and describes employee benefits "
+                        "and workplace culture."
+                    ),
+                }
+            ],
+            "statuses": [{"source": "scrapingdog", "stage": "ok"}],
+        }
+    )
+    call = AsyncMock(return_value=stage_one)
+
+    with (
+        patch(
+            "qualification.scoring.intent_verification_three_stage._call_openrouter",
+            call,
+        ),
+        patch(
+            "qualification.scoring.intent_verification_three_stage._fetch_sd_then_exa",
+            fetch,
+        ),
+    ):
+        result = await verify_three_stage(
+            object(),
+            company_name="Acme",
+            company_linkedin="https://www.linkedin.com/company/acme",
+            company_website="https://acme.com",
+            source_url=url,
+            miner_claim="Acme is actively hiring data engineers",
+            target_signal_text="The company is actively hiring data engineers",
+            miner_signal_date="2026-07-01",
+            declared_source="job_board",
+            stage1_soft_reject=True,
+        )
+
+    fetch.assert_awaited_once_with([url])
+    assert call.await_count == 1
+    assert result["client_ready"] is False
+    assert result["rejection_reason"] == "job_body_not_in_fetched_content"
+
+
+def test_gateway_fulfillment_wires_fail_closed_source_policy() -> None:
+    root = Path(__file__).resolve().parents[1]
+    tree = ast.parse((root / "gateway/fulfillment/scoring.py").read_text())
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "_score_single_intent_signal"
+        )
+    ]
+    assert len(calls) == 1
+    keywords = {keyword.arg: keyword.value for keyword in calls[0].keywords}
+    for required in ("enforce_source_integrity", "stage1_soft_reject"):
+        assert isinstance(keywords[required], ast.Constant)
+        assert keywords[required].value is True


### PR DESCRIPTION
## Summary

Fulfillment accepted a miner-declared source category without validating that
the evidence URL belonged to that category. That allowed an arbitrary publisher
such as `bedrocki.com` to declare `job_board`, receive its full multiplier, and
potentially pass Stage 1 without an exact-page fetch.

This PR:

- enables a fulfillment-only fail-closed source/URL integrity gate before
  provider calls or multiplier application;
- binds `company_website` and first-party `job_board` claims to the submitted
  lead domain;
- requires recognized domains for third-party job, news, social, review, and
  reference categories;
- restricts `other` to government/education evidence rather than arbitrary
  self-published domains;
- forces the exact submitted page through Stage 2/Stage 3 in fulfillment;
- makes declared first-party `job_board` pages pass the fetched job-body gate,
  even when the URL path itself is not a known hosted-board pattern;
- documents the source policy and adds regression coverage for the reported
  Bedrock URL.

## Tradeoff

Unknown legitimate third-party publishers now fail closed until they are
explicitly classified and allowlisted. First-party evidence remains supported
on the lead's own domain, and government/education evidence remains supported
as `other`.

## Verification

- GitHub Actions `Deploy Checks` passed for commit
  `7e0dff6e42b82f44e0fab03618a731298f8c9be2`:
  `Unit and Workflow Tests (3.11)` and `Docker Build Smoke Tests` are green.
- `150 passed, 2 subtests passed` across source-integrity, three-stage
  grounding/freshness, fulfillment, dense reward, champion/reimbursement,
  allocation handoff, weight bundle/input, validator differential, and
  reward-weight invariance tests.
- `gateway.main` imports successfully with a production-shaped dependency
  environment.
- `py_compile` and `git diff --check` pass.
- Focused fatal-error lint is clean for the new changes; the one reported
  `IntentSignal` F821 is present unchanged on `origin/main`.
- Full-suite attempt: `3928 passed, 1 skipped, 46 failed, 13 errors, 202
  subtests passed`. The remaining failures/errors are outside these changed
  paths and include local sandbox restrictions on loopback socket binding plus
  tests requiring Docker/process/service state.

## Release gates

- Database/schema changes: none.
- N-1-to-N restart rehearsal: unexercised for this candidate.
- Production deployment/restart: not performed or authorized.
- Because this changes gateway-imported fulfillment/qualification code,
  deployment requires merge to `main`, normal attestation/PCR0 handling, the
  block-position/restart gates, and a separately authorized gateway restart.
