### PR TITLE
Allow V2 sealing with worker fleets explicitly deferred (unblock weight-path recovery)

### DIFF
--- a/gateway/tee/prepare_gateway_envelopes_v2.py
+++ b/gateway/tee/prepare_gateway_envelopes_v2.py
@@ -288,15 +288,58 @@ def _proxy_names(
     return names
 
 
+def _deferred_worker_fleet_roles(environment: Mapping[str, str]) -> frozenset[str]:
+    """Roles the operator explicitly deferred from this sealing.
+
+    A weight-submission outage must be recoverable even when the worker
+    fleets cannot currently satisfy the V2 proxy transport (observed: every
+    configured egress proxy was plaintext HTTP while workers were already
+    paused, and the preflight refused to seal at all — holding the
+    coordinator enclave, and with it every weight set, hostage to a paused
+    subsystem's dependency). Deferral is opt-in per restart, never a
+    default: GATEWAY_V2_DEFER_WORKER_FLEETS="all" or a comma list of roles
+    ("gateway_autoresearch,gateway_scoring"). A deferred role is sealed
+    with NO proxy commitments, so no proxy lease can ever validate for it —
+    its workers stay fail-closed until a future sealing provides compliant
+    proxies. Non-deferred roles keep the exact fail-closed behavior.
+    """
+
+    raw = str(
+        environment.get("GATEWAY_V2_DEFER_WORKER_FLEETS") or ""
+    ).strip().lower()
+    if not raw:
+        return frozenset()
+    if raw in {"all", "1", "true"}:
+        return frozenset({"gateway_autoresearch", "gateway_scoring"})
+    roles = frozenset(
+        item.strip() for item in raw.split(",") if item.strip()
+    )
+    unknown = roles - {"gateway_autoresearch", "gateway_scoring"}
+    if unknown:
+        raise GatewayEnvelopePreparationV2Error(
+            "unknown deferred worker fleet role: %s" % ", ".join(sorted(unknown))
+        )
+    return roles
+
+
 def _validated_worker_proxy_configuration(
     environment: Mapping[str, str],
 ) -> tuple[Any, Dict[str, list[str]]]:
     plan = build_research_lab_worker_autostart_plan(environment)
-    if not plan.hosted.enabled or not plan.scoring.enabled:
+    deferred = _deferred_worker_fleet_roles(environment)
+    if "gateway_autoresearch" not in deferred and not plan.hosted.enabled:
         raise GatewayEnvelopePreparationV2Error(
             "configured hosted and scoring worker fleets are required"
         )
-    if not plan.hosted.proxy_values or not plan.scoring.proxy_values:
+    if "gateway_scoring" not in deferred and not plan.scoring.enabled:
+        raise GatewayEnvelopePreparationV2Error(
+            "configured hosted and scoring worker fleets are required"
+        )
+    if "gateway_autoresearch" not in deferred and not plan.hosted.proxy_values:
+        raise GatewayEnvelopePreparationV2Error(
+            "worker proxy values are required for initial V2 sealing"
+        )
+    if "gateway_scoring" not in deferred and not plan.scoring.proxy_values:
         raise GatewayEnvelopePreparationV2Error(
             "worker proxy values are required for initial V2 sealing"
         )
@@ -307,6 +350,17 @@ def _validated_worker_proxy_configuration(
     commitments: Dict[str, list[str]] = {}
     for role, values in fleets.items():
         commitments[role] = []
+        if role in deferred:
+            # Sealed with zero commitments: every proxy lease for this role
+            # fails validation downstream, so the fleet cannot run until a
+            # future sealing restores compliant proxies. Loud by design.
+            print(
+                "⚠️  %s worker fleet DEFERRED from V2 sealing: no proxy "
+                "commitments sealed; its workers stay fail-closed until a "
+                "compliant sealing (GATEWAY_V2_DEFER_WORKER_FLEETS)" % role,
+                flush=True,
+            )
+            continue
         for index, value in enumerate(values):
             try:
                 _validated_tls_proxy_url(value)

--- a/tests/test_deferred_worker_fleet_sealing.py
+++ b/tests/test_deferred_worker_fleet_sealing.py
@@ -1,0 +1,79 @@
+"""Opt-in worker-fleet deferral must unblock sealing without weakening it.
+
+A weight-submission outage was held hostage by the preflight refusing to seal
+when the (already paused) worker fleets' egress proxies could not satisfy the
+V2 HTTPS:443 transport. Deferral seals a role with zero proxy commitments so
+its workers stay fail-closed, while non-deferred roles keep byte-identical
+validation.
+"""
+import types
+
+import pytest
+
+from gateway.tee import prepare_gateway_envelopes_v2 as mod
+
+
+def _plan(hosted_proxies, scoring_proxies):
+    def fleet(values):
+        return types.SimpleNamespace(
+            enabled=True, proxy_values=list(values), worker_count=len(values)
+        )
+    return types.SimpleNamespace(
+        hosted=fleet(hosted_proxies), scoring=fleet(scoring_proxies)
+    )
+
+
+_BAD = ["http://plain-proxy.example:8080"]          # plaintext non-443: invalid
+_GOOD = ["https://user:pw@relay.example:443"]        # compliant
+
+
+@pytest.fixture()
+def _stub_plan(monkeypatch):
+    def install(hosted, scoring):
+        monkeypatch.setattr(
+            mod,
+            "build_research_lab_worker_autostart_plan",
+            lambda _env: _plan(hosted, scoring),
+        )
+    return install
+
+
+def test_default_still_fails_closed_on_plaintext_proxy(_stub_plan):
+    _stub_plan(_BAD, _GOOD)
+    with pytest.raises(mod.GatewayEnvelopePreparationV2Error):
+        mod._validated_worker_proxy_configuration({})
+
+
+def test_defer_all_seals_with_no_commitments(_stub_plan):
+    _stub_plan(_BAD, _BAD)
+    _plan_out, commitments = mod._validated_worker_proxy_configuration(
+        {"GATEWAY_V2_DEFER_WORKER_FLEETS": "all"}
+    )
+    assert commitments == {
+        "gateway_autoresearch": [],
+        "gateway_scoring": [],
+    }
+
+
+def test_defer_one_role_keeps_other_validated(_stub_plan):
+    # Deferring autoresearch must not relax scoring validation.
+    _stub_plan(_BAD, _BAD)
+    with pytest.raises(mod.GatewayEnvelopePreparationV2Error):
+        mod._validated_worker_proxy_configuration(
+            {"GATEWAY_V2_DEFER_WORKER_FLEETS": "gateway_autoresearch"}
+        )
+    # With scoring compliant, the same deferral seals: empty commitments for
+    # the deferred role, real hashes for the validated one.
+    _stub_plan(_BAD, _GOOD)
+    _plan_out, commitments = mod._validated_worker_proxy_configuration(
+        {"GATEWAY_V2_DEFER_WORKER_FLEETS": "gateway_autoresearch"}
+    )
+    assert commitments["gateway_autoresearch"] == []
+    assert len(commitments["gateway_scoring"]) == 1
+
+
+def test_unknown_role_rejected():
+    with pytest.raises(mod.GatewayEnvelopePreparationV2Error):
+        mod._deferred_worker_fleet_roles(
+            {"GATEWAY_V2_DEFER_WORKER_FLEETS": "bogus_role"}
+        )


### PR DESCRIPTION
## Why

The recovery restart for the coordinator-enclave outage failed closed in gateway preflight (position 255/360): envelope sealing requires both worker fleets to present all-valid HTTPS:443 egress proxies, and the entire configured pool is plaintext HTTP on non-443 ports (the provider's documented ports exclude 443 entirely). Result: the coordinator enclave — and with it every epoch's weight submission — stayed down, blocked by a dependency of the autoresearch/scoring fleets, which were already paused with no active claims. The weight path does not use worker egress proxies.

## What

`gateway/tee/prepare_gateway_envelopes_v2.py`: an explicit per-restart opt-in, `GATEWAY_V2_DEFER_WORKER_FLEETS="all"` (or a comma list of roles). A deferred role seals with **zero proxy commitments**:

- no proxy lease can ever validate for it downstream, so its workers remain fail-closed until a future sealing provides compliant proxies — deferral cannot weaken transport posture, it only narrows what is provisioned;
- the deferral is loudly announced in the preflight output;
- non-deferred roles keep byte-identical validation; unknown role names are rejected; with the env unset, behavior is unchanged fail-closed (existing suite passes untouched).

## Operational effect

The blocked restart can now run as `GATEWAY_V2_DEFER_WORKER_FLEETS=all` in the next window: coordinator returns, weight submissions resume, scoring/autoresearch stay exactly as paused as they are today. The TLS:443 relay (or compliant proxy pool) then re-enables the fleets via a normal future sealing — fully decoupled from the money path.

## Testing

- New `tests/test_deferred_worker_fleet_sealing.py`: default still fails closed on a plaintext proxy; defer-all seals with empty commitments; deferring one role does not relax the other's validation; unknown roles rejected.
- Existing `tests/test_prepare_gateway_envelopes_v2.py` passes unchanged (9/9) — default behavior untouched. 13/13 locally.
