### PR TITLE
Fix scoped ingress for attested V2 weight graphs

### DIFF
--- a/gateway/middleware/body_size.py
+++ b/gateway/middleware/body_size.py
@@ -2,36 +2,89 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Awaitable, Callable
 
 
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024
+DEFAULT_WEIGHT_AUTHORITY_MAX_BODY_BYTES = 32 * 1024 * 1024
+
+# These POST endpoints carry complete attested receipt graphs.  Keep the larger
+# allowance exact so it cannot silently broaden ordinary unauthenticated
+# gateway ingress.  PriorityMiddleware separately bounds their concurrency.
+WEIGHT_AUTHORITY_GRAPH_PATHS = frozenset(
+    {
+        "/weights/subnet-epoch/candidate/v1",
+        "/weights/subnet-epoch/boundary/v1",
+        "/weights/submit/v2",
+        "/weights/finalize/v2",
+    }
+)
+
+
+class _RequestBodyTooLarge(Exception):
+    pass
+
+
 class BodySizeLimitMiddleware:
-    def __init__(self, app, max_body_bytes: int | None = None) -> None:
+    def __init__(
+        self,
+        app,
+        max_body_bytes: int | None = None,
+        max_weight_authority_body_bytes: int | None = None,
+    ) -> None:
         self.app = app
         self.max_body_bytes = int(
             max_body_bytes
             if max_body_bytes is not None
-            else os.getenv("GATEWAY_MAX_BODY_BYTES", "10485760")
+            else os.getenv("GATEWAY_MAX_BODY_BYTES", str(DEFAULT_MAX_BODY_BYTES))
         )
+        self.max_weight_authority_body_bytes = int(
+            max_weight_authority_body_bytes
+            if max_weight_authority_body_bytes is not None
+            else os.getenv(
+                "GATEWAY_WEIGHT_AUTHORITY_MAX_BODY_BYTES",
+                str(DEFAULT_WEIGHT_AUTHORITY_MAX_BODY_BYTES),
+            )
+        )
+        if self.max_body_bytes <= 0:
+            raise ValueError("GATEWAY_MAX_BODY_BYTES must be positive")
+        if self.max_weight_authority_body_bytes <= 0:
+            raise ValueError(
+                "GATEWAY_WEIGHT_AUTHORITY_MAX_BODY_BYTES must be positive"
+            )
 
     async def __call__(self, scope, receive: Callable, send: Callable) -> None:
         if scope.get("type") != "http":
             await self.app(scope, receive, send)
             return
 
-        headers = {
-            key.lower(): value
-            for key, value in scope.get("headers", [])
-        }
+        max_body_bytes = self._max_body_bytes_for_scope(scope)
+        headers = {key.lower(): value for key, value in scope.get("headers", [])}
         content_length = headers.get(b"content-length")
         if content_length:
             try:
-                if int(content_length) > self.max_body_bytes:
-                    await self._reject(send)
+                declared_bytes = int(content_length)
+                if declared_bytes < 0 or declared_bytes > max_body_bytes:
+                    await self._reject(
+                        scope=scope,
+                        send=send,
+                        max_body_bytes=max_body_bytes,
+                        observed_bytes=declared_bytes,
+                        reason="content_length",
+                    )
                     return
             except ValueError:
-                await self._reject(send)
+                await self._reject(
+                    scope=scope,
+                    send=send,
+                    max_body_bytes=max_body_bytes,
+                    observed_bytes=None,
+                    reason="invalid_content_length",
+                )
                 return
 
         consumed = 0
@@ -41,16 +94,47 @@ class BodySizeLimitMiddleware:
             message = await receive()
             if message.get("type") == "http.request":
                 consumed += len(message.get("body") or b"")
-                if consumed > self.max_body_bytes:
-                    await self._reject(send)
-                    return {
-                        "type": "http.disconnect",
-                    }
+                if consumed > max_body_bytes:
+                    raise _RequestBodyTooLarge
             return message
 
-        await self.app(scope, limited_receive, send)
+        try:
+            await self.app(scope, limited_receive, send)
+        except _RequestBodyTooLarge:
+            await self._reject(
+                scope=scope,
+                send=send,
+                max_body_bytes=max_body_bytes,
+                observed_bytes=consumed,
+                reason="streamed_body",
+            )
 
-    async def _reject(self, send: Callable[..., Awaitable[None]]) -> None:
+    def _max_body_bytes_for_scope(self, scope) -> int:
+        if (
+            str(scope.get("method") or "").upper() == "POST"
+            and scope.get("path") in WEIGHT_AUTHORITY_GRAPH_PATHS
+        ):
+            return self.max_weight_authority_body_bytes
+        return self.max_body_bytes
+
+    async def _reject(
+        self,
+        *,
+        scope,
+        send: Callable[..., Awaitable[None]],
+        max_body_bytes: int,
+        observed_bytes: int | None,
+        reason: str,
+    ) -> None:
+        logger.warning(
+            "gateway_request_body_rejected tag=gateway_body_limit method=%s "
+            "path=%s reason=%s observed_bytes=%s max_body_bytes=%s",
+            scope.get("method", ""),
+            scope.get("path", ""),
+            reason,
+            observed_bytes,
+            max_body_bytes,
+        )
         body = b'{"detail":"Request body too large"}'
         await send({
             "type": "http.response.start",

--- a/gateway/middleware/priority.py
+++ b/gateway/middleware/priority.py
@@ -13,6 +13,7 @@ from typing import Iterable, Optional
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from gateway.middleware.body_size import WEIGHT_AUTHORITY_GRAPH_PATHS
 from gateway.utils.ops_registry import set_priority_middleware
 
 
@@ -41,6 +42,12 @@ class RouteClass:
     wait_timeout_s: float
 
 
+WEIGHT_AUTHORITY_CLASS = RouteClass(
+    "weight_authority",
+    _int_env("WEIGHT_AUTHORITY_MAX_CONCURRENT", 2),
+    _int_env("WEIGHT_AUTHORITY_MAX_WAITING", 4),
+    _float_env("WEIGHT_AUTHORITY_SLOT_WAIT_TIMEOUT_SECONDS", 30),
+)
 VALIDATOR_CLASS = RouteClass(
     "validator",
     _int_env("VALIDATOR_MAX_CONCURRENT", 75),
@@ -64,7 +71,6 @@ OTHER_CLASS = RouteClass(
 VALIDATOR_EXACT = {
     "/validate",
     "/weights/submit",
-    "/weights/submit/v2",
     "/fulfillment/scoring",
     "/fulfillment/score",
     "/fulfillment/rewards/active",
@@ -93,6 +99,8 @@ def _matches(path: str, exact: set[str], prefixes: Iterable[str]) -> bool:
 
 
 def classify_path(path: str) -> str:
+    if path in WEIGHT_AUTHORITY_GRAPH_PATHS:
+        return "weight_authority"
     if _matches(path, VALIDATOR_EXACT, VALIDATOR_PREFIXES):
         return "validator"
     if _matches(path, MINER_EXACT, MINER_PREFIXES):
@@ -228,6 +236,7 @@ class PriorityMiddleware:
         else:
             miner_class = MINER_CLASS
         self.pools = {
+            "weight_authority": _Pool(WEIGHT_AUTHORITY_CLASS),
             "validator": _Pool(VALIDATOR_CLASS),
             "miner": _Pool(miner_class),
             "other": _Pool(OTHER_CLASS),

--- a/tests/test_gateway_body_size.py
+++ b/tests/test_gateway_body_size.py
@@ -2,7 +2,68 @@ import gzip
 
 import pytest
 
-from gateway.middleware.body_size import BodySizeLimitMiddleware
+from gateway.middleware.body_size import (
+    DEFAULT_MAX_BODY_BYTES,
+    DEFAULT_WEIGHT_AUTHORITY_MAX_BODY_BYTES,
+    WEIGHT_AUTHORITY_GRAPH_PATHS,
+    BodySizeLimitMiddleware,
+)
+
+
+_FAILED_PRODUCTION_WIRE_BYTES = 10_701_583
+
+
+def _receipt_graph_json_body(size: int) -> bytes:
+    prefix = b'{"receipt_graph":{"transport_attempts":["'
+    suffix = b'"]}}'
+    return prefix + (b"x" * (size - len(prefix) - len(suffix))) + suffix
+
+
+async def _drive_request(
+    middleware: BodySizeLimitMiddleware,
+    *,
+    path: str,
+    body: bytes,
+    method: str = "POST",
+    include_content_length: bool = True,
+) -> tuple[list[bytes], list[dict]]:
+    observed = []
+    sent = []
+
+    async def app(scope, receive, send):
+        message = await receive()
+        observed.append(message.get("body") or b"")
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    middleware.app = app
+    headers = []
+    if include_content_length:
+        headers.append((b"content-length", str(len(body)).encode("ascii")))
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": headers,
+    }
+    delivered = False
+
+    async def receive():
+        nonlocal delivered
+        if delivered:
+            return {"type": "http.disconnect"}
+        delivered = True
+        return {
+            "type": "http.request",
+            "body": body,
+            "more_body": False,
+        }
+
+    async def send(message):
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+    return observed, sent
 
 
 @pytest.mark.asyncio
@@ -49,3 +110,113 @@ async def test_body_guard_never_expands_unauthenticated_gzip() -> None:
     assert observed[0][0] is scope
     assert observed[0][1]["body"] == compressed
     assert sent[0]["status"] == 204
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/weights/submit/v2",
+        "/weights/finalize/v2",
+    ],
+)
+async def test_weight_authority_routes_accept_failed_production_body_size(
+    path: str,
+) -> None:
+    body = _receipt_graph_json_body(_FAILED_PRODUCTION_WIRE_BYTES)
+    assert len(body) > DEFAULT_MAX_BODY_BYTES
+
+    middleware = BodySizeLimitMiddleware(lambda *_args: None)
+    observed, sent = await _drive_request(
+        middleware,
+        path=path,
+        body=body,
+    )
+
+    assert observed == [body]
+    assert sent[0]["status"] == 204
+
+
+@pytest.mark.asyncio
+async def test_large_body_allowance_is_exact_and_post_only() -> None:
+    body = _receipt_graph_json_body(DEFAULT_MAX_BODY_BYTES + 1)
+    middleware = BodySizeLimitMiddleware(lambda *_args: None)
+
+    for path, method in (
+        ("/fulfillment/scoring", "POST"),
+        ("/weights/submit/v2/typo", "POST"),
+        ("/weights/submit/v2", "GET"),
+    ):
+        observed, sent = await _drive_request(
+            middleware,
+            path=path,
+            method=method,
+            body=body,
+        )
+        assert observed == []
+        assert sent[0]["status"] == 413
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", sorted(WEIGHT_AUTHORITY_GRAPH_PATHS))
+async def test_all_weight_authority_graph_routes_share_scoped_limit(
+    path: str,
+) -> None:
+    middleware = BodySizeLimitMiddleware(
+        lambda *_args: None,
+        max_body_bytes=4,
+        max_weight_authority_body_bytes=8,
+    )
+    observed, sent = await _drive_request(
+        middleware,
+        path=path,
+        body=b"12345678",
+    )
+
+    assert observed == [b"12345678"]
+    assert sent[0]["status"] == 204
+
+
+@pytest.mark.asyncio
+async def test_weight_authority_limit_still_rejects_oversized_body() -> None:
+    middleware = BodySizeLimitMiddleware(lambda *_args: None)
+    sent = []
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/weights/finalize/v2",
+        "headers": [
+            (
+                b"content-length",
+                str(DEFAULT_WEIGHT_AUTHORITY_MAX_BODY_BYTES + 1).encode("ascii"),
+            ),
+        ],
+    }
+
+    async def receive():
+        raise AssertionError("declared oversized body must not be consumed")
+
+    async def send(message):
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+
+    assert sent[0]["status"] == 413
+
+
+@pytest.mark.asyncio
+async def test_weight_authority_limit_rejects_oversized_streamed_body() -> None:
+    middleware = BodySizeLimitMiddleware(
+        lambda *_args: None,
+        max_body_bytes=4,
+        max_weight_authority_body_bytes=8,
+    )
+    observed, sent = await _drive_request(
+        middleware,
+        path="/weights/submit/v2",
+        body=b"123456789",
+        include_content_length=False,
+    )
+
+    assert observed == []
+    assert sent[0]["status"] == 413

--- a/tests/test_gateway_flood_protection.py
+++ b/tests/test_gateway_flood_protection.py
@@ -11,7 +11,16 @@ from gateway.utils.hotkey_bucket import HotkeyBuckets, enforce, observe
 
 def test_priority_route_classification_is_explicit():
     assert classify_path("/weights/submit") == "validator"
-    assert classify_path("/weights/submit/v2") == "validator"
+    assert (
+        classify_path("/weights/subnet-epoch/candidate/v1")
+        == "weight_authority"
+    )
+    assert (
+        classify_path("/weights/subnet-epoch/boundary/v1")
+        == "weight_authority"
+    )
+    assert classify_path("/weights/submit/v2") == "weight_authority"
+    assert classify_path("/weights/finalize/v2") == "weight_authority"
     assert classify_path("/fulfillment/scoring") == "validator"
     assert classify_path("/fulfillment/rewards/active") == "validator"
     assert classify_path("/fulfillment/requests/active") == "miner"

--- a/tests/test_priority_middleware_asgi.py
+++ b/tests/test_priority_middleware_asgi.py
@@ -48,8 +48,9 @@ class _Collector:
         return None
 
 
-def test_classify_path_unchanged():
-    assert classify_path("/weights/submit/v2") == "validator"
+def test_classify_path_is_explicit():
+    assert classify_path("/weights/submit/v2") == "weight_authority"
+    assert classify_path("/weights/finalize/v2") == "weight_authority"
     assert classify_path("/epoch/24123") == "validator"
     assert classify_path("/fulfillment/requests/active") == "miner"
     assert classify_path("/anything-else") == "other"
@@ -65,8 +66,21 @@ def test_http_request_passes_through_and_releases_slot():
     asyncio.run(mw(_http_scope("/weights/submit/v2"), _receive, send))
 
     assert send.status == 200
-    # The validator slot must be fully released after a normal response.
-    assert mw.pools["validator"].in_flight == 0
+    # The weight-authority slot must be fully released after a normal response.
+    assert mw.pools["weight_authority"].in_flight == 0
+
+
+def test_weight_authority_uses_small_dedicated_pool():
+    async def app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    mw = PriorityMiddleware(app)
+    weight_pool = mw.pools["weight_authority"]
+
+    assert weight_pool is not mw.pools["validator"]
+    assert weight_pool.route_class.max_concurrent == 2
+    assert weight_pool.route_class.max_waiting == 4
 
 
 def test_downstream_exception_releases_slot_and_propagates():
@@ -79,7 +93,7 @@ def test_downstream_exception_releases_slot_and_propagates():
     with pytest.raises(RuntimeError, match="endpoint failed"):
         asyncio.run(mw(_http_scope("/weights/submit/v2"), _receive, send))
 
-    assert mw.pools["validator"].in_flight == 0  # released despite the raise
+    assert mw.pools["weight_authority"].in_flight == 0
 
 
 def test_non_http_scope_passes_through_untouched():
@@ -125,10 +139,10 @@ def test_no_slot_leak_under_repeated_exceptions():
 
     asyncio.run(drive())
     # 50 failing requests must leave zero in-flight and full capacity.
-    assert mw.pools["validator"].in_flight == 0
+    assert mw.pools["weight_authority"].in_flight == 0
     assert (
-        mw.pools["validator"].semaphore._value
-        == mw.pools["validator"].route_class.max_concurrent
+        mw.pools["weight_authority"].semaphore._value
+        == mw.pools["weight_authority"].route_class.max_concurrent
     )
 
 


### PR DESCRIPTION
## Incident

The primary validator's epoch 24155 automatic publication sent a
10,701,583-byte JSON body to `POST /weights/submit/v2`. The gateway's global
10 MiB body guard rejected every attempt with HTTP 413 before the route could
validate or persist the bundle. The same complete receipt graph is also carried
into finalization, so changing submit alone would only move the failure
downstream.

## Targeted fix

- Keep the ordinary gateway body limit at 10 MiB.
- Allow up to 32 MiB only for exact POST matches on the four attested graph
  routes: subnet-epoch candidate, subnet-epoch boundary, V2 submit, and V2
  finalize.
- Put those routes in a dedicated priority pool limited to 2 active and 4
  waiting requests, instead of broadening the 75-slot validator pool.
- Preserve fail-closed 413 handling for oversized declared and streamed bodies,
  with a stable rejection log tag.
- Add a regression using the observed 10,701,583-byte valid JSON wire size on
  both submit and finalize, plus exact-path, method, upper-bound, chunked-body,
  and pool-accounting coverage.

## Verification

- `103 passed`: mandatory weight authority, automatic flow, chain source,
  Python 3.7 enclave compatibility, crash recovery, submission retry,
  same-epoch auditor mirroring, and auditor hardening suites under isolated
  Python 3.11 plus repository-pinned Bittensor 10.5.
- `109 passed`: gateway body/flood/priority, V2 weight routes, attested store,
  and stateful epoch route suites.
- Focused compilation passed.
- `import gateway.main` passed in a CI-like, background-disabled environment.
- `git diff --check` passed.

## Safety and remaining gates

- This does not weaken attestation, receipt ancestry, signature, PCR0,
  persistence, finalization, auditor verification, or on-chain confirmation
  checks; it changes only pre-routing ingress capacity and bounded scheduling.
- The exact N-1-to-N gateway/validator restart rehearsal is **unexercised** for
  this candidate and remains advisory.
- GitHub Actions are pending.
- No merge, deployment, restart, Supabase write, or chain write was performed.
  Production automatic-weight recovery remains unproven until the PR is merged,
  the authorized gateway restart completes, and the live current-epoch
  submit/finalize/auditor/on-chain path is observed.
- This is the immediate incident fix, not the permanent answer to an
  ever-growing receipt graph. The graph still needs a separately reviewed
  checkpoint/reference transport before it reaches the later graph-row ceiling.
