### PR TITLE
Make ScrapingDog verifier retries deadline-aware

### DIFF
--- a/qualification/scoring/intent_verification_three_stage.py
+++ b/qualification/scoring/intent_verification_three_stage.py
@@ -63,6 +63,7 @@ import json
 import logging
 import os
 import re
+import time
 from datetime import date
 from typing import Any, Dict, List, Mapping, Optional
 from urllib.parse import urlparse, urlunsplit
@@ -77,6 +78,8 @@ logger = logging.getLogger(__name__)
 # ─────────────────────────────────────────────────────────────────────
 MAX_SCRAPED_CHARS = 60_000
 SCRAPE_TIMEOUT = 60
+SCRAPINGDOG_PROVIDER_DEADLINE_S = 55
+SCRAPINGDOG_TERMINAL_TIMEOUT_S = 60
 
 # Anti-bot / login-wall / parked-page text markers. When found in a short
 # response body, indicates the scraper hit a challenge page instead of real
@@ -112,7 +115,9 @@ _SPA_ROOT_RE = re.compile(
 )
 
 # ScrapingDog escalation tiers. Each fired only when the previous tier's
-# response was inadequate (HTTP fail, empty body, anti-bot marker, JS shell).
+# response contained recoverable content failure (empty body, anti-bot marker,
+# JS shell, or selected anti-bot HTTP status). Provider/transport failures stop
+# this ladder and move to the independent fallback.
 # NO host list — every URL gets the same cascade.
 _SD_TIERS = (
     ("baseline",        {}),
@@ -127,8 +132,18 @@ _SD_TIER_TIMEOUT = {
     "baseline":        25,
     "dynamic_render":  40,
     "premium_stealth": 40,
-    "full_combined":   55,
+    # This is the only tier intended to await ScrapingDog's terminal
+    # response. Keep a delivery margin above the provider's 55-second
+    # deadline; the cheaper tiers remain deliberate fast-fail probes.
+    "full_combined":   SCRAPINGDOG_TERMINAL_TIMEOUT_S,
 }
+_SD_CONTENT_ESCALATION_VERDICTS = frozenset({
+    "body_too_short",
+    "anti_bot_marker",
+    "js_shell",
+    "non_textual",
+})
+_SD_ANTIBOT_HTTP_VERDICTS = frozenset({"http_400", "http_403"})
 
 
 JOB_BOARD_HOSTS = (
@@ -233,6 +248,31 @@ def _evaluate_sd_response(status_code: int, body: str) -> str:
     if not _looks_textual(body):
         return "non_textual"
     return "ok"
+
+
+def _should_escalate_sd_response(verdict: str, tier_name: str) -> bool:
+    """Return whether a stronger ScrapingDog tier can plausibly help.
+
+    Content challenges and one baseline 404 may benefit from rendering or a
+    stronger proxy. Provider failures, throttles, and other HTTP statuses do
+    not; those should move to the independent fallback instead of duplicating
+    the same target request.
+    """
+    if verdict == "http_404":
+        return tier_name == "baseline"
+    return (
+        verdict in _SD_CONTENT_ESCALATION_VERDICTS
+        or verdict in _SD_ANTIBOT_HTTP_VERDICTS
+    )
+
+
+def _safe_sd_request_id(response: httpx.Response) -> str:
+    request_id = (
+        response.headers.get("x-request-id")
+        or response.headers.get("request-id")
+        or ""
+    )
+    return re.sub(r"[^A-Za-z0-9_.:-]", "_", request_id)[:128]
 
 
 # Social-media post URL routing — ScrapingDog's specialized endpoints return
@@ -528,10 +568,10 @@ async def _scrape_sd_hardened(url: str) -> Dict[str, Any]:
     """Content-driven progressive escalation.
 
     Starts with the cheapest ScrapingDog call (baseline) and escalates only
-    when the response is inadequate (HTTP failure / empty body / anti-bot
-    marker / JS shell shape). When all ScrapingDog tiers exhaust, falls back
-    to a Wayback Machine snapshot. NO hardcoded host list — every URL goes
-    through the same cascade.
+    when stronger rendering or proxying may recover inadequate content.
+    Client deadlines, transport errors, throttles, and provider 5xx responses
+    stop the ScrapingDog ladder and move to Wayback. NO hardcoded host list —
+    every URL uses the same failure-aware routing.
 
     Returns the original {ok, stage, content, error} contract so callers in
     verify_three_stage and the attribute-verification path work unchanged.
@@ -560,6 +600,7 @@ async def _scrape_sd_hardened(url: str) -> Dict[str, Any]:
         for tier_name, extra in _SD_TIERS:
             tier_timeout = _SD_TIER_TIMEOUT.get(tier_name, SCRAPE_TIMEOUT)
             params = {**base_params, **extra}
+            started = time.monotonic()
             try:
                 r = await cli.get(
                     "https://api.scrapingdog.com/scrape",
@@ -570,6 +611,16 @@ async def _scrape_sd_hardened(url: str) -> Dict[str, Any]:
                 history.append((tier_name, verdict))
                 last_status = r.status_code
                 last_verdict = verdict
+                logger.info(
+                    "scrapingdog_scrape_attempt tier=%s timeout_s=%s elapsed_ms=%d "
+                    "response_received=true status=%s verdict=%s request_id=%s",
+                    tier_name,
+                    tier_timeout,
+                    int((time.monotonic() - started) * 1000),
+                    r.status_code,
+                    verdict,
+                    _safe_sd_request_id(r),
+                )
                 if verdict == "ok":
                     # Extract article body from raw HTML before truncation.
                     # Removes nav/sidebar/footer/related-posts that otherwise
@@ -582,14 +633,43 @@ async def _scrape_sd_hardened(url: str) -> Dict[str, Any]:
                     return {"ok": True, "stage": f"sd:{tier_name}",
                             "content": body[:MAX_SCRAPED_CHARS],
                             "error": None, "stage_history": history}
-                # If origin returned 404 even after dynamic rendering, the URL
-                # is genuinely dead — escalating to premium proxies won't help.
-                if verdict == "http_404" and tier_name == "dynamic_render":
+                if not _should_escalate_sd_response(verdict, tier_name):
                     break
+            except httpx.TimeoutException:
+                last_verdict = f"client_deadline:{tier_name}"
+                history.append((tier_name, last_verdict))
+                logger.info(
+                    "scrapingdog_scrape_attempt tier=%s timeout_s=%s elapsed_ms=%d "
+                    "response_received=false failure_class=client_deadline",
+                    tier_name,
+                    tier_timeout,
+                    int((time.monotonic() - started) * 1000),
+                )
+                break
+            except httpx.TransportError as e:
+                last_verdict = f"transport_error:{type(e).__name__}"
+                history.append((tier_name, last_verdict))
+                logger.info(
+                    "scrapingdog_scrape_attempt tier=%s timeout_s=%s elapsed_ms=%d "
+                    "response_received=false failure_class=transport_error error_type=%s",
+                    tier_name,
+                    tier_timeout,
+                    int((time.monotonic() - started) * 1000),
+                    type(e).__name__,
+                )
+                break
             except Exception as e:
-                history.append((tier_name, f"exception:{type(e).__name__}"))
                 last_verdict = f"exception:{type(e).__name__}"
-                continue
+                history.append((tier_name, last_verdict))
+                logger.warning(
+                    "scrapingdog_scrape_attempt tier=%s timeout_s=%s elapsed_ms=%d "
+                    "response_received=false failure_class=unexpected error_type=%s",
+                    tier_name,
+                    tier_timeout,
+                    int((time.monotonic() - started) * 1000),
+                    type(e).__name__,
+                )
+                break
 
     # All ScrapingDog tiers exhausted. Try Wayback as the final source of
     # content — stale snapshot is better than nothing for evidence verification.

--- a/tests/test_scrapingdog_deadline_routing.py
+++ b/tests/test_scrapingdog_deadline_routing.py
@@ -1,0 +1,192 @@
+import asyncio
+import unittest
+from unittest import mock
+
+import aiohttp
+import httpx
+
+from qualification.scoring import intent_verification_three_stage as intent
+from validator_models import fulfillment_attribute_verification as attributes
+
+
+class _HttpxClient:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+class _AiohttpResponse:
+    def __init__(self, status, body, headers=None):
+        self.status = status
+        self._body = body
+        self.headers = headers or {}
+
+    async def text(self):
+        return self._body
+
+
+class _AiohttpContext:
+    def __init__(self, outcome):
+        self.outcome = outcome
+
+    async def __aenter__(self):
+        if isinstance(self.outcome, BaseException):
+            raise self.outcome
+        return self.outcome
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _AiohttpSession:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return _AiohttpContext(self.outcomes.pop(0))
+
+
+class IntentScrapingDogDeadlineTests(unittest.IsolatedAsyncioTestCase):
+    async def test_client_deadline_stops_scrapingdog_ladder(self):
+        client = _HttpxClient([httpx.ReadTimeout("client deadline")])
+        with mock.patch.object(intent.httpx, "AsyncClient", return_value=client), \
+                mock.patch.object(
+                    intent,
+                    "_try_wayback",
+                    new=mock.AsyncMock(return_value={
+                        "ok": False,
+                        "stage": "wayback_no_snapshot",
+                        "content": "",
+                        "error": "no archived snapshot",
+                    }),
+                ), \
+                mock.patch.dict("os.environ", {"SCRAPINGDOG_API_KEY": "test"}):
+            result = await intent._scrape_sd_hardened("https://unreachable.example")
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(len(client.calls), 1)
+        self.assertEqual(
+            result["stage_history"][0],
+            ("baseline", "client_deadline:baseline"),
+        )
+
+    async def test_provider_5xx_stops_scrapingdog_ladder(self):
+        client = _HttpxClient([
+            httpx.Response(503, text="provider unavailable", headers={}),
+        ])
+        with mock.patch.object(intent.httpx, "AsyncClient", return_value=client), \
+                mock.patch.object(
+                    intent,
+                    "_try_wayback",
+                    new=mock.AsyncMock(return_value={
+                        "ok": False,
+                        "stage": "wayback_no_snapshot",
+                        "content": "",
+                        "error": "no archived snapshot",
+                    }),
+                ), \
+                mock.patch.dict("os.environ", {"SCRAPINGDOG_API_KEY": "test"}):
+            result = await intent._scrape_sd_hardened("https://provider-failure.example")
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(len(client.calls), 1)
+        self.assertEqual(result["stage_history"][0], ("baseline", "http_503"))
+
+    async def test_content_challenge_still_escalates(self):
+        client = _HttpxClient([
+            httpx.Response(200, text="<html>captcha" + ("x" * 700), headers={}),
+            httpx.Response(200, text="<html><body>" + ("evidence " * 600), headers={}),
+        ])
+        with mock.patch.object(intent.httpx, "AsyncClient", return_value=client), \
+                mock.patch.dict("os.environ", {"SCRAPINGDOG_API_KEY": "test"}):
+            result = await intent._scrape_sd_hardened("https://challenged.example")
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(len(client.calls), 2)
+        self.assertEqual(result["stage"], "sd:dynamic_render")
+
+    def test_terminal_tier_has_provider_delivery_margin(self):
+        self.assertGreater(
+            intent._SD_TIER_TIMEOUT["full_combined"],
+            intent.SCRAPINGDOG_PROVIDER_DEADLINE_S,
+        )
+
+
+class AttributeScrapingDogDeadlineTests(unittest.IsolatedAsyncioTestCase):
+    async def test_client_deadline_stops_scrapingdog_ladder(self):
+        session = _AiohttpSession([asyncio.TimeoutError()])
+        with mock.patch.object(attributes, "SCRAPINGDOG_KEY", "test"), \
+                mock.patch.object(
+                    attributes,
+                    "_wayback_fetch",
+                    new=mock.AsyncMock(return_value=(False, "", "wayback_no_snapshot")),
+                ):
+            result = await attributes.fetch_url_via_scrapingdog(
+                session,
+                "https://unreachable.example",
+            )
+
+        self.assertFalse(result[0])
+        self.assertEqual(len(session.calls), 1)
+        self.assertIn("client_deadline:baseline", result[2])
+
+    async def test_provider_5xx_stops_scrapingdog_ladder(self):
+        session = _AiohttpSession([
+            _AiohttpResponse(503, "provider unavailable"),
+        ])
+        with mock.patch.object(attributes, "SCRAPINGDOG_KEY", "test"), \
+                mock.patch.object(
+                    attributes,
+                    "_wayback_fetch",
+                    new=mock.AsyncMock(return_value=(False, "", "wayback_no_snapshot")),
+                ):
+            result = await attributes.fetch_url_via_scrapingdog(
+                session,
+                "https://provider-failure.example",
+            )
+
+        self.assertFalse(result[0])
+        self.assertEqual(len(session.calls), 1)
+        self.assertIn("http_503", result[2])
+
+    async def test_transport_error_stops_scrapingdog_ladder(self):
+        session = _AiohttpSession([aiohttp.ClientConnectionError("unreachable")])
+        with mock.patch.object(attributes, "SCRAPINGDOG_KEY", "test"), \
+                mock.patch.object(
+                    attributes,
+                    "_wayback_fetch",
+                    new=mock.AsyncMock(return_value=(False, "", "wayback_no_snapshot")),
+                ):
+            result = await attributes.fetch_url_via_scrapingdog(
+                session,
+                "https://unreachable.example",
+            )
+
+        self.assertFalse(result[0])
+        self.assertEqual(len(session.calls), 1)
+        self.assertIn("transport_error:ClientConnectionError", result[2])
+
+    def test_terminal_tier_has_provider_delivery_margin(self):
+        self.assertGreater(
+            attributes._SD_TIER_TIMEOUT["full_combined"],
+            attributes.SCRAPINGDOG_PROVIDER_DEADLINE_S,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validator_models/fulfillment_attribute_verification.py
+++ b/validator_models/fulfillment_attribute_verification.py
@@ -63,6 +63,8 @@ MAX_CONCURRENCY = 8
 SD_URL = "https://api.scrapingdog.com/scrape"
 SD_TIMEOUT_S = 30                  # per-fetch (legacy default — superseded by
                                    # per-tier timeouts below for the cascade)
+SCRAPINGDOG_PROVIDER_DEADLINE_S = 55
+SCRAPINGDOG_TERMINAL_TIMEOUT_S = 60
 SD_MAX_CONTENT_CHARS = 12_000      # truncate fetched content per cited URL.
                                    # Raised from 4k alongside trafilatura
                                    # body extraction. With body extraction the
@@ -73,8 +75,9 @@ SD_MAX_CONTENT_CHARS = 12_000      # truncate fetched content per cited URL.
 SD_RETRY_DELAYS_S = (1, 2)         # legacy retry (unused by new cascade)
 
 # Content-driven escalation tiers — same cascade used by intent verifier.
-# Cheap tier first; escalate only when response is inadequate (HTTP failure /
-# empty body / anti-bot marker / JS-shell shape). NO host list.
+# Cheap tier first; escalate only for recoverable content failures (empty body,
+# anti-bot marker, JS shell, or selected anti-bot HTTP status). Provider and
+# transport failures stop the ScrapingDog ladder. NO host list.
 _SD_TIERS = (
     ("baseline",        {}),
     ("dynamic_render",  {"dynamic": "true", "wait": "5000"}),
@@ -86,8 +89,16 @@ _SD_TIER_TIMEOUT = {
     "baseline":        20,
     "dynamic_render":  30,
     "premium_stealth": 30,
-    "full_combined":   45,
+    # Only this final tier is intended to await the provider's terminal
+    # response; keep a delivery margin above ScrapingDog's 55-second deadline.
+    "full_combined":   SCRAPINGDOG_TERMINAL_TIMEOUT_S,
 }
+_SD_CONTENT_ESCALATION_VERDICTS = frozenset({
+    "body_too_short",
+    "anti_bot_marker",
+    "js_shell",
+})
+_SD_ANTIBOT_HTTP_VERDICTS = frozenset({"http_400", "http_403"})
 
 # Anti-bot / challenge / login-wall / parked-page markers — same as the
 # intent-verifier set, kept locally so this module is self-contained.
@@ -657,6 +668,25 @@ def _sd_evaluate(status_code: int, body: str) -> str:
     return "ok"
 
 
+def _sd_should_escalate(verdict: str, tier_name: str) -> bool:
+    """Escalate only when rendering or stronger proxying may recover content."""
+    if verdict == "http_404":
+        return tier_name == "baseline"
+    return (
+        verdict in _SD_CONTENT_ESCALATION_VERDICTS
+        or verdict in _SD_ANTIBOT_HTTP_VERDICTS
+    )
+
+
+def _sd_request_id(response: aiohttp.ClientResponse) -> str:
+    request_id = (
+        response.headers.get("x-request-id")
+        or response.headers.get("request-id")
+        or ""
+    )
+    return re.sub(r"[^A-Za-z0-9_.:-]", "_", request_id)[:128]
+
+
 async def _wayback_fetch(session: aiohttp.ClientSession, url: str) -> Tuple[bool, str, str]:
     """Wayback Machine snapshot fallback for URLs Scrapingdog tiers exhaust."""
     try:
@@ -689,11 +719,11 @@ async def fetch_url_via_scrapingdog(
     """Fetch one miner-cited URL via Scrapingdog with content-driven
     escalation + Wayback fallback.
 
-    Cascades through four Scrapingdog tiers, escalating only when the
-    response is inadequate (HTTP failure / empty body / anti-bot marker /
-    JS-shell shape). When all tiers exhaust, falls back to a Wayback
-    Machine snapshot. NO hardcoded host list — every URL goes through the
-    same cascade.
+    Cascades through Scrapingdog tiers only while stronger rendering or
+    proxying may recover inadequate content. Client deadlines, transport
+    errors, throttles, and provider 5xx responses stop the ScrapingDog ladder
+    and move to Wayback. NO hardcoded host list — every URL uses the same
+    failure-aware routing.
 
     Returns ``(ok, content, error)`` where:
       * ``ok=True``  → ``content`` is the page text (truncated to SD_MAX_CONTENT_CHARS).
@@ -724,6 +754,7 @@ async def fetch_url_via_scrapingdog(
             **extra,
         }
         tier_timeout = _SD_TIER_TIMEOUT.get(tier_name, SD_TIMEOUT_S)
+        started = time.monotonic()
         try:
             async with session.get(
                 SD_URL, params=params,
@@ -732,6 +763,16 @@ async def fetch_url_via_scrapingdog(
                 text = await resp.text()
                 verdict = _sd_evaluate(resp.status, text)
                 last_verdict = verdict
+                _sd_logger.info(
+                    "scrapingdog_scrape_attempt tier=%s timeout_s=%s elapsed_ms=%d "
+                    "response_received=true status=%s verdict=%s request_id=%s",
+                    tier_name,
+                    tier_timeout,
+                    int((time.monotonic() - started) * 1000),
+                    resp.status,
+                    verdict,
+                    _sd_request_id(resp),
+                )
                 if verdict == "ok":
                     # Body extraction (trafilatura) — pulls just the article
                     # body from raw HTML, stripping nav/sidebar/footer. Safe
@@ -742,14 +783,43 @@ async def fetch_url_via_scrapingdog(
                     except Exception:
                         pass
                     return True, text[:SD_MAX_CONTENT_CHARS], f"sd:{tier_name}"
-                # If the origin returns 404 even after dynamic-render, the URL
-                # is genuinely dead — escalating to premium won't help.
-                if verdict == "http_404" and tier_name == "dynamic_render":
-                    return False, "", "genuine_404"
+                if not _sd_should_escalate(verdict, tier_name):
+                    break
         except asyncio.TimeoutError:
-            last_verdict = f"timeout:{tier_name}"
+            last_verdict = f"client_deadline:{tier_name}"
+            _sd_logger.info(
+                "scrapingdog_scrape_attempt tier=%s timeout_s=%s elapsed_ms=%d "
+                "response_received=false failure_class=client_deadline",
+                tier_name,
+                tier_timeout,
+                int((time.monotonic() - started) * 1000),
+            )
+            break
+        except aiohttp.ClientError as e:
+            last_verdict = f"transport_error:{type(e).__name__}"
+            _sd_logger.info(
+                "scrapingdog_scrape_attempt tier=%s timeout_s=%s elapsed_ms=%d "
+                "response_received=false failure_class=transport_error error_type=%s",
+                tier_name,
+                tier_timeout,
+                int((time.monotonic() - started) * 1000),
+                type(e).__name__,
+            )
+            break
         except Exception as e:
             last_verdict = f"exception:{type(e).__name__}"
+            _sd_logger.warning(
+                "scrapingdog_scrape_attempt tier=%s timeout_s=%s elapsed_ms=%d "
+                "response_received=false failure_class=unexpected error_type=%s",
+                tier_name,
+                tier_timeout,
+                int((time.monotonic() - started) * 1000),
+                type(e).__name__,
+            )
+            break
+
+    if last_verdict == "http_404":
+        return False, "", "genuine_404"
 
     # All Scrapingdog tiers exhausted. Try Wayback Machine for a cached
     # snapshot — stale evidence is far better than zero evidence when the
@@ -759,8 +829,8 @@ async def fetch_url_via_scrapingdog(
         return True, wb_content, "wayback"
 
     _sd_logger.warning(
-        "SD+Wayback fetch failed url=%s reason=%s wb=%s",
-        url[:200], last_verdict, wb_err,
+        "SD+Wayback fetch failed host=%s reason=%s wb=%s",
+        _sd_host(url), last_verdict, wb_err,
     )
     return False, "", f"all_tiers_exhausted:{last_verdict}"
 


### PR DESCRIPTION
## What changed

- stop intent and required-attribute ScrapingDog ladders after client deadlines, transport errors, throttles, and provider 5xx responses
- continue escalating recoverable content failures, selected anti-bot responses, and one baseline 404 render check
- give the terminal-response tier a 60-second deadline above ScrapingDog's documented 55-second provider deadline
- add bounded transport telemetry without logging target URLs or credentials
- add regression tests for timeout, transport, 5xx, challenge escalation, and deadline margin

## Root cause

The verifier treated every exception and HTTP failure as a reason to advance to the next paid ScrapingDog tier. Because the provider can hold a request for 55 seconds, the shorter client deadlines could abandon a still-running request and immediately issue another request for the same target.

## Impact

Unreachable origins and provider failures now move to the existing independent fallback after one ScrapingDog attempt. Valid anti-bot/content recovery behavior remains intact. No gateway or validator restart is included.

## Verification

- focused verifier and required-gate suite — 21 passed
- representative reward/weight suite — 20 passed
- relevant modules compiled successfully
- `git diff --check`

One broader weight test remains unexercised locally because the installed Bittensor package lacks the repository's expected `bittensor.Keypair` / `bittensor.utils` API. The recommended N-1-to-N gateway/validator restart rehearsal is unexercised. No production restart, deploy, or on-chain action was performed.
