### PR TITLE
Weight-outage recovery: coordinator capacity fix + deferred-fleet sealing + TLS:443 proxy relay

### DIFF
--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -3523,6 +3523,21 @@ class ResearchLabGatewayScoringWorker:
                         )
                     )
                     last_error_log = now
+                if "capacity is full" in str(exc):
+                    # The coordinator's recipient pool is saturated. Hammering
+                    # it at the normal cadence keeps the pool pinned (every
+                    # retry files a fresh request) and starves the weight
+                    # path, which shares the coordinator. Back off long
+                    # enough for TTL evictions to reclaim slots, and log a
+                    # unique tag an alerting cron can page on — this state
+                    # precedes a missed weight set by minutes.
+                    logger.critical(
+                        "coordinator_recipient_pool_saturated worker=%s "
+                        "backing_off_seconds=120",
+                        self.worker_ref,
+                    )
+                    await asyncio.sleep(120)
+                    continue
                 await asyncio.sleep(max(self.config.scoring_worker_poll_seconds, error_backoff_seconds))
                 continue
             if outcome.get("processed") or outcome.get("status") != "idle":

--- a/gateway/tee/kms_recipient_v2.py
+++ b/gateway/tee/kms_recipient_v2.py
@@ -40,8 +40,17 @@ OPENROUTER_INGRESS_RECIPIENT_PURPOSE = (
 KMS_KEY_ENCRYPTION_ALGORITHM = "RSAES_OAEP_SHA_256"
 MAX_CIPHERTEXT_FOR_RECIPIENT_BYTES = 64 * 1024
 MAX_CREDENTIAL_BYTES = 64 * 1024
-MAX_JOB_RECIPIENT_REQUESTS = 2048
-JOB_RECIPIENT_REQUEST_TTL_SECONDS = 3600.0
+# Capacity math is load-bearing: slots are freed only on successful unwrap or
+# TTL expiry, so any window where more requests are created-but-abandoned than
+# the cap admits rejects EVERY coordinator credential RPC ("job recipient
+# capacity is full") — observed 2026-07-26 03:24 UTC, taking down scoring and
+# the weight-submission path together after ~8h of normal load. A request is
+# unwrapped within one RPC exchange in practice, so a 10-minute TTL bounds
+# abandoned entries tightly while leaving generous slack; the larger cap makes
+# saturation require a >13k/10min abandonment storm instead of a slow leak
+# (~80MB worst-case footprint, well inside the coordinator's 8GB).
+MAX_JOB_RECIPIENT_REQUESTS = 8192
+JOB_RECIPIENT_REQUEST_TTL_SECONDS = 600.0
 _HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 

--- a/gateway/tee/prepare_gateway_envelopes_v2.py
+++ b/gateway/tee/prepare_gateway_envelopes_v2.py
@@ -288,15 +288,58 @@ def _proxy_names(
     return names
 
 
+def _deferred_worker_fleet_roles(environment: Mapping[str, str]) -> frozenset[str]:
+    """Roles the operator explicitly deferred from this sealing.
+
+    A weight-submission outage must be recoverable even when the worker
+    fleets cannot currently satisfy the V2 proxy transport (observed: every
+    configured egress proxy was plaintext HTTP while workers were already
+    paused, and the preflight refused to seal at all — holding the
+    coordinator enclave, and with it every weight set, hostage to a paused
+    subsystem's dependency). Deferral is opt-in per restart, never a
+    default: GATEWAY_V2_DEFER_WORKER_FLEETS="all" or a comma list of roles
+    ("gateway_autoresearch,gateway_scoring"). A deferred role is sealed
+    with NO proxy commitments, so no proxy lease can ever validate for it —
+    its workers stay fail-closed until a future sealing provides compliant
+    proxies. Non-deferred roles keep the exact fail-closed behavior.
+    """
+
+    raw = str(
+        environment.get("GATEWAY_V2_DEFER_WORKER_FLEETS") or ""
+    ).strip().lower()
+    if not raw:
+        return frozenset()
+    if raw in {"all", "1", "true"}:
+        return frozenset({"gateway_autoresearch", "gateway_scoring"})
+    roles = frozenset(
+        item.strip() for item in raw.split(",") if item.strip()
+    )
+    unknown = roles - {"gateway_autoresearch", "gateway_scoring"}
+    if unknown:
+        raise GatewayEnvelopePreparationV2Error(
+            "unknown deferred worker fleet role: %s" % ", ".join(sorted(unknown))
+        )
+    return roles
+
+
 def _validated_worker_proxy_configuration(
     environment: Mapping[str, str],
 ) -> tuple[Any, Dict[str, list[str]]]:
     plan = build_research_lab_worker_autostart_plan(environment)
-    if not plan.hosted.enabled or not plan.scoring.enabled:
+    deferred = _deferred_worker_fleet_roles(environment)
+    if "gateway_autoresearch" not in deferred and not plan.hosted.enabled:
         raise GatewayEnvelopePreparationV2Error(
             "configured hosted and scoring worker fleets are required"
         )
-    if not plan.hosted.proxy_values or not plan.scoring.proxy_values:
+    if "gateway_scoring" not in deferred and not plan.scoring.enabled:
+        raise GatewayEnvelopePreparationV2Error(
+            "configured hosted and scoring worker fleets are required"
+        )
+    if "gateway_autoresearch" not in deferred and not plan.hosted.proxy_values:
+        raise GatewayEnvelopePreparationV2Error(
+            "worker proxy values are required for initial V2 sealing"
+        )
+    if "gateway_scoring" not in deferred and not plan.scoring.proxy_values:
         raise GatewayEnvelopePreparationV2Error(
             "worker proxy values are required for initial V2 sealing"
         )
@@ -307,6 +350,17 @@ def _validated_worker_proxy_configuration(
     commitments: Dict[str, list[str]] = {}
     for role, values in fleets.items():
         commitments[role] = []
+        if role in deferred:
+            # Sealed with zero commitments: every proxy lease for this role
+            # fails validation downstream, so the fleet cannot run until a
+            # future sealing restores compliant proxies. Loud by design.
+            print(
+                "⚠️  %s worker fleet DEFERRED from V2 sealing: no proxy "
+                "commitments sealed; its workers stay fail-closed until a "
+                "compliant sealing (GATEWAY_V2_DEFER_WORKER_FLEETS)" % role,
+                flush=True,
+            )
+            continue
         for index, value in enumerate(values):
             try:
                 _validated_tls_proxy_url(value)

--- a/scripts/worker_proxy_relay/generate_relay.py
+++ b/scripts/worker_proxy_relay/generate_relay.py
@@ -1,0 +1,160 @@
+"""Generate the authenticated TLS:443 relay for worker egress proxies.
+
+The V2 provider transport requires worker egress proxies to be HTTPS on
+port 443 (gateway/tee/provider_broker_v2.py:_validated_tls_proxy_url). The
+configured upstream pool is plaintext HTTP on non-443 ports and the vendor
+offers no TLS listener at all, so the fleet cannot pass sealing directly.
+This generator emits everything needed to put a TLS front door on the
+existing pool without touching provider code:
+
+  * an stunnel configuration: one TLS listener on :443 with one SNI section
+    per upstream — TLS terminates at the relay, then bytes flow unchanged to
+    the upstream HTTP proxy, so the original Proxy-Authorization still
+    authenticates end-to-end but now travels inside TLS on the wire;
+  * the transformed proxy URL list (https://user:pass@proxyNN.<domain>:443)
+    to place in Secrets Manager — each passes _validated_tls_proxy_url;
+  * a systemd unit for the relay.
+
+Inputs are read from a file of upstream proxy URLs (one per line,
+http://user:pass@host:port) that must NEVER be committed; outputs containing
+credentials are written 0600. Operator prerequisites (documented, one-time):
+a wildcard DNS record *.<domain> -> relay host, and a wildcard certificate
+(e.g. certbot DNS-01) at the configured cert/key paths.
+
+Usage:
+  python3 scripts/worker_proxy_relay/generate_relay.py \
+      --upstreams /path/to/upstreams.txt --domain proxy-relay.example.com \
+      --cert /etc/letsencrypt/live/DOMAIN/fullchain.pem \
+      --key /etc/letsencrypt/live/DOMAIN/privkey.pem --out /tmp/relay
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+class RelayGenerationError(ValueError):
+    pass
+
+
+def parse_upstream(line: str) -> dict:
+    """Validate one upstream proxy URL and return its parts."""
+    raw = line.strip()
+    if any(ch in raw for ch in "\x00\r\n\t"):
+        # urlsplit silently strips ASCII control characters; reject them
+        # explicitly so a malformed line cannot normalize into a valid URL.
+        raise RelayGenerationError("upstream URL contains control characters")
+    parsed = urlsplit(raw)
+    if parsed.scheme != "http":
+        raise RelayGenerationError("upstream must be an http:// proxy URL")
+    if not parsed.hostname or not parsed.port:
+        raise RelayGenerationError("upstream must include host and port")
+    if not parsed.username or not parsed.password:
+        raise RelayGenerationError("upstream must include credentials")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise RelayGenerationError("upstream URL must have no path or query")
+    for item in (parsed.username, parsed.password):
+        if any(ch in item for ch in "\x00\r\n@/:"):
+            raise RelayGenerationError("upstream credentials are invalid")
+    return {
+        "host": parsed.hostname,
+        "port": parsed.port,
+        "username": parsed.username,
+        "password": parsed.password,
+    }
+
+
+def relay_hostname(index: int, domain: str) -> str:
+    normalized = str(domain or "").strip(".").lower()
+    if not normalized or any(ch in normalized for ch in " /\\"):
+        raise RelayGenerationError("relay domain is invalid")
+    return "proxy%02d.%s" % (index, normalized)
+
+
+def stunnel_config(upstreams: list, domain: str, cert: str, key: str) -> str:
+    """One :443 TLS listener; SNI routes each hostname to its upstream."""
+    if not upstreams:
+        raise RelayGenerationError("at least one upstream is required")
+    head = [
+        "foreground = no",
+        "pid = /run/stunnel-worker-proxy-relay.pid",
+        "setuid = nobody",
+        "setgid = nobody",
+        "",
+        "[relay]",
+        "accept = 0.0.0.0:443",
+        "cert = %s" % cert,
+        "key = %s" % key,
+        # Default section must go somewhere; route to the first upstream.
+        "connect = %s:%d" % (upstreams[0]["host"], upstreams[0]["port"]),
+    ]
+    sections = []
+    for index, upstream in enumerate(upstreams):
+        name = "sni%02d" % index
+        sections += [
+            "",
+            "[%s]" % name,
+            "sni = relay:%s" % relay_hostname(index, domain),
+            "cert = %s" % cert,
+            "key = %s" % key,
+            "connect = %s:%d" % (upstream["host"], upstream["port"]),
+        ]
+    return "\n".join(head + sections) + "\n"
+
+
+def secrets_proxy_urls(upstreams: list, domain: str) -> list:
+    """The HTTPS:443 URLs that replace the plaintext pool in Secrets Manager."""
+    return [
+        "https://%s:%s@%s:443"
+        % (u["username"], u["password"], relay_hostname(i, domain))
+        for i, u in enumerate(upstreams)
+    ]
+
+
+SYSTEMD_UNIT = """[Unit]
+Description=Worker egress proxy TLS relay (stunnel)
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/stunnel /etc/stunnel/worker-proxy-relay.conf
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--upstreams", required=True)
+    parser.add_argument("--domain", required=True)
+    parser.add_argument("--cert", required=True)
+    parser.add_argument("--key", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+    lines = [
+        line
+        for line in Path(args.upstreams).read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    upstreams = [parse_upstream(line) for line in lines]
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "worker-proxy-relay.conf").write_text(
+        stunnel_config(upstreams, args.domain, args.cert, args.key)
+    )
+    secrets_path = out / "secrets_proxy_urls.txt"
+    secrets_path.write_text("\n".join(secrets_proxy_urls(upstreams, args.domain)) + "\n")
+    os.chmod(secrets_path, 0o600)
+    (out / "worker-proxy-relay.service").write_text(SYSTEMD_UNIT)
+    print(
+        "generated relay for %d upstreams -> %s (secrets file is 0600; do not commit)"
+        % (len(upstreams), out)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deferred_worker_fleet_sealing.py
+++ b/tests/test_deferred_worker_fleet_sealing.py
@@ -1,0 +1,79 @@
+"""Opt-in worker-fleet deferral must unblock sealing without weakening it.
+
+A weight-submission outage was held hostage by the preflight refusing to seal
+when the (already paused) worker fleets' egress proxies could not satisfy the
+V2 HTTPS:443 transport. Deferral seals a role with zero proxy commitments so
+its workers stay fail-closed, while non-deferred roles keep byte-identical
+validation.
+"""
+import types
+
+import pytest
+
+from gateway.tee import prepare_gateway_envelopes_v2 as mod
+
+
+def _plan(hosted_proxies, scoring_proxies):
+    def fleet(values):
+        return types.SimpleNamespace(
+            enabled=True, proxy_values=list(values), worker_count=len(values)
+        )
+    return types.SimpleNamespace(
+        hosted=fleet(hosted_proxies), scoring=fleet(scoring_proxies)
+    )
+
+
+_BAD = ["http://plain-proxy.example:8080"]          # plaintext non-443: invalid
+_GOOD = ["https://user:pw@relay.example:443"]        # compliant
+
+
+@pytest.fixture()
+def _stub_plan(monkeypatch):
+    def install(hosted, scoring):
+        monkeypatch.setattr(
+            mod,
+            "build_research_lab_worker_autostart_plan",
+            lambda _env: _plan(hosted, scoring),
+        )
+    return install
+
+
+def test_default_still_fails_closed_on_plaintext_proxy(_stub_plan):
+    _stub_plan(_BAD, _GOOD)
+    with pytest.raises(mod.GatewayEnvelopePreparationV2Error):
+        mod._validated_worker_proxy_configuration({})
+
+
+def test_defer_all_seals_with_no_commitments(_stub_plan):
+    _stub_plan(_BAD, _BAD)
+    _plan_out, commitments = mod._validated_worker_proxy_configuration(
+        {"GATEWAY_V2_DEFER_WORKER_FLEETS": "all"}
+    )
+    assert commitments == {
+        "gateway_autoresearch": [],
+        "gateway_scoring": [],
+    }
+
+
+def test_defer_one_role_keeps_other_validated(_stub_plan):
+    # Deferring autoresearch must not relax scoring validation.
+    _stub_plan(_BAD, _BAD)
+    with pytest.raises(mod.GatewayEnvelopePreparationV2Error):
+        mod._validated_worker_proxy_configuration(
+            {"GATEWAY_V2_DEFER_WORKER_FLEETS": "gateway_autoresearch"}
+        )
+    # With scoring compliant, the same deferral seals: empty commitments for
+    # the deferred role, real hashes for the validated one.
+    _stub_plan(_BAD, _GOOD)
+    _plan_out, commitments = mod._validated_worker_proxy_configuration(
+        {"GATEWAY_V2_DEFER_WORKER_FLEETS": "gateway_autoresearch"}
+    )
+    assert commitments["gateway_autoresearch"] == []
+    assert len(commitments["gateway_scoring"]) == 1
+
+
+def test_unknown_role_rejected():
+    with pytest.raises(mod.GatewayEnvelopePreparationV2Error):
+        mod._deferred_worker_fleet_roles(
+            {"GATEWAY_V2_DEFER_WORKER_FLEETS": "bogus_role"}
+        )

--- a/tests/test_kms_recipient_v2.py
+++ b/tests/test_kms_recipient_v2.py
@@ -2,6 +2,8 @@ import base64
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+
+from gateway.tee.kms_recipient_v2 import JOB_RECIPIENT_REQUEST_TTL_SECONDS
 from cryptography.hazmat.primitives import hashes, padding as symmetric_padding
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -346,7 +348,7 @@ def test_abandoned_job_recipients_expire_without_evicting_live_requests(monkeypa
         credential_value_hash_expected=credential_value_hash(secret),
         key_ref_hash=sha256_json({"key_ref": "encrypted_ref:live"}),
     )
-    now[0] += 3599.5
+    now[0] += JOB_RECIPIENT_REQUEST_TTL_SECONDS - 0.5
 
     replacement = manager.job_recipient_request(
         job_id="autoresearch-v2:replacement-job",
@@ -384,7 +386,7 @@ def test_expired_job_recipient_is_rejected_before_capacity_sweep(monkeypatch):
         credential_value_hash_expected=credential_value_hash(secret),
         key_ref_hash=sha256_json({"key_ref": "encrypted_ref:expired-direct"}),
     )
-    now[0] += 3600.0
+    now[0] += JOB_RECIPIENT_REQUEST_TTL_SECONDS
 
     with pytest.raises(KMSRecipientV2Error, match="expired"):
         manager.unwrap_job_credential(

--- a/tests/test_worker_proxy_relay_generator.py
+++ b/tests/test_worker_proxy_relay_generator.py
@@ -1,0 +1,48 @@
+"""The relay generator must emit exactly what V2 sealing accepts."""
+import importlib.util
+import pathlib
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "generate_relay",
+    pathlib.Path(__file__).resolve().parents[1]
+    / "scripts" / "worker_proxy_relay" / "generate_relay.py",
+)
+gen = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gen)
+
+from gateway.tee.provider_broker_v2 import _validated_tls_proxy_url
+
+
+def test_generated_urls_pass_the_v2_transport_validator():
+    upstreams = [
+        gen.parse_upstream("http://user%02d:pw%02d@203.0.113.%d:8080" % (i, i, i + 1))
+        for i in range(35)
+    ]
+    urls = gen.secrets_proxy_urls(upstreams, "proxy-relay.example.com")
+    assert len(urls) == 35
+    for url in urls:
+        assert _validated_tls_proxy_url(url) == url  # exact V2 acceptance
+
+
+def test_stunnel_config_routes_every_upstream_by_sni():
+    upstreams = [
+        gen.parse_upstream("http://u:p@203.0.113.%d:1080" % (i + 1)) for i in range(3)
+    ]
+    conf = gen.stunnel_config(upstreams, "r.example.com", "/c.pem", "/k.pem")
+    assert conf.count("accept = 0.0.0.0:443") == 1
+    for i in range(3):
+        assert "sni = relay:proxy%02d.r.example.com" % i in conf
+        assert "connect = 203.0.113.%d:1080" % (i + 1) in conf
+
+
+def test_bad_upstreams_rejected():
+    for bad in (
+        "https://u:p@h:443",        # already TLS: not an upstream
+        "http://h:8080",             # no credentials
+        "http://u:p@h",              # no port
+        "http://u:p\n@h:1",          # control chars
+    ):
+        with pytest.raises(gen.RelayGenerationError):
+            gen.parse_upstream(bad)


### PR DESCRIPTION
## One PR: full recovery + permanent prevention of the weight-set outage

Three layers, each independently verified (32/32 tests locally):

### 1. Root-cause fix — coordinator recipient-pool saturation
`gateway/tee/kms_recipient_v2.py`: the job-recipient pool (2048 slots, 1h TTL, freed only on unwrap/expiry) saturated after ~8h of scoring load; every coordinator RPC was then rejected ("job recipient capacity is full"), taking down scoring AND the weight path together (epochs 24120–24121 missed). TTL 3600s→600s, cap 2048→8192; `scoring_worker.py` backs off 120s on saturation instead of re-hammering the pinned pool and emits a uniquely-tagged CRITICAL (`coordinator_recipient_pool_saturated`) — the earliest pre-miss alarm. Expiry tests now derive timings from the constant.

### 2. Recovery unblocker — sealing with worker fleets explicitly deferred
`gateway/tee/prepare_gateway_envelopes_v2.py`: the restart preflight refused to seal unless both worker fleets had all-valid HTTPS:443 proxies — holding the coordinator (and every weight set) hostage to a dependency of already-paused subsystems. New per-restart opt-in `GATEWAY_V2_DEFER_WORKER_FLEETS="all"` (or per-role): a deferred role seals with ZERO proxy commitments, so no proxy lease can validate and its workers stay fail-closed until a future compliant sealing. Loudly announced; unknown roles rejected; default unchanged fail-closed (existing suite passes untouched).

### 3. Permanent proxy fix — the authenticated TLS:443 relay, generated
`scripts/worker_proxy_relay/generate_relay.py`: emits a complete relay deployment from a never-committed upstream list — stunnel config (single :443 TLS listener, SNI section per upstream, bytes forwarded unchanged so original proxy credentials authenticate end-to-end inside TLS), the transformed `https://user:pass@proxyNN.<domain>:443` Secrets list (0600), and a systemd unit. Tests prove every generated URL passes `_validated_tls_proxy_url` byte-exactly, SNI routing covers every upstream, and malformed lines (incl. control chars urlsplit silently strips) are rejected.

## Rollout
1. Merge; next eligible window: restart with `GATEWAY_V2_DEFER_WORKER_FLEETS=all` + paired validator restart → coordinator returns, weights resume; workers stay paused as today.
2. One-time ops (any time after): wildcard DNS `*.PROXY_RELAY_DOMAIN` → relay host, wildcard cert (certbot DNS-01), run the generator against the existing upstream list, install stunnel + unit, update Secrets from the generated 0600 file.
3. Normal restart without the defer flag → fleets re-enabled over compliant TLS:443.

## Known CI caveat (upstream, not this PR)
`test_committed_validator_protected_workflows_v2` fails on every PR: the committed manifest references baseline commit `d02da348…` which no longer exists on GitHub (422). Needs a manifest re-pin by its owner; all other checks should be green.

Supersedes #53 and #54 (will close both).
