### PR TITLE
Close the remaining weight-submission window failure modes

### DIFF
--- a/gateway/middleware/body_size.py
+++ b/gateway/middleware/body_size.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import os
@@ -94,7 +95,15 @@ class BodySizeLimitMiddleware:
                     detail="Compressed weight transport is not authorized",
                 )
                 return
-            authorization = self._transport_authorization(
+            # The authorization check imports bittensor and runs an sr25519
+            # verify; the body verification hashes up to 10 MiB compressed +
+            # 64 MiB logical and inflates the gzip. All of that is synchronous
+            # CPU that would otherwise stall the single gateway event loop
+            # (every miner and validator request) for ~100ms+ right at the
+            # weight-submission window. Offload to a worker thread; the check
+            # order and every fail-closed rejection are unchanged.
+            authorization = await asyncio.to_thread(
+                self._transport_authorization,
                 scope=scope,
                 headers=headers,
             )
@@ -112,35 +121,16 @@ class BodySizeLimitMiddleware:
             )
             if compressed is None:
                 return
-            if (
-                len(compressed) != authorization["wire_body_bytes"]
-                or sha256_bytes(compressed)
-                != authorization["wire_body_hash"]
-            ):
+            body, verify_error = await asyncio.to_thread(
+                self._verify_wire_and_decompress,
+                compressed,
+                authorization,
+            )
+            if body is None:
                 await self._reject(
                     send,
                     status=400,
-                    detail="Compressed weight transport body differs",
-                )
-                return
-            try:
-                body = self._decompress_gzip(compressed)
-            except ValueError:
-                await self._reject(
-                    send,
-                    status=400,
-                    detail="Invalid compressed request body",
-                )
-                return
-            if (
-                len(body) != authorization["logical_body_bytes"]
-                or sha256_bytes(body)
-                != authorization["logical_body_hash"]
-            ):
-                await self._reject(
-                    send,
-                    status=400,
-                    detail="Compressed weight transport payload differs",
+                    detail=verify_error or "Invalid compressed request body",
                 )
                 return
             rewritten_headers = [
@@ -280,6 +270,30 @@ class BodySizeLimitMiddleware:
                 return None
             if not message.get("more_body", False):
                 return bytes(body)
+
+    def _verify_wire_and_decompress(
+        self,
+        compressed: bytes,
+        authorization,
+    ):
+        """Runs in a worker thread: byte-count/hash checks and the bounded
+        gzip inflate, in the exact order the inline code used. Returns
+        (logical_body, None) on success or (None, rejection_detail)."""
+        if (
+            len(compressed) != authorization["wire_body_bytes"]
+            or sha256_bytes(compressed) != authorization["wire_body_hash"]
+        ):
+            return None, "Compressed weight transport body differs"
+        try:
+            body = self._decompress_gzip(compressed)
+        except ValueError:
+            return None, "Invalid compressed request body"
+        if (
+            len(body) != authorization["logical_body_bytes"]
+            or sha256_bytes(body) != authorization["logical_body_hash"]
+        ):
+            return None, "Compressed weight transport payload differs"
+        return body, None
 
     def _decompress_gzip(self, body: bytes) -> bytes:
         decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)

--- a/gateway/middleware/priority.py
+++ b/gateway/middleware/priority.py
@@ -64,7 +64,19 @@ OTHER_CLASS = RouteClass(
 VALIDATOR_EXACT = {
     "/validate",
     "/weights/submit",
+    # Every stage of the V2 weight-submission exchange must share the
+    # validator pool. Before this, only /weights/submit/v2 was reserved:
+    # the input fetch, finalize POST, subnet-epoch captures, and the
+    # attested-allocation fetch all fell to the OTHER pool (8s shed,
+    # shared with miscellaneous traffic), so near block 300 under load
+    # the most critical calls of the epoch could be shed with a 503
+    # while ordinary traffic held slots. A shed allocation fetch eats
+    # one of the validator's four fetch attempts inside its 90s budget.
     "/weights/submit/v2",
+    "/weights/finalize/v2",
+    "/weights/inputs/v2",
+    "/weights/subnet-epoch/candidate/v1",
+    "/weights/subnet-epoch/boundary/v1",
     "/fulfillment/scoring",
     "/fulfillment/score",
     "/fulfillment/rewards/active",
@@ -74,6 +86,9 @@ VALIDATOR_PREFIXES = (
     "/qualification/validator/",
     "/fulfillment/ban/",
     "/fulfillment/results/",
+    # Attested/live allocation reads are the fail-closed prerequisite for
+    # every weight submission (validator aborts the epoch without them).
+    "/research-lab/allocations/",
 )
 MINER_EXACT = {
     "/presign",

--- a/gateway/research_lab/allocation_handoff_disk_cache.py
+++ b/gateway/research_lab/allocation_handoff_disk_cache.py
@@ -1,0 +1,142 @@
+"""Restart-surviving disk cache for the assembled attested allocation handoff.
+
+The in-memory handoff cache in ``gateway.research_lab.api`` is wiped by every
+gateway process restart. A restart between the block-180 prewarm and the
+block-300 weight submission therefore forced a full cold rebuild — receipt
+ancestry reconstruction plus a fresh enclave attestation — inside the
+validator's 90s fetch budget, which is exactly the window where a slow build
+becomes a missed weight set.
+
+The allocation authority is deterministic for an epoch (see the cache comment
+in ``api.py``), so the fully-assembled handoff can be cached on local disk and
+served after a process restart. This is a read-through cache only: it is never
+an alternative authority (the validator re-validates the handoff and its
+receipt bindings fail-closed), entries are keyed strictly by
+``(epoch, persist_snapshot)``, expire on the same TTL the memory cache uses,
+and every failure here falls open to the normal cold build.
+
+Env knobs:
+- ``RESEARCH_LAB_ALLOCATION_HANDOFF_DISK_CACHE`` — set to ``0`` to disable.
+- ``RESEARCH_LAB_ALLOCATION_HANDOFF_DIR`` — cache directory override.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_FILE_PREFIX = "allocation_handoff_"
+
+
+def _enabled() -> bool:
+    return os.getenv("RESEARCH_LAB_ALLOCATION_HANDOFF_DISK_CACHE", "1") != "0"
+
+
+def _cache_dir() -> str:
+    configured = os.getenv("RESEARCH_LAB_ALLOCATION_HANDOFF_DIR", "").strip()
+    if configured:
+        return configured
+    return os.path.join(tempfile.gettempdir(), "leadpoet_allocation_handoff")
+
+
+def _entry_path(epoch: int, persist_snapshot: bool) -> str:
+    suffix = "persist" if persist_snapshot else "readonly"
+    return os.path.join(
+        _cache_dir(), f"{_FILE_PREFIX}{int(epoch)}_{suffix}.json"
+    )
+
+
+def store_handoff(
+    epoch: int,
+    persist_snapshot: bool,
+    handoff: dict[str, Any],
+    *,
+    ttl_seconds: float,
+) -> None:
+    """Persist an assembled handoff; prune other-epoch entries. Fail-open."""
+
+    if not _enabled():
+        return
+    try:
+        directory = _cache_dir()
+        os.makedirs(directory, exist_ok=True)
+        document = {
+            "schema": "leadpoet.allocation_handoff_disk_cache.v1",
+            "epoch": int(epoch),
+            "persist_snapshot": bool(persist_snapshot),
+            "stored_at": time.time(),
+            "ttl_seconds": float(ttl_seconds),
+            "handoff": handoff,
+        }
+        path = _entry_path(epoch, persist_snapshot)
+        tmp_path = f"{path}.tmp.{os.getpid()}"
+        with open(tmp_path, "w", encoding="utf-8") as fh:
+            json.dump(document, fh, separators=(",", ":"))
+        os.replace(tmp_path, path)
+        # The authority is only ever served for the current epoch; drop
+        # entries from other epochs so the directory cannot grow unbounded.
+        for name in os.listdir(directory):
+            if not name.startswith(_FILE_PREFIX):
+                continue
+            if name.startswith(f"{_FILE_PREFIX}{int(epoch)}_"):
+                continue
+            try:
+                os.remove(os.path.join(directory, name))
+            except OSError:
+                pass
+    except Exception as exc:  # fail-open: disk cache is best-effort only
+        logger.warning(
+            "allocation_handoff_disk_cache_store_failed epoch=%s error=%s",
+            epoch,
+            str(exc)[:200],
+        )
+
+
+def load_handoff(
+    epoch: int,
+    persist_snapshot: bool,
+) -> Optional[dict[str, Any]]:
+    """Return a fresh same-epoch handoff from disk, or None. Fail-open."""
+
+    if not _enabled():
+        return None
+    try:
+        path = _entry_path(epoch, persist_snapshot)
+        if not os.path.exists(path):
+            return None
+        with open(path, "r", encoding="utf-8") as fh:
+            document = json.load(fh)
+        if (
+            not isinstance(document, dict)
+            or document.get("schema")
+            != "leadpoet.allocation_handoff_disk_cache.v1"
+            or document.get("epoch") != int(epoch)
+            or document.get("persist_snapshot") is not bool(persist_snapshot)
+        ):
+            return None
+        stored_at = float(document.get("stored_at") or 0.0)
+        ttl_seconds = float(document.get("ttl_seconds") or 0.0)
+        if stored_at <= 0 or time.time() - stored_at >= ttl_seconds:
+            return None
+        handoff = document.get("handoff")
+        if not isinstance(handoff, dict) or not handoff:
+            return None
+        logger.info(
+            "allocation_handoff_disk_cache_hit epoch=%s persist_snapshot=%s",
+            epoch,
+            persist_snapshot,
+        )
+        return handoff
+    except Exception as exc:  # fail-open: fall back to the cold build
+        logger.warning(
+            "allocation_handoff_disk_cache_load_failed epoch=%s error=%s",
+            epoch,
+            str(exc)[:200],
+        )
+        return None

--- a/gateway/research_lab/api.py
+++ b/gateway/research_lab/api.py
@@ -19,7 +19,9 @@ import time
 from typing import Any, Mapping, Optional, Sequence
 from uuid import uuid4
 
+import gzip
 from fastapi import APIRouter, Header, HTTPException, Query, Request
+from fastapi.responses import Response
 
 from gateway.qualification.api.payment import get_payment_info, verify_payment
 from gateway.qualification.utils.chain import (
@@ -168,6 +170,7 @@ from .source_add_workflow import (
 from research_lab.improvement_engine.fix_generator import sanitized_miner_opportunity
 from research_lab.improvement_engine.scanner import scan_for_issues
 from leadpoet_canonical.constants import EPOCH_LENGTH
+from gateway.research_lab import allocation_handoff_disk_cache
 
 
 logger = logging.getLogger(__name__)
@@ -3199,10 +3202,43 @@ def _allocation_build_task(
     return task
 
 
+async def _allocation_handoff_response(
+    handoff: dict[str, Any],
+    accept_encoding: Optional[str],
+):
+    """Serve the handoff gzip-compressed when the caller asks for it.
+
+    The handoff is multi-MB, hash-dense JSON that compresses several-fold, and
+    it is fetched inside the validator's bounded pre-submission budget — the
+    dominant cost of a cold-epoch fetch should be the build, not the transfer.
+    Callers that do not advertise gzip get the identity JSON exactly as
+    before. Serialization + compression run in a worker thread so the response
+    path never stalls the shared event loop.
+    """
+
+    if "gzip" not in str(accept_encoding or "").lower():
+        return handoff
+
+    def _encode() -> bytes:
+        raw = json.dumps(handoff, separators=(",", ":")).encode("utf-8")
+        return gzip.compress(raw, compresslevel=6)
+
+    wire = await asyncio.to_thread(_encode)
+    return Response(
+        content=wire,
+        media_type="application/json",
+        headers={
+            "Content-Encoding": "gzip",
+            "Vary": "Accept-Encoding",
+        },
+    )
+
+
 @router.get("/allocations/attested/{epoch}")
 async def get_research_lab_attested_allocation(
     epoch: int,
     x_leadpoet_internal_key: Optional[str] = Header(default=None),
+    accept_encoding: Optional[str] = Header(default=None),
 ):
     """Return the unchanged live allocation plus its enclave-signed sidecar."""
 
@@ -3220,18 +3256,43 @@ async def get_research_lab_attested_allocation(
         persist_snapshot,
     )
     if cached_handoff is not None:
-        return cached_handoff
+        return await _allocation_handoff_response(cached_handoff, accept_encoding)
+    # Warm-start after a process restart: the memory cache is wiped by every
+    # gateway restart, and a restart between the block-180 prewarm and the
+    # block-300 submission used to force a full cold rebuild (receipt-ancestry
+    # reconstruction + fresh enclave attestation) inside the validator's 90s
+    # fetch budget. The handoff is deterministic per epoch, the validator
+    # re-validates it fail-closed, and any disk-cache failure falls open to
+    # the normal build below.
+    if _ALLOCATION_BUILD_TASKS.get(
+        _allocation_cache_key(int(epoch), persist_snapshot)
+    ) is None:
+        disk_handoff = await asyncio.to_thread(
+            allocation_handoff_disk_cache.load_handoff,
+            int(epoch),
+            persist_snapshot,
+        )
+        if disk_handoff is not None:
+            _allocation_handoff_cache_put(
+                int(epoch),
+                persist_snapshot,
+                disk_handoff,
+            )
+            return await _allocation_handoff_response(
+                disk_handoff, accept_encoding
+            )
     # Shield the complete build-and-cache task from client disconnects. The
     # previous lock only serialized live requests: when a validator timed out,
     # request cancellation released the lock before the finished authority
     # could be assembled and cached, so the next retry started over.
-    return await asyncio.shield(
+    built_handoff = await asyncio.shield(
         _allocation_build_task(
             config=config,
             epoch=int(epoch),
             persist_snapshot=persist_snapshot,
         )
     )
+    return await _allocation_handoff_response(built_handoff, accept_encoding)
 
 
 async def _build_and_cache_attested_allocation(
@@ -3330,6 +3391,15 @@ async def _build_and_cache_attested_allocation(
         int(epoch),
         persist_snapshot,
         handoff,
+    )
+    # Best-effort restart-surviving copy so a gateway restart mid-window can
+    # warm-start instead of rebuilding cold (fail-open on any disk error).
+    await asyncio.to_thread(
+        allocation_handoff_disk_cache.store_handoff,
+        int(epoch),
+        persist_snapshot,
+        handoff,
+        ttl_seconds=_ALLOCATION_CACHE_TTL_SECONDS,
     )
     return handoff
 

--- a/gateway/tasks/epoch_monitor.py
+++ b/gateway/tasks/epoch_monitor.py
@@ -78,6 +78,7 @@ class EpochMonitor:
         # missed-weight early warning; one alert per epoch per stage).
         self._weight_publication_alerted: set = set()
         self._weight_finalization_alerted: set = set()
+        self._weight_authority_read_alerted: set = set()
         self._weight_publication_seen: set = set()
         self._weight_finalization_done: set = set()
         self.initialized_epochs = set()  # Epochs that SUCCESSFULLY completed initialization
@@ -509,6 +510,7 @@ class EpochMonitor:
             )
 
             published = None
+            authority_read_failed = False
             for hotkey in primary_hotkeys:
                 try:
                     published = await load_weight_authority_v2(
@@ -517,10 +519,29 @@ class EpochMonitor:
                         validator_hotkey=hotkey,
                         require_finalization=False,
                     )
-                except Exception:
+                except Exception as exc:
+                    authority_read_failed = True
                     published = None
+                    alert_key = (settlement_epoch, hotkey)
+                    if alert_key not in self._weight_authority_read_alerted:
+                        self._weight_authority_read_alerted.add(alert_key)
+                        logging.getLogger(__name__).warning(
+                            "weight_publication_alarm_authority_read_failed "
+                            "netuid=%s epoch=%s validator_hotkey=%s "
+                            "error_type=%s error=%s",
+                            self.netuid,
+                            settlement_epoch,
+                            hotkey,
+                            type(exc).__name__,
+                            str(exc)[:200],
+                        )
                 if published is not None:
                     break
+            if published is None and authority_read_failed:
+                # A store/read failure is not evidence that the durable
+                # publication is absent. Retry on the next poll without
+                # raising a false missing-publication alarm.
+                return
             if published is not None:
                 self._weight_publication_seen.add(settlement_epoch)
                 if str(published.get("authority_stage") or "") == "finalized":

--- a/gateway/tasks/epoch_monitor.py
+++ b/gateway/tasks/epoch_monitor.py
@@ -74,6 +74,12 @@ class EpochMonitor:
         self.netuid = int(os.getenv("BITTENSOR_NETUID", "71"))
         self._validated_cutover_hash = None
         self._stateful_hydrated = False
+        # Epochs already alerted for a missing weight publication (in-epoch
+        # missed-weight early warning; one alert per epoch per stage).
+        self._weight_publication_alerted: set = set()
+        self._weight_finalization_alerted: set = set()
+        self._weight_publication_seen: set = set()
+        self._weight_finalization_done: set = set()
         self.initialized_epochs = set()  # Epochs that SUCCESSFULLY completed initialization
         self.initializing_epochs = set()  # Epochs currently being initialized (prevents duplicate tasks)
         self.validation_ended_epochs = set()
@@ -158,6 +164,7 @@ class EpochMonitor:
                     await self._hydrate_stateful_state(snapshot)
                     self._stateful_hydrated = True
                 await self._process_stateful_snapshot(snapshot)
+                await self._check_weight_publication_alarm(snapshot, cutover)
                 
                 # Wait before next poll (12 seconds = approx block time)
                 await asyncio.sleep(12)
@@ -465,6 +472,90 @@ class EpochMonitor:
                         self.skipped_epochs.add(target_epoch)
             cursor = boundary
         return cursor
+
+    async def _check_weight_publication_alarm(self, snapshot, cutover) -> None:
+        """In-epoch missed-weight early warning.
+
+        Every existing signal (journal quarantine CRITICALs, the >380-block
+        stale cron) fires after the epoch is already lost. The monitor already
+        polls the chain every ~block; from block 330 (~30 blocks / ~6 min of
+        submission window left) check whether the primary validator's durable
+        V2 weight publication exists for this settlement epoch, and emit one
+        loud, uniquely-tagged CRITICAL if it does not — while the validator's
+        retry loops can still save the epoch. Never raises into the poll loop.
+        """
+        try:
+            if snapshot.epoch_block < 330:
+                return
+            settlement_epoch = int(snapshot.settlement_epoch_id(cutover))
+            primary_hotkeys = [
+                item.strip()
+                for item in os.getenv("PRIMARY_VALIDATOR_HOTKEYS", "").split(",")
+                if item.strip()
+            ]
+            if not primary_hotkeys:
+                return
+            if settlement_epoch in self._weight_finalization_done:
+                return
+            if (
+                settlement_epoch in self._weight_publication_seen
+                and snapshot.epoch_block < 350
+            ):
+                # Publication already confirmed; next check is the block-350
+                # finalization stage — skip the authority reload until then.
+                return
+            from gateway.research_lab.attested_v2_store import (
+                load_weight_authority_v2,
+            )
+
+            published = None
+            for hotkey in primary_hotkeys:
+                try:
+                    published = await load_weight_authority_v2(
+                        netuid=int(self.netuid),
+                        epoch_id=settlement_epoch,
+                        validator_hotkey=hotkey,
+                        require_finalization=False,
+                    )
+                except Exception:
+                    published = None
+                if published is not None:
+                    break
+            if published is not None:
+                self._weight_publication_seen.add(settlement_epoch)
+                if str(published.get("authority_stage") or "") == "finalized":
+                    self._weight_finalization_done.add(settlement_epoch)
+                    return
+            if published is None:
+                if settlement_epoch not in self._weight_publication_alerted:
+                    self._weight_publication_alerted.add(settlement_epoch)
+                    message = (
+                        "weight_epoch_missing_publication "
+                        f"netuid={self.netuid} epoch={settlement_epoch} "
+                        f"epoch_block={snapshot.epoch_block} "
+                        f"blocks_remaining={snapshot.blocks_remaining} "
+                        "no durable V2 weight publication with the submission "
+                        "window closing"
+                    )
+                    logging.getLogger(__name__).critical(message)
+                    print(f"🚨 {message}")
+                return
+            if (
+                snapshot.epoch_block >= 350
+                and settlement_epoch not in self._weight_finalization_alerted
+            ):
+                self._weight_finalization_alerted.add(settlement_epoch)
+                self._weight_finalization_done.add(settlement_epoch)
+                message = (
+                    "weight_epoch_missing_finalization "
+                    f"netuid={self.netuid} epoch={settlement_epoch} "
+                    f"epoch_block={snapshot.epoch_block} "
+                    "published but no finalized chain proof yet"
+                )
+                logging.getLogger(__name__).critical(message)
+                print(f"🚨 {message}")
+        except Exception as alarm_error:
+            print(f"   ⚠️ Weight publication alarm check error: {alarm_error}")
 
     async def _process_stateful_snapshot(self, snapshot):
         """Drive lifecycle actions from one official scheduler observation."""

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -3158,6 +3158,22 @@ class Validator(BaseValidatorNeuron):
                                 await self.submit_weights_at_epoch_end()
                             except Exception as weight_err:
                                 print(f"   ⚠️ Weight submission check error: {weight_err}")
+                        elif epoch_state_bg.deadline_reached(ALLOCATION_PREPARATION_BLOCK):
+                            # Prewarm the attested allocation from here too. Batch
+                            # validation blocks the main loop for 10+ minutes, so the
+                            # block-180 prewarm inside the weight-submission path may
+                            # not run until the submission window opens — losing the
+                            # 120-block build margin and starting the expensive
+                            # gateway allocation build cold at block 300. The prepare
+                            # task is per-epoch idempotent and wait=False never
+                            # blocks this updater.
+                            try:
+                                await self._prepare_research_lab_allocation(
+                                    current_epoch_bg,
+                                    wait=False,
+                                )
+                            except Exception as prewarm_err:
+                                print(f"   ⚠️ Allocation prewarm error: {prewarm_err}")
                     except asyncio.CancelledError:
                         break  # Stop when batch validation completes
                     except Exception as e:

--- a/research_lab/validator_integration.py
+++ b/research_lab/validator_integration.py
@@ -20,6 +20,7 @@ from typing import Any, Iterable, Mapping
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
+import zlib
 
 from leadpoet_canonical.attested_receipts import (
     SCORING_ROLE,
@@ -442,6 +443,27 @@ def _is_retryable_allocation_fetch_error(exc: BaseException) -> bool:
     return False
 
 
+# Sanity bound for decompressing a gzip allocation response. The handoff is
+# ~10 MB serialized today; this is a zip-bomb guard, not a policy limit, so it
+# is set far above any realistic handoff size.
+_ALLOCATION_RESPONSE_MAX_LOGICAL_BYTES = 256 * 1024 * 1024
+
+
+def _decode_allocation_response_gzip(wire: bytes) -> bytes:
+    decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
+    body = decompressor.decompress(
+        wire, _ALLOCATION_RESPONSE_MAX_LOGICAL_BYTES + 1
+    )
+    if (
+        len(body) > _ALLOCATION_RESPONSE_MAX_LOGICAL_BYTES
+        or not decompressor.eof
+        or decompressor.unused_data
+        or decompressor.unconsumed_tail
+    ):
+        raise RuntimeError("allocation response gzip failed validation")
+    return body
+
+
 def _fetch_allocation_json(
     url: str,
     *,
@@ -466,12 +488,31 @@ def _fetch_allocation_json(
             break
         request = Request(
             url,
-            headers=_request_headers(include_internal_key=True),
+            headers={
+                **_request_headers(include_internal_key=True),
+                # The attested handoff is multi-MB, hash-dense JSON that
+                # compresses several-fold; ask for gzip so a cold-epoch fetch
+                # spends its 90s budget on the gateway build, not the
+                # transfer. Gateways without response compression ignore this
+                # header and keep returning identity unchanged.
+                "Accept-Encoding": "gzip",
+            },
             method="GET",
         )
         try:
             with urlopen(request, timeout=remaining) as response:
-                return json.loads(response.read().decode("utf-8"))
+                raw = response.read()
+                declared_encoding = str(
+                    response.headers.get("Content-Encoding") or ""
+                ).strip().lower()
+                if declared_encoding == "gzip":
+                    raw = _decode_allocation_response_gzip(raw)
+                elif declared_encoding not in ("", "identity"):
+                    raise RuntimeError(
+                        "unsupported allocation response encoding: %s"
+                        % declared_encoding
+                    )
+                return json.loads(raw.decode("utf-8"))
         except Exception as exc:  # noqa: BLE001 - reclassified below
             last_error = exc
             remaining_after = deadline - time.monotonic()

--- a/tests/test_allocation_fetch_retry.py
+++ b/tests/test_allocation_fetch_retry.py
@@ -22,6 +22,9 @@ from research_lab import validator_integration as vi
 class _FakeResponse:
     def __init__(self, payload):
         self._payload = json.dumps(payload).encode("utf-8")
+        # Mirror the real urlopen response interface: the fetch inspects
+        # Content-Encoding to decode a gzip allocation response.
+        self.headers = {}
 
     def read(self):
         return self._payload

--- a/tests/test_epoch_monitor_reconciliation.py
+++ b/tests/test_epoch_monitor_reconciliation.py
@@ -47,6 +47,89 @@ def _snapshot(
 
 
 @pytest.mark.asyncio
+async def test_weight_publication_alarm_waits_until_block_330(monkeypatch, caplog):
+    from gateway.research_lab import attested_v2_store
+    from gateway.tasks import epoch_monitor
+
+    calls = []
+
+    async def load(**kwargs):
+        calls.append(kwargs)
+        return None
+
+    monkeypatch.setenv("PRIMARY_VALIDATOR_HOTKEYS", "primary-hotkey")
+    monkeypatch.setattr(attested_v2_store, "load_weight_authority_v2", load)
+    monitor = epoch_monitor.EpochMonitor()
+
+    await monitor._check_weight_publication_alarm(
+        _snapshot(block=429),
+        _cutover(),
+    )
+
+    assert calls == []
+    assert "weight_epoch_missing_publication" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_weight_publication_alarm_emits_each_stage_once(monkeypatch, caplog):
+    from gateway.research_lab import attested_v2_store
+    from gateway.tasks import epoch_monitor
+
+    publications = [
+        None,
+        None,
+        {"authority_stage": "published"},
+        {"authority_stage": "published"},
+    ]
+
+    async def load(**_kwargs):
+        return publications.pop(0)
+
+    monkeypatch.setenv("PRIMARY_VALIDATOR_HOTKEYS", "primary-hotkey")
+    monkeypatch.setattr(attested_v2_store, "load_weight_authority_v2", load)
+    caplog.set_level("CRITICAL", logger=epoch_monitor.__name__)
+    monitor = epoch_monitor.EpochMonitor()
+
+    await monitor._check_weight_publication_alarm(_snapshot(block=430), _cutover())
+    await monitor._check_weight_publication_alarm(_snapshot(block=431), _cutover())
+    await monitor._check_weight_publication_alarm(_snapshot(block=449), _cutover())
+    await monitor._check_weight_publication_alarm(_snapshot(block=450), _cutover())
+    await monitor._check_weight_publication_alarm(_snapshot(block=451), _cutover())
+
+    assert caplog.text.count("weight_epoch_missing_publication") == 1
+    assert caplog.text.count("weight_epoch_missing_finalization") == 1
+
+
+@pytest.mark.asyncio
+async def test_weight_publication_alarm_does_not_treat_read_error_as_absence(
+    monkeypatch,
+    caplog,
+):
+    from gateway.research_lab import attested_v2_store
+    from gateway.tasks import epoch_monitor
+
+    async def failed_read(**_kwargs):
+        raise RuntimeError("store unavailable")
+
+    monkeypatch.setenv("PRIMARY_VALIDATOR_HOTKEYS", "primary-hotkey")
+    monkeypatch.setattr(
+        attested_v2_store,
+        "load_weight_authority_v2",
+        failed_read,
+    )
+    caplog.set_level("WARNING", logger=epoch_monitor.__name__)
+    monitor = epoch_monitor.EpochMonitor()
+
+    await monitor._check_weight_publication_alarm(_snapshot(block=430), _cutover())
+    await monitor._check_weight_publication_alarm(_snapshot(block=431), _cutover())
+
+    assert caplog.text.count(
+        "weight_publication_alarm_authority_read_failed"
+    ) == 1
+    assert "weight_epoch_missing_publication" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_stateful_monitor_uses_finalized_scheduler_snapshot(monkeypatch):
     from gateway.tasks import epoch_monitor
     from gateway.utils import epoch as epoch_utils

--- a/tests/test_gateway_weight_inputs_client_v2.py
+++ b/tests/test_gateway_weight_inputs_client_v2.py
@@ -247,6 +247,46 @@ async def test_client_retries_transient_gateway_failure_with_same_authorization(
 
 
 @pytest.mark.asyncio
+async def test_client_retries_gateway_500_with_same_authorization(monkeypatch):
+    monkeypatch.setattr(client_module, "validate_boot_identity", lambda _value: None)
+    monkeypatch.setattr(
+        client_module, "validate_signed_execution_receipt", lambda _value: None
+    )
+    monkeypatch.setattr(client_module, "validate_transport_attempt", lambda _value: None)
+    monkeypatch.setattr(
+        client_module, "validate_host_operation_record", lambda _value: None
+    )
+    payloads = []
+
+    async def post_json(_url, payload, _timeout):
+        payloads.append(payload)
+        if len(payloads) == 1:
+            raise GatewayWeightInputsV2Error(
+                "gateway V2 weight input request failed with HTTP 500",
+                status_code=500,
+            )
+        return _response(payload["request"])
+
+    client = FakeClient()
+    result = await fetch_gateway_weight_inputs_v2(
+        gateway_url="https://gateway.example",
+        calculation_snapshot=_calculation(),
+        validator_hotkey=HOTKEY,
+        allocation_hash="sha256:" + "3" * 64,
+        leaderboard_window_start="2026-07-03T20:00:00Z",
+        leaderboard_window_end="2026-07-10T20:00:00Z",
+        client=client,
+        post_json=post_json,
+        retry_delay_seconds=0,
+    )
+
+    assert len(payloads) == 2
+    assert payloads[0] == payloads[1]
+    assert len(client.messages) == 1
+    assert result["gateway_authority_event_hash"] == "sha256:" + "4" * 64
+
+
+@pytest.mark.asyncio
 async def test_client_does_not_retry_semantic_gateway_400():
     calls = 0
 

--- a/tests/test_weight_window_resilience.py
+++ b/tests/test_weight_window_resilience.py
@@ -1,0 +1,290 @@
+"""Trials for the weight-window resilience fixes.
+
+Covers: (1) every weight-submission endpoint rides the validator priority
+pool, (2) the compressed weight-transport verification runs off the event
+loop with identical accept/reject behavior, (3) the allocation handoff disk
+cache warm-starts a restart and fails open on corruption, (4) the validator
+allocation fetch negotiates gzip against a real HTTP server and still
+accepts identity responses from an older gateway.
+"""
+
+import asyncio
+import gzip
+import http.server
+import json
+import threading
+import time
+
+import pytest
+
+from gateway.middleware.priority import classify_path
+from gateway.middleware import body_size as body_size_module
+from gateway.middleware.body_size import BodySizeLimitMiddleware
+from gateway.research_lab import allocation_handoff_disk_cache as disk_cache
+from leadpoet_canonical.attested_v2 import sha256_bytes
+from leadpoet_canonical.hotkey_authority_v2 import (
+    build_weight_transport_authorization_v2,
+)
+from research_lab.validator_integration import _fetch_allocation_json
+
+
+# ---------------------------------------------------------------------------
+# 1. Priority routing: the whole weight exchange shares the validator pool.
+# ---------------------------------------------------------------------------
+
+def test_every_weight_submission_stage_rides_validator_pool():
+    for path in (
+        "/weights/submit",
+        "/weights/submit/v2",
+        "/weights/finalize/v2",
+        "/weights/inputs/v2",
+        "/weights/subnet-epoch/candidate/v1",
+        "/weights/subnet-epoch/boundary/v1",
+        "/research-lab/allocations/attested/24103",
+        "/research-lab/allocations/live/24103",
+    ):
+        assert classify_path(path) == "validator", path
+
+
+def test_public_weight_reads_stay_out_of_validator_pool():
+    # Public reads must not be able to consume validator slots.
+    for path in ("/weights/latest/71/24103", "/weights/current/71",
+                 "/weights/transparency/events"):
+        assert classify_path(path) == "other", path
+    assert classify_path("/fulfillment/requests/active") == "miner"
+
+
+# ---------------------------------------------------------------------------
+# 2. Compressed weight transport: same verdicts, now off the event loop.
+# ---------------------------------------------------------------------------
+
+_HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+
+
+def _authorized_request(logical: bytes, path: str = "/weights/submit/v2"):
+    wire = gzip.compress(logical, compresslevel=1)
+    authorization = build_weight_transport_authorization_v2(
+        validator_hotkey=_HOTKEY,
+        path=path,
+        wire_body_hash=sha256_bytes(wire),
+        wire_body_bytes=len(wire),
+        logical_body_hash=sha256_bytes(logical),
+        logical_body_bytes=len(logical),
+    )
+    import base64
+
+    headers = [
+        (b"content-encoding", b"gzip"),
+        (b"content-length", str(len(wire)).encode()),
+        (
+            b"x-leadpoet-weight-transport",
+            base64.b64encode(json.dumps(authorization).encode()),
+        ),
+        (b"x-leadpoet-weight-transport-signature", b"ab" * 64),
+    ]
+    scope = {"type": "http", "method": "POST", "path": path, "headers": headers}
+    return scope, wire
+
+
+def _drive(middleware, scope, wire_body):
+    seen = {}
+    sent = []
+
+    async def app(app_scope, receive, send):
+        message = await receive()
+        seen["body"] = message.get("body")
+        seen["headers"] = dict(app_scope["headers"])
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    middleware.app = app
+    delivered = False
+
+    async def receive():
+        nonlocal delivered
+        if delivered:
+            return {"type": "http.disconnect"}
+        delivered = True
+        return {"type": "http.request", "body": wire_body, "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    asyncio.run(middleware(scope, receive, send))
+    statuses = [m["status"] for m in sent if m["type"] == "http.response.start"]
+    return seen, statuses
+
+
+@pytest.fixture()
+def _authorized_env(monkeypatch):
+    monkeypatch.setenv("PRIMARY_VALIDATOR_HOTKEYS", _HOTKEY)
+    # The trial exercises everything except the sr25519 verify itself
+    # (no bittensor wheel locally); the verify call site and order are
+    # unchanged and covered by the existing transport tests in CI.
+    monkeypatch.setattr(
+        body_size_module, "_verify_transport_signature", lambda **_kw: True
+    )
+
+
+def test_authorized_compressed_post_decompresses_off_loop(_authorized_env):
+    logical = json.dumps(
+        {"receipt_graph": {"receipts": ["r" * 4096] * 64}}
+    ).encode()
+    scope, wire = _authorized_request(logical)
+    seen, statuses = _drive(BodySizeLimitMiddleware(None), scope, wire)
+    assert statuses == [204]
+    assert seen["body"] == logical
+    assert b"content-encoding" not in seen["headers"]
+
+
+def test_tampered_wire_body_still_rejected_400(_authorized_env):
+    logical = b'{"receipt_graph":{}}'
+    scope, wire = _authorized_request(logical)
+    seen, statuses = _drive(
+        BodySizeLimitMiddleware(None), scope, wire + b"x"
+    )
+    assert statuses == [400]
+    assert "body" not in seen
+
+
+def test_logical_hash_mismatch_still_rejected_400(_authorized_env):
+    logical = b'{"receipt_graph":{}}'
+    scope, _wire = _authorized_request(logical)
+    forged_wire = gzip.compress(b'{"receipt_graph":{"x":1}}', compresslevel=1)
+    # Fix the wire hash so only the logical check can catch the swap.
+    import base64
+
+    authorization = build_weight_transport_authorization_v2(
+        validator_hotkey=_HOTKEY,
+        path="/weights/submit/v2",
+        wire_body_hash=sha256_bytes(forged_wire),
+        wire_body_bytes=len(forged_wire),
+        logical_body_hash=sha256_bytes(logical),
+        logical_body_bytes=len(logical),
+    )
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/weights/submit/v2",
+        "headers": [
+            (b"content-encoding", b"gzip"),
+            (
+                b"x-leadpoet-weight-transport",
+                base64.b64encode(json.dumps(authorization).encode()),
+            ),
+            (b"x-leadpoet-weight-transport-signature", b"ab" * 64),
+        ],
+    }
+    seen, statuses = _drive(BodySizeLimitMiddleware(None), scope, forged_wire)
+    assert statuses == [400]
+    assert "body" not in seen
+
+
+def test_unauthorized_gzip_still_401(monkeypatch):
+    monkeypatch.setenv("PRIMARY_VALIDATOR_HOTKEYS", "")
+    logical = b'{"receipt_graph":{}}'
+    scope, wire = _authorized_request(logical)
+    seen, statuses = _drive(BodySizeLimitMiddleware(None), scope, wire)
+    assert statuses == [401]
+    assert "body" not in seen
+
+
+# ---------------------------------------------------------------------------
+# 3. Disk cache: restart warm-start semantics.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def _cache_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("RESEARCH_LAB_ALLOCATION_HANDOFF_DIR", str(tmp_path))
+    monkeypatch.delenv(
+        "RESEARCH_LAB_ALLOCATION_HANDOFF_DISK_CACHE", raising=False
+    )
+    return tmp_path
+
+
+def test_disk_cache_roundtrip_survives_process_restart(_cache_dir):
+    handoff = {"bundle": {"epoch_id": 24103}, "root_receipt_hash": "ab" * 32}
+    disk_cache.store_handoff(24103, True, handoff, ttl_seconds=5400.0)
+    # A "restarted" process shares only the directory, not any state.
+    assert disk_cache.load_handoff(24103, True) == handoff
+    # Wrong key variants must miss.
+    assert disk_cache.load_handoff(24103, False) is None
+    assert disk_cache.load_handoff(24104, True) is None
+
+
+def test_disk_cache_prunes_other_epochs(_cache_dir):
+    disk_cache.store_handoff(24102, True, {"old": 1}, ttl_seconds=5400.0)
+    disk_cache.store_handoff(24103, True, {"new": 1}, ttl_seconds=5400.0)
+    assert disk_cache.load_handoff(24102, True) is None
+    assert disk_cache.load_handoff(24103, True) == {"new": 1}
+
+
+def test_disk_cache_expires_and_fails_open(_cache_dir):
+    disk_cache.store_handoff(24103, True, {"h": 1}, ttl_seconds=0.05)
+    time.sleep(0.06)
+    assert disk_cache.load_handoff(24103, True) is None
+    # Corruption must fail open (return None), never raise.
+    path = disk_cache._entry_path(24103, True)
+    with open(path, "w") as fh:
+        fh.write("{not json")
+    assert disk_cache.load_handoff(24103, True) is None
+
+
+def test_disk_cache_disabled_by_env(_cache_dir, monkeypatch):
+    monkeypatch.setenv("RESEARCH_LAB_ALLOCATION_HANDOFF_DISK_CACHE", "0")
+    disk_cache.store_handoff(24103, True, {"h": 1}, ttl_seconds=5400.0)
+    assert disk_cache.load_handoff(24103, True) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Allocation fetch: gzip negotiation against a real HTTP server.
+# ---------------------------------------------------------------------------
+
+_PAYLOAD = {"bundle": {"epoch_id": 24103}, "receipt_graph": {"receipts": []}}
+
+
+class _AllocationHandler(http.server.BaseHTTPRequestHandler):
+    mode = "gzip"
+
+    def do_GET(self):
+        assert "gzip" in self.headers.get("Accept-Encoding", "")
+        raw = json.dumps(_PAYLOAD).encode()
+        if self.mode == "gzip":
+            body = gzip.compress(raw, compresslevel=6)
+            self.send_response(200)
+            self.send_header("Content-Encoding", "gzip")
+        else:
+            body = raw
+            self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        pass
+
+
+@pytest.fixture()
+def _allocation_server():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _AllocationHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_port}/alloc"
+    server.shutdown()
+
+
+def test_fetch_decodes_gzip_response(_allocation_server):
+    _AllocationHandler.mode = "gzip"
+    assert (
+        _fetch_allocation_json(_allocation_server, deadline_seconds=10)
+        == _PAYLOAD
+    )
+
+
+def test_fetch_still_accepts_identity_from_older_gateway(_allocation_server):
+    _AllocationHandler.mode = "identity"
+    assert (
+        _fetch_allocation_json(_allocation_server, deadline_seconds=10)
+        == _PAYLOAD
+    )

--- a/validator_tee/host/gateway_weight_inputs_v2.py
+++ b/validator_tee/host/gateway_weight_inputs_v2.py
@@ -29,7 +29,11 @@ from validator_tee.host.vsock_client import ValidatorEnclaveClient
 
 logger = logging.getLogger(__name__)
 
-_RETRYABLE_HTTP_STATUSES = frozenset({408, 429, 502, 503, 504})
+# 500 included: the inputs fetch is a read/compute request the gateway
+# serves idempotently (attested executions replay), and a transient
+# app-level 500 (e.g. a DB blip surfacing through the handler) used to
+# abort the whole attempt sequence inside the submission window.
+_RETRYABLE_HTTP_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
 _MAX_WEIGHT_INPUT_RESPONSE_FRAME_BYTES = 8 * 1024 * 1024
 _MAX_WEIGHT_INPUT_RESPONSE_BYTES = 64 * 1024 * 1024
 


### PR DESCRIPTION
## Why

UID 0 recently went ~1102 blocks stale on weight sets. The transport-limit root cause is fixed on main (gzip weight transport), but a full trace of the block-180 → block-300 submission flow surfaced four remaining ways a weight set can still be lost or slowed, all host-side. This PR closes them.

## What

1. **Priority routing** (`gateway/middleware/priority.py`): only `/weights/submit` and `/weights/submit/v2` had reserved validator pool capacity. The rest of the exchange — `/weights/inputs/v2`, `/weights/finalize/v2`, both `/weights/subnet-epoch/*/v1` captures, and the fail-closed `/research-lab/allocations/*` fetches — fell to the shared OTHER pool (8s shed, 150 slots shared with misc traffic), so the most critical requests of the epoch could be shed 503 under load. All stages now ride the validator pool; public `/weights/*` GET reads deliberately stay in OTHER so they can't consume validator slots.

2. **Prewarm survives batch validation** (`neurons/validator.py`): the block-180 allocation prewarm runs from the main loop, which batch validation blocks for 10+ minutes. If validation straddled 180→300, the allocation build started cold at block 300 inside the submission window. The background block-file updater now also kicks the idempotent, non-blocking prepare at block 180. (Enclosing function is not a protected workflow symbol; manifest unchanged.)

3. **Weight-transport verification off the event loop** (`gateway/middleware/body_size.py`): the sr25519 authorization check (including a lazy bittensor import) and the hash-hash-inflate of up to 10 MiB wire / 64 MiB logical ran synchronously on the shared event loop — stalling every concurrent request exactly at the submission window. Both now run via `asyncio.to_thread`; check order and every 401/400 verdict are byte-for-byte unchanged.

4. **Restart warm-start for the attested handoff** (`gateway/research_lab/allocation_handoff_disk_cache.py` + `api.py`): the assembled handoff lived only in process memory, so a gateway restart between blocks 180–300 forced a cold rebuild (receipt-ancestry reconstruction + fresh enclave attestation) inside the validator's 90s fetch budget. The deterministic per-epoch handoff is now also written to disk (atomic, keyed by `(epoch, persist_snapshot)`, same TTL, other epochs pruned) and re-served after a restart. Strictly a read-through cache: every disk failure falls open to the normal build, and the validator still re-validates the handoff fail-closed. Opt-out: `RESEARCH_LAB_ALLOCATION_HANDOFF_DISK_CACHE=0`.

5. **Gzip for the allocation fetch** (`research_lab/validator_integration.py` + `api.py`): the multi-MB receipt ancestry was fetched as identity JSON (no `Accept-Encoding`, no response compression) while the submit direction already ships gzip. The fetch now negotiates gzip with a bounded inflate; identity responses from an older gateway are accepted unchanged, so either side deploys first.

## Trials

- New `tests/test_weight_window_resilience.py` (12 tests): routing classification for every stage + public reads kept out; authorized compressed POST accepted and tampered wire / logical-hash mismatch / unauthorized sender still rejected after the thread offload; disk-cache restart roundtrip, other-epoch pruning, TTL expiry, corruption fail-open, disable knob; allocation fetch decoding gzip from a live local HTTP server and still accepting identity.
- Existing `test_gateway_body_size.py`, `test_priority_middleware_asgi.py`, `test_gateway_flood_protection.py`: pass with these changes (the one real-sr25519 test needs the bittensor wheel and runs in CI).
- No protected enclave workflow symbol is modified; gateway and validator manifests untouched.

Deploy note: gateway and validator sides are independently deployable (gzip is negotiated; disk cache is gateway-local; routing and offload are gateway-only; prewarm is validator-only).

## Second wave (deep-dive follow-ups)

6. **In-epoch missed-weight alarm** (`gateway/tasks/epoch_monitor.py`): every existing signal fires after the epoch is lost (journal CRITICALs are epoch-closed-gated; the stale cron is >380 blocks). The monitor now checks for the durable V2 publication at block 330 and emits `weight_epoch_missing_publication` (CRITICAL) while validator retries can still save the epoch, escalating at block 350 (`weight_epoch_missing_finalization`) if the chain proof is absent. ~2 authority reads per healthy epoch; never raises into the poll loop.
7. **HTTP 500 retryable on the inputs fetch** (`validator_tee/host/gateway_weight_inputs_v2.py`): a transient app-level 500 aborted the whole idempotent attempt sequence inside the window; now retried like 502/503/504.

## Verified but deliberately NOT included (need a manifest-refresh / contract decision)

CI's protected-workflow check showed `submit_weights_v2`, `finalize_weights_v2`, and `build_research_lab_allocation_bundle` are gateway-manifest-protected, and the per-request archive-anchor proof is a test-pinned contract on the weight/capture routes. These verified improvements were therefore reverted from this PR and are proposed for a deliberate follow-up with a manifest refresh:
- Cache the immutable cutover-anchor archive proof per mapping hash (3 call sites re-prove it per request; an archive outage during the window 503s every call → missed set). The sibling cache already exists in `gateway/utils/epoch.py`.
- Run the cheap `PRIMARY_VALIDATOR_HOTKEYS` gate before the expensive bundle validation in submit/finalize (unauthenticated peers can burn CPU-pool threads during the window).
- Build the release-lineage boot verifier (disk manifest + per-ancestor S3 fetch) off the event loop in submit/finalize/boundary.
- Bounded retry on the idempotent allocation-snapshot insert (one transient DB blip aborts the whole build after the enclave receipt exists).

Also flagged from the deep-dives (larger, for separate review): stale-prepared-journal replay can wedge an epoch on a deterministic 400 (drift) until epoch close; prior-epoch signed-journal recovery (10× full archive scans) runs inside the next epoch's window — an early-recovery kick at block 180 would clear it before the window; submit retry can strand a persisted bundle when the window re-check runs on the publication-completion path; the enclave's finalized-view read policy pages at 2 rows per attested round trip; readiness/receipt-graph loads are recomputed per build and are memoizable (immutable inputs).

<!-- codex-rebase-verification:start -->
## Current rebase and gate status (2026-07-25)
- Contains current `origin/main` `b1a10d167c41b67ee539f26a000e8a9780a2d6f0`; exact head `680f4758a02a2b4a73b848b28c33e62dc5f3b34a`.
- Follow-up fixes include alarm read-failure observability, avoiding false missing-publication alarms when the durable read fails, explicit block-330 stages, and a transient HTTP 500 retry regression.
- Code-level verification: 75 affected-path tests, 109 mandatory weight/auditor tests, and 86 reward-path tests passed in separate runs; gateway import passed; Deploy Checks run 710 passed for this exact head.
- Exact N-1-to-N gateway/validator rehearsal: unexercised (advisory). Live validator submission, persisted readback, and on-chain confirmation remain unproven.
- No merge, deployment, restart, or production write was performed. Review, branch-protection, block-position, and restart-in-progress gates still apply before any merge.
<!-- codex-rebase-verification:end -->
