### PR TITLE
Bound the per-job credential pool retention (weight-outage root cause)

### DIFF
--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -3523,6 +3523,21 @@ class ResearchLabGatewayScoringWorker:
                         )
                     )
                     last_error_log = now
+                if "job recipient capacity is full" in str(exc):
+                    # Exact match for the coordinator's per-job credential
+                    # pool saturation (kms_recipient_v2). Retrying at normal
+                    # cadence files a fresh request per pass and keeps the
+                    # pool pinned, starving the weight path that shares the
+                    # coordinator; production hit this at 2026-07-26 03:24
+                    # UTC. Back off long enough for TTL evictions to reclaim
+                    # slots and page via a unique tag.
+                    logger.critical(
+                        "coordinator_job_credential_pool_saturated worker=%s "
+                        "backing_off_seconds=120",
+                        self.worker_ref,
+                    )
+                    await asyncio.sleep(120)
+                    continue
                 await asyncio.sleep(max(self.config.scoring_worker_poll_seconds, error_backoff_seconds))
                 continue
             if outcome.get("processed") or outcome.get("status") != "idle":

--- a/gateway/tee/kms_recipient_v2.py
+++ b/gateway/tee/kms_recipient_v2.py
@@ -42,6 +42,20 @@ MAX_CIPHERTEXT_FOR_RECIPIENT_BYTES = 64 * 1024
 MAX_CREDENTIAL_BYTES = 64 * 1024
 MAX_JOB_RECIPIENT_REQUESTS = 2048
 JOB_RECIPIENT_REQUEST_TTL_SECONDS = 3600.0
+# Dedicated retention for the per-job credential pool ONLY. On 2026-07-26
+# 03:24 UTC production logs show every coordinator credential RPC rejected
+# with "job recipient capacity is full" after ~8h of scoring load: slots are
+# freed only on successful unwrap or TTL expiry, so entries abandoned between
+# claim and unwrap accumulated for a full hour against the shared 2048 cap,
+# and the weight-submission path (which shares the coordinator) went down
+# with scoring. A job credential is unwrapped within one RPC exchange in
+# practice, so a 10-minute TTL bounds abandoned entries tightly, and the
+# larger cap makes saturation require an abandonment storm rather than a
+# slow leak (~80MB worst case, well inside the coordinator's memory). The
+# SOURCE_ADD and OpenRouter ingress pools keep their existing shared limits
+# unchanged.
+MAX_JOB_CREDENTIAL_REQUESTS = 8192
+JOB_CREDENTIAL_REQUEST_TTL_SECONDS = 600.0
 _HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
@@ -497,11 +511,11 @@ class KMSRecipientV2:
                 item_request_id
                 for item_request_id, item in self._job_requests.items()
                 if now - float(item["created_monotonic"])
-                >= JOB_RECIPIENT_REQUEST_TTL_SECONDS
+                >= JOB_CREDENTIAL_REQUEST_TTL_SECONDS
             ]
             for item_request_id in expired:
                 self._job_requests.pop(item_request_id, None)
-            if len(self._job_requests) >= MAX_JOB_RECIPIENT_REQUESTS:
+            if len(self._job_requests) >= MAX_JOB_CREDENTIAL_REQUESTS:
                 raise KMSRecipientV2Error("job recipient capacity is full")
             self._job_requests[request_id] = {
                 "request": dict(request),
@@ -523,7 +537,7 @@ class KMSRecipientV2:
                 raise KMSRecipientV2Error("job recipient request was not found")
             if (
                 time.monotonic() - float(record["created_monotonic"])
-                >= JOB_RECIPIENT_REQUEST_TTL_SECONDS
+                >= JOB_CREDENTIAL_REQUEST_TTL_SECONDS
             ):
                 self._job_requests.pop(normalized_request_id, None)
                 raise KMSRecipientV2Error("job recipient request expired")

--- a/tests/test_kms_recipient_v2.py
+++ b/tests/test_kms_recipient_v2.py
@@ -2,6 +2,8 @@ import base64
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+
+from gateway.tee.kms_recipient_v2 import JOB_CREDENTIAL_REQUEST_TTL_SECONDS
 from cryptography.hazmat.primitives import hashes, padding as symmetric_padding
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -286,7 +288,7 @@ def test_job_kms_recipient_is_single_use_and_binds_job_key_hash():
 
 
 def test_used_job_recipients_do_not_exhaust_capacity(monkeypatch):
-    monkeypatch.setattr("gateway.tee.kms_recipient_v2.MAX_JOB_RECIPIENT_REQUESTS", 2)
+    monkeypatch.setattr("gateway.tee.kms_recipient_v2.MAX_JOB_CREDENTIAL_REQUESTS", 2)
     manager, _, _ = _manager()
     secret = "miner-specific-key"
 
@@ -304,7 +306,7 @@ def test_used_job_recipients_do_not_exhaust_capacity(monkeypatch):
 
 
 def test_unconsumed_job_recipients_still_fail_closed_at_capacity(monkeypatch):
-    monkeypatch.setattr("gateway.tee.kms_recipient_v2.MAX_JOB_RECIPIENT_REQUESTS", 2)
+    monkeypatch.setattr("gateway.tee.kms_recipient_v2.MAX_JOB_CREDENTIAL_REQUESTS", 2)
     manager, _, _ = _manager()
     secret = "miner-specific-key"
 
@@ -325,7 +327,7 @@ def test_unconsumed_job_recipients_still_fail_closed_at_capacity(monkeypatch):
 
 
 def test_abandoned_job_recipients_expire_without_evicting_live_requests(monkeypatch):
-    monkeypatch.setattr("gateway.tee.kms_recipient_v2.MAX_JOB_RECIPIENT_REQUESTS", 2)
+    monkeypatch.setattr("gateway.tee.kms_recipient_v2.MAX_JOB_CREDENTIAL_REQUESTS", 2)
     now = [100.0]
     monkeypatch.setattr(
         "gateway.tee.kms_recipient_v2.time.monotonic",
@@ -346,7 +348,7 @@ def test_abandoned_job_recipients_expire_without_evicting_live_requests(monkeypa
         credential_value_hash_expected=credential_value_hash(secret),
         key_ref_hash=sha256_json({"key_ref": "encrypted_ref:live"}),
     )
-    now[0] += 3599.5
+    now[0] += JOB_CREDENTIAL_REQUEST_TTL_SECONDS - 0.5
 
     replacement = manager.job_recipient_request(
         job_id="autoresearch-v2:replacement-job",
@@ -384,7 +386,7 @@ def test_expired_job_recipient_is_rejected_before_capacity_sweep(monkeypatch):
         credential_value_hash_expected=credential_value_hash(secret),
         key_ref_hash=sha256_json({"key_ref": "encrypted_ref:expired-direct"}),
     )
-    now[0] += 3600.0
+    now[0] += JOB_CREDENTIAL_REQUEST_TTL_SECONDS
 
     with pytest.raises(KMSRecipientV2Error, match="expired"):
         manager.unwrap_job_credential(


### PR DESCRIPTION
## Repush of the salvageable part of PR 55, correcting each review point

**Shared-limit concern → fixed.** The change is now scoped strictly to the per-job credential pool: new constants `MAX_JOB_CREDENTIAL_REQUESTS = 8192` / `JOB_CREDENTIAL_REQUEST_TTL_SECONDS = 600s` used only by the job request/unwrap paths. The SOURCE_ADD and OpenRouter ingress pools keep `MAX_JOB_RECIPIENT_REQUESTS = 2048` byte-identically.

**Overly broad error match → fixed.** The scoring-worker backoff matches the exact per-job pool error string ("job recipient capacity is full", raised only at the job-pool site), not a generic "capacity" substring that would also catch the ingress pools.

**"Not supported by production logs" → evidence attached.** Gateway log (~/gateway/gateway.log, 2026-07-26 03:24:53–03:24:55 UTC) shows the saturation storm across scoring workers, e.g.:
```
RESEARCH LAB SCORING WORKER PASS FAILED
   Worker : research-lab-scorer-7
   Error  : RuntimeError: RPC failed: Enclave error: job recipient capacity is full
```
repeating across workers (scorer-7, scorer-19, …) from 03:24:53 — which is also the exact time of the last successful weight set (epoch 24119) before the 739-block stale. This satisfies the "only after logs establish saturation" bar for the capacity-specific alert, which is included with a unique tag (`coordinator_job_credential_pool_saturated`) and a 120s backoff so a pinned pool is not hammered with a fresh request per pass.

**TTL-relative test** (deemed valid in review) is included; job-pool tests now derive timings and capacity from the new constants.

**Dropped entirely per review:** the worker-deferral (superseded by the complete implementation on main) and the TLS relay (unnecessary now that measured HTTP CONNECT works directly).

Retention issues beyond the job pool ("other retention issues unresolved") are intentionally out of scope here — happy to take those as a follow-up with the same per-pool discipline if wanted.
