### PR TITLE
Stop coordinator recipient-pool saturation from killing the weight path

### DIFF
--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -3523,6 +3523,21 @@ class ResearchLabGatewayScoringWorker:
                         )
                     )
                     last_error_log = now
+                if "capacity is full" in str(exc):
+                    # The coordinator's recipient pool is saturated. Hammering
+                    # it at the normal cadence keeps the pool pinned (every
+                    # retry files a fresh request) and starves the weight
+                    # path, which shares the coordinator. Back off long
+                    # enough for TTL evictions to reclaim slots, and log a
+                    # unique tag an alerting cron can page on — this state
+                    # precedes a missed weight set by minutes.
+                    logger.critical(
+                        "coordinator_recipient_pool_saturated worker=%s "
+                        "backing_off_seconds=120",
+                        self.worker_ref,
+                    )
+                    await asyncio.sleep(120)
+                    continue
                 await asyncio.sleep(max(self.config.scoring_worker_poll_seconds, error_backoff_seconds))
                 continue
             if outcome.get("processed") or outcome.get("status") != "idle":

--- a/gateway/tee/kms_recipient_v2.py
+++ b/gateway/tee/kms_recipient_v2.py
@@ -40,8 +40,17 @@ OPENROUTER_INGRESS_RECIPIENT_PURPOSE = (
 KMS_KEY_ENCRYPTION_ALGORITHM = "RSAES_OAEP_SHA_256"
 MAX_CIPHERTEXT_FOR_RECIPIENT_BYTES = 64 * 1024
 MAX_CREDENTIAL_BYTES = 64 * 1024
-MAX_JOB_RECIPIENT_REQUESTS = 2048
-JOB_RECIPIENT_REQUEST_TTL_SECONDS = 3600.0
+# Capacity math is load-bearing: slots are freed only on successful unwrap or
+# TTL expiry, so any window where more requests are created-but-abandoned than
+# the cap admits rejects EVERY coordinator credential RPC ("job recipient
+# capacity is full") — observed 2026-07-26 03:24 UTC, taking down scoring and
+# the weight-submission path together after ~8h of normal load. A request is
+# unwrapped within one RPC exchange in practice, so a 10-minute TTL bounds
+# abandoned entries tightly while leaving generous slack; the larger cap makes
+# saturation require a >13k/10min abandonment storm instead of a slow leak
+# (~80MB worst-case footprint, well inside the coordinator's 8GB).
+MAX_JOB_RECIPIENT_REQUESTS = 8192
+JOB_RECIPIENT_REQUEST_TTL_SECONDS = 600.0
 _HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 

--- a/tests/test_kms_recipient_v2.py
+++ b/tests/test_kms_recipient_v2.py
@@ -2,6 +2,8 @@ import base64
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+
+from gateway.tee.kms_recipient_v2 import JOB_RECIPIENT_REQUEST_TTL_SECONDS
 from cryptography.hazmat.primitives import hashes, padding as symmetric_padding
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -346,7 +348,7 @@ def test_abandoned_job_recipients_expire_without_evicting_live_requests(monkeypa
         credential_value_hash_expected=credential_value_hash(secret),
         key_ref_hash=sha256_json({"key_ref": "encrypted_ref:live"}),
     )
-    now[0] += 3599.5
+    now[0] += JOB_RECIPIENT_REQUEST_TTL_SECONDS - 0.5
 
     replacement = manager.job_recipient_request(
         job_id="autoresearch-v2:replacement-job",
@@ -384,7 +386,7 @@ def test_expired_job_recipient_is_rejected_before_capacity_sweep(monkeypatch):
         credential_value_hash_expected=credential_value_hash(secret),
         key_ref_hash=sha256_json({"key_ref": "encrypted_ref:expired-direct"}),
     )
-    now[0] += 3600.0
+    now[0] += JOB_RECIPIENT_REQUEST_TTL_SECONDS
 
     with pytest.raises(KMSRecipientV2Error, match="expired"):
         manager.unwrap_job_credential(


### PR DESCRIPTION
## Why

At 03:24 UTC Jul 26 the coordinator enclave's job-recipient pool saturated ("job recipient capacity is full", `gateway/tee/kms_recipient_v2.py:505`) after ~8h of normal scoring load. Slots (2048, 1h TTL) are freed only on successful unwrap or expiry, so a window where more requests are created-but-abandoned than the cap admits rejects every coordinator credential RPC — scoring and the weight-submission path went down together, producing the epoch 24120–24121 missed weight sets (UID 0, 739 blocks stale). This is load-dependent, not restart-dependent: it recurs hours after every restart until fixed.

## What

1. `kms_recipient_v2.py`: TTL 3600s → 600s, cap 2048 → 8192. Requests unwrap within one RPC exchange in practice; a 10-minute TTL bounds abandoned entries tightly (generous slack retained), and the larger cap turns saturation from a slow leak into something requiring a >13k/10min abandonment storm. Worst-case footprint ~80MB, well inside the coordinator's 8GB.
2. `scoring_worker.py`: on the saturation error, workers back off 120s (instead of re-hammering at normal cadence — each retry files a fresh request, pinning the pool) and emit a uniquely-tagged CRITICAL (`coordinator_recipient_pool_saturated`) for alerting; this state precedes the missed weight set by minutes.

Neither file is in a protected-workflow manifest. The enclave-side constant change lands through the normal gw_restart enclave rebuild + allowlist flow.

## Evidence

Live box audit: journalctl launch records (all 3 enclaves launched cleanly Jul 25 19:28), gateway.log:230259 (saturation storm from 03:24:53 across workers), nitro logs (coordinator socket gone, no terminate command → crash), staleness math matching the last set at epoch 24119.
