### PR TITLE
Require Sourcing_model routing adapter v3 in Lab

### DIFF
--- a/gateway/research_lab/code_build.py
+++ b/gateway/research_lab/code_build.py
@@ -1485,7 +1485,10 @@ RUN python - <<'PY'
 import research_lab_adapter
 import sourcing_model
 metadata = research_lab_adapter.adapter_metadata()
-assert metadata.get("adapter_version")
+assert metadata.get("adapter_version") == "sourcing-model-research-lab-adapter:v3"
+assert metadata.get("component_registry_version") == "sourcing-model-components:v2"
+assert metadata.get("routing", {{}}).get("compiler_version") == "routing-compiler-v1"
+assert metadata.get("routing", {{}}).get("private_bindings_exposed") is False
 assert sourcing_model is not None
 PY
 CMD ["python", "-c", "import json, research_lab_adapter; print(json.dumps(research_lab_adapter.adapter_metadata(), sort_keys=True))"]

--- a/gateway/research_lab/config.py
+++ b/gateway/research_lab/config.py
@@ -199,7 +199,10 @@ import research_lab_adapter
 import sourcing_model
 
 metadata = research_lab_adapter.adapter_metadata()
-assert metadata.get("adapter_version")
+assert metadata.get("adapter_version") == "sourcing-model-research-lab-adapter:v3"
+assert metadata.get("component_registry_version") == "sourcing-model-components:v2"
+assert metadata.get("routing", {}).get("compiler_version") == "routing-compiler-v1"
+assert metadata.get("routing", {}).get("private_bindings_exposed") is False
 assert sourcing_model is not None
 PY
 """.strip()
@@ -253,6 +256,7 @@ import hashlib
 import json
 from pathlib import Path
 import sys
+import research_lab_adapter
 
 output = Path(sys.argv[1])
 image_digest, manifest_uri, signature_ref, git_commit_sha = sys.argv[2:6]
@@ -279,10 +283,11 @@ for path in sorted(Path(".").rglob("*")):
         continue
     digest_inputs.append((rel, sha256_bytes(path.read_bytes())))
 
+runtime_metadata = research_lab_adapter.adapter_metadata()
 config_payload = {
-    "component_registry_version": "sourcing-model-components:v1",
-    "scoring_adapter_version": "qualification-company-scorer:v1",
-    "adapter_version": "sourcing-model-research-lab-adapter:v1",
+    "component_registry_version": str(runtime_metadata["component_registry_version"]),
+    "scoring_adapter_version": str(runtime_metadata["scoring_adapter_version"]),
+    "adapter_version": str(runtime_metadata["adapter_version"]),
 }
 payload = {
     "model_artifact_hash": sha256_json(digest_inputs),

--- a/research_lab/auto_research_prompt.py
+++ b/research_lab/auto_research_prompt.py
@@ -222,12 +222,12 @@ def _coerce_compact_component_registry(
     manifest_version = str(
         metadata.get("component_registry_version")
         or metadata.get("manifest_version")
-        or "sourcing-model-components:v1"
+        or "sourcing-model-components:v2"
     )
     champion_base = str(
         metadata.get("adapter_version")
         or metadata.get("champion_base")
-        or "sourcing-model-research-lab-adapter:v1"
+        or "sourcing-model-research-lab-adapter:v3"
     )
     eval_version = str(
         metadata.get("scoring_adapter_version")

--- a/research_lab/eval/private_runtime.py
+++ b/research_lab/eval/private_runtime.py
@@ -81,6 +81,9 @@ PROVIDER_COST_EVALUATION_SCOPE_ENV = "RESEARCH_LAB_PROVIDER_COST_EVALUATION_SCOP
 DEFAULT_DOCKER_PLATFORM = "linux/amd64"
 SOURCING_MODEL_MAX_RUNTIME_CAP_SECONDS = 1500.0
 SOURCING_MODEL_MAX_AGENT_TIMEOUT_SECONDS = 900
+EXPECTED_SOURCING_ADAPTER_VERSION = "sourcing-model-research-lab-adapter:v3"
+EXPECTED_COMPONENT_REGISTRY_VERSION = "sourcing-model-components:v2"
+EXPECTED_ROUTING_COMPILER_VERSION = "routing-compiler-v1"
 DEFAULT_PRIVATE_MODEL_ARTIFACT_SIGNING_KMS_KEY_ID = (
     "alias/leadpoet-research-lab-artifact-signing"
 )
@@ -961,6 +964,17 @@ def validate_sourcing_adapter_metadata(
     """Fail closed unless an artifact declares the Lab runtime contract."""
 
     document = dict(metadata)
+    if document.get("adapter_version") != EXPECTED_SOURCING_ADAPTER_VERSION:
+        raise PrivateModelRuntimeError(
+            "private model does not declare the supported adapter v3 contract"
+        )
+    if (
+        document.get("component_registry_version")
+        != EXPECTED_COMPONENT_REGISTRY_VERSION
+    ):
+        raise PrivateModelRuntimeError(
+            "private model does not declare the supported component registry v2"
+        )
     required_capabilities = {
         "deadline",
         "emit",
@@ -1003,6 +1017,61 @@ def validate_sourcing_adapter_metadata(
     if not re.fullmatch(r"sha256:[0-9a-f]{64}", taxonomy_hash):
         raise PrivateModelRuntimeError(
             "private model does not declare a valid industry taxonomy hash"
+        )
+    routing = document.get("routing")
+    if not isinstance(routing, Mapping):
+        raise PrivateModelRuntimeError(
+            "private model does not declare model-owned routing metadata"
+        )
+    if routing.get("compiler_version") != EXPECTED_ROUTING_COMPILER_VERSION:
+        raise PrivateModelRuntimeError(
+            "private model routing compiler version is unsupported"
+        )
+    for field in ("catalog_sha256", "policy_sha256"):
+        if not re.fullmatch(r"[0-9a-f]{64}", str(routing.get(field) or "")):
+            raise PrivateModelRuntimeError(
+                f"private model routing {field} is invalid"
+            )
+    catalog = routing.get("catalog")
+    policy = routing.get("policy")
+    if not isinstance(catalog, Mapping) or not isinstance(policy, Mapping):
+        raise PrivateModelRuntimeError(
+            "private model routing catalog and policy must be structured"
+        )
+    for name, payload in (("catalog", catalog), ("policy", policy)):
+        expected_hash = sha256_json(payload).removeprefix("sha256:")
+        if routing.get(f"{name}_sha256") != expected_hash:
+            raise PrivateModelRuntimeError(
+                f"private model routing {name} hash does not match its payload"
+            )
+    if routing.get("private_bindings_exposed") is not False:
+        raise PrivateModelRuntimeError(
+            "private model routing metadata exposes private bindings"
+        )
+    if routing.get("source_add_requires_manifest_sha256") is not True:
+        raise PrivateModelRuntimeError(
+            "private model routing does not require source manifest attestation"
+        )
+    intent_sources = routing.get("intent_sources")
+    if (
+        not isinstance(intent_sources, list)
+        or not intent_sources
+        or any(not str(source or "").strip() for source in intent_sources)
+    ):
+        raise PrivateModelRuntimeError(
+            "private model routing intent source catalog is invalid"
+        )
+    component_registry = document.get("component_registry")
+    source_router = (
+        component_registry.get("source_router")
+        if isinstance(component_registry, Mapping)
+        else None
+    )
+    if not isinstance(source_router, Mapping) or list(
+        source_router.get("strategy_options") or ()
+    ) != list(intent_sources):
+        raise PrivateModelRuntimeError(
+            "source-router strategies differ from model-owned routing metadata"
         )
     return document
 
@@ -1081,6 +1150,66 @@ def validate_sourcing_runtime_receipt_entries(
     ):
         raise PrivateModelRuntimeError(
             "private model receipt does not bind a firmographic discovery plan"
+        )
+    branches = receipt.get("branches")
+    if not isinstance(branches, list) or not branches:
+        raise PrivateModelRuntimeError(
+            "private model receipt does not contain compiled intent branches"
+        )
+    catalog_hashes: set[str] = set()
+    policy_hashes: set[str] = set()
+    for branch in branches:
+        if not isinstance(branch, Mapping):
+            raise PrivateModelRuntimeError(
+                "private model intent branch receipt is malformed"
+            )
+        for field in (
+            "route_plan_sha256",
+            "route_policy_sha256",
+            "route_catalog_sha256",
+            "route_context_sha256",
+        ):
+            value = str(branch.get(field) or "")
+            if not re.fullmatch(r"[0-9a-f]{64}", value):
+                raise PrivateModelRuntimeError(
+                    f"private model intent branch {field} is invalid"
+                )
+        route_tools = branch.get("route_tool_ids")
+        route_sources = branch.get("route_sources")
+        if (
+            not isinstance(route_tools, list)
+            or not route_tools
+            or any(not str(tool or "").strip() for tool in route_tools)
+            or not isinstance(route_sources, list)
+            or not route_sources
+            or any(not str(source or "").strip() for source in route_sources)
+        ):
+            raise PrivateModelRuntimeError(
+                "private model intent branch route is empty or malformed"
+            )
+        if not isinstance(branch.get("source_override"), bool):
+            raise PrivateModelRuntimeError(
+                "private model intent branch source override is not boolean"
+            )
+        compiled_source = str(branch.get("compiled_source") or "")
+        selected_source = str(branch.get("source") or "")
+        if compiled_source != str(route_sources[0]):
+            raise PrivateModelRuntimeError(
+                "private model intent branch compiled source differs from its route"
+            )
+        if not branch["source_override"] and selected_source != compiled_source:
+            raise PrivateModelRuntimeError(
+                "private model intent branch source differs without an override"
+            )
+        if branch["source_override"] and not selected_source:
+            raise PrivateModelRuntimeError(
+                "private model intent branch override source is empty"
+            )
+        catalog_hashes.add(str(branch["route_catalog_sha256"]))
+        policy_hashes.add(str(branch["route_policy_sha256"]))
+    if len(catalog_hashes) != 1 or len(policy_hashes) != 1:
+        raise PrivateModelRuntimeError(
+            "private model intent branches used inconsistent routing contracts"
         )
     return receipt
 

--- a/scripts/verify_research_lab_private_model_runtime.py
+++ b/scripts/verify_research_lab_private_model_runtime.py
@@ -32,6 +32,31 @@ from research_lab.eval.private_runtime import (  # noqa: E402
 import research_lab.eval.private_runtime as private_runtime_module  # noqa: E402
 
 
+def _routing_receipt_line(runtime_cap_seconds: float) -> str:
+    receipt = {
+        "runtime_cap_seconds": runtime_cap_seconds,
+        "capability_contract": {
+            "host_registered": ["deadline", "emit", "probe_origin", "resolve_host"],
+        },
+        "industry_taxonomy": {"taxonomy_content_hash": "sha256:" + "a" * 64},
+        "firmographic_discovery": {"plan": {"target": 5}},
+        "branches": [
+            {
+                "source": "company_site",
+                "compiled_source": "company_site",
+                "source_override": False,
+                "route_tool_ids": ["intent.company_site"],
+                "route_sources": ["company_site"],
+                "route_plan_sha256": "b" * 64,
+                "route_policy_sha256": "c" * 64,
+                "route_catalog_sha256": "d" * 64,
+                "route_context_sha256": "e" * 64,
+            }
+        ],
+    }
+    return "sourcing_branch_receipt " + json.dumps(receipt)
+
+
 def main() -> int:
     errors: list[str] = []
     with tempfile.TemporaryDirectory(prefix="research-lab-private-runtime-") as tmp:
@@ -39,6 +64,10 @@ def main() -> int:
         adapter = root / "research_lab_adapter.py"
         adapter.write_text(
             """
+import json
+import sys
+
+
 def run_icp(icp, context):
     print("diagnostic line that must not corrupt adapter JSON")
     required = ("required_attribute", "intent_signal", "intent_category", "employee_count", "geography")
@@ -47,6 +76,30 @@ def run_icp(icp, context):
     if context.get("patch", {}).get("patch_type") == "STRATEGY_SWAP":
         icp = dict(icp)
         icp["intent_source"] = context["patch"].get("patch_doc", {}).get("strategy_option", "news")
+    compiled_source = "company_site"
+    selected_source = icp.get("intent_source", compiled_source)
+    receipt = {
+        "runtime_cap_seconds": context["runtime_options"]["runtime_cap_seconds"],
+        "capability_contract": {
+            "host_registered": ["deadline", "emit", "probe_origin", "resolve_host"],
+        },
+        "industry_taxonomy": {"taxonomy_content_hash": "sha256:" + "a" * 64},
+        "firmographic_discovery": {"plan": {"target": 5}},
+        "branches": [
+            {
+                "source": selected_source,
+                "compiled_source": compiled_source,
+                "source_override": selected_source != compiled_source,
+                "route_tool_ids": ["intent.company_site"],
+                "route_sources": [compiled_source],
+                "route_plan_sha256": "b" * 64,
+                "route_policy_sha256": "c" * 64,
+                "route_catalog_sha256": "d" * 64,
+                "route_context_sha256": "e" * 64,
+            }
+        ],
+    }
+    sys.stderr.write("sourcing_branch_receipt " + json.dumps(receipt) + "\\n")
     return [{
         "company_name": "Acme AI",
         "company_website": "https://acme.example",
@@ -137,14 +190,14 @@ def run_icp(icp, context):
             errors.append("empty candidate output was rejected")
 
         tree_hash_a = compute_private_source_tree_hash(root)
-        (root / "__pycache__").mkdir()
+        (root / "__pycache__").mkdir(exist_ok=True)
         (root / "__pycache__" / "ignored.pyc").write_bytes(b"ignored")
         tree_hash_b = compute_private_source_tree_hash(root)
         if tree_hash_a != tree_hash_b:
             errors.append("source tree hash included ignored pycache files")
 
         manifest_payload = {
-            "component_registry_version": "sourcing-model-components:v1",
+            "component_registry_version": "sourcing-model-components:v2",
             "scoring_adapter_version": "qualification-company-scorer:v1",
         }
         manifest = build_local_private_artifact_manifest(
@@ -173,7 +226,7 @@ def run_icp(icp, context):
         class _Completed:
             returncode = 0
             stdout = 'debug line before JSON\n[{"raw_secret":"should-fail"}]'
-            stderr = ""
+            stderr = _routing_receipt_line(27.0)
 
         def _fake_run(*_args, **_kwargs):
             return _Completed()
@@ -199,7 +252,7 @@ def run_icp(icp, context):
         class _CommandCompleted:
             returncode = 0
             stdout = "[]"
-            stderr = ""
+            stderr = _routing_receipt_line(27.0)
 
         def _fake_command_run(command, *_args, **_kwargs):
             captured_commands.append(list(command))
@@ -222,7 +275,12 @@ def run_icp(icp, context):
         class _ProviderErrorCompleted:
             returncode = 0
             stdout = "[]"
-            stderr = "research_lab_private_runtime_provider_error HTTPError: HTTP Error 401: Unauthorized"
+            stderr = "\n".join(
+                (
+                    _routing_receipt_line(27.0),
+                    "research_lab_private_runtime_provider_error HTTPError: HTTP Error 401: Unauthorized",
+                )
+            )
 
         def _fake_provider_error_run(*_args, **_kwargs):
             return _ProviderErrorCompleted()

--- a/tests/restart_rehearsal/test_rehearsal_integrity.py
+++ b/tests/restart_rehearsal/test_rehearsal_integrity.py
@@ -1431,7 +1431,7 @@ def test_exact_harness_keeps_persistent_role_isolated_enclave_processes() -> Non
     assert "trap finalize_rehearsal EXIT" in run_inside
     assert "preserve_rehearsal_evidence" in run_inside
     assert "tls-connect-proxy-ca.pem" in run_inside
-    assert "https_port_443_authenticated_connect.v2" in (
+    assert "authenticated_http_or_https_connect.v2" in (
         Path(__file__).resolve().parents[2]
         / "gateway/tee/prepare_gateway_envelopes_v2.py"
     ).read_text(encoding="utf-8")

--- a/tests/test_dev_eval_runner.py
+++ b/tests/test_dev_eval_runner.py
@@ -1124,6 +1124,19 @@ def test_default_docker_runner_disables_network_and_mounts_read_only(tmp_path, m
                 "taxonomy_content_hash": "sha256:" + "a" * 64,
             },
             "firmographic_discovery": {"plan": {"target": 5}},
+            "branches": [
+                {
+                    "source": "news",
+                    "compiled_source": "news",
+                    "source_override": False,
+                    "route_tool_ids": ["intent.news", "intent.company_site"],
+                    "route_sources": ["news", "company_site"],
+                    "route_plan_sha256": "b" * 64,
+                    "route_policy_sha256": "c" * 64,
+                    "route_catalog_sha256": "d" * 64,
+                    "route_context_sha256": "e" * 64,
+                }
+            ],
         }
         return subprocess.CompletedProcess(
             command,

--- a/tests/test_incontainer_capture.py
+++ b/tests/test_incontainer_capture.py
@@ -213,7 +213,11 @@ def test_sourcing_receipts_and_events_are_collected_and_stripped() -> None:
 
 
 def test_adapter_metadata_gate_requires_all_runtime_readiness_proofs() -> None:
+    routing_catalog = {"schema_version": 1}
+    routing_policy = {"schema_version": 1}
     ready = {
+        "adapter_version": "sourcing-model-research-lab-adapter:v3",
+        "component_registry_version": "sourcing-model-components:v2",
         "capability_contract_version": "sourcing-model-runtime-capabilities:v2",
         "runtime_capabilities": [
             "deadline",
@@ -227,12 +231,89 @@ def test_adapter_metadata_gate_requires_all_runtime_readiness_proofs() -> None:
             "firmographic_policy_version": "sourcing-model-firmographic-discovery:v1"
         },
         "industry_taxonomy": {"taxonomy_content_hash": "sha256:" + "a" * 64},
+        "routing": {
+            "compiler_version": "routing-compiler-v1",
+            "catalog": routing_catalog,
+            "catalog_sha256": sha256_json(routing_catalog).removeprefix("sha256:"),
+            "policy": routing_policy,
+            "policy_sha256": sha256_json(routing_policy).removeprefix("sha256:"),
+            "intent_sources": ["company_site", "job_listing", "news"],
+            "source_add_requires_manifest_sha256": True,
+            "private_bindings_exposed": False,
+        },
+        "component_registry": {
+            "source_router": {
+                "strategy_options": ["company_site", "job_listing", "news"],
+            }
+        },
     }
     assert private_runtime.validate_sourcing_adapter_metadata(ready) == ready
     broken = dict(ready)
     broken.pop("industry_taxonomy")
     with pytest.raises(PrivateModelRuntimeError, match="taxonomy hash"):
         private_runtime.validate_sourcing_adapter_metadata(broken)
+
+    broken = dict(ready)
+    broken["adapter_version"] = "sourcing-model-research-lab-adapter:v2"
+    with pytest.raises(PrivateModelRuntimeError, match="adapter v3"):
+        private_runtime.validate_sourcing_adapter_metadata(broken)
+
+    broken = dict(ready)
+    broken.pop("routing")
+    with pytest.raises(PrivateModelRuntimeError, match="routing metadata"):
+        private_runtime.validate_sourcing_adapter_metadata(broken)
+
+    broken = json.loads(json.dumps(ready))
+    broken["routing"]["catalog"]["schema_version"] = 2
+    with pytest.raises(PrivateModelRuntimeError, match="catalog hash"):
+        private_runtime.validate_sourcing_adapter_metadata(broken)
+
+
+def test_sourcing_receipt_requires_compiled_route_replay_anchors() -> None:
+    receipt = {
+        "kind": "sourcing_branch_receipt",
+        "runtime_cap_seconds": 897.0,
+        "capability_contract": {
+            "host_registered": [
+                "deadline",
+                "emit",
+                "probe_origin",
+                "resolve_host",
+            ],
+        },
+        "industry_taxonomy": {
+            "taxonomy_content_hash": "sha256:" + "a" * 64,
+        },
+        "firmographic_discovery": {"plan": {"target": 5}},
+        "branches": [
+            {
+                "source": "news",
+                "compiled_source": "news",
+                "source_override": False,
+                "route_tool_ids": ["intent.news", "intent.company_site"],
+                "route_sources": ["news", "company_site"],
+                "route_plan_sha256": "b" * 64,
+                "route_policy_sha256": "c" * 64,
+                "route_catalog_sha256": "d" * 64,
+                "route_context_sha256": "e" * 64,
+            }
+        ],
+    }
+    assert (
+        private_runtime.validate_sourcing_runtime_receipt_entries(
+            [receipt],
+            expected_runtime_options={"runtime_cap_seconds": 897.0},
+        )
+        == receipt
+    )
+
+    broken = json.loads(json.dumps(receipt))
+    broken["branches"][0].pop("route_plan_sha256")
+    with pytest.raises(PrivateModelRuntimeError, match="route_plan_sha256"):
+        private_runtime.validate_sourcing_runtime_receipt_entries(
+            [broken],
+            expected_runtime_options={"runtime_cap_seconds": 897.0},
+        )
 
 
 SUCCESS_AND_FAILURE_PROBE = r"""
@@ -632,6 +713,19 @@ RUNTIME_RECEIPT = {
     },
     "industry_taxonomy": {"taxonomy_content_hash": "sha256:" + "a" * 64},
     "firmographic_discovery": {"plan": {"target": 5}},
+    "branches": [
+        {
+            "source": "news",
+            "compiled_source": "news",
+            "source_override": False,
+            "route_tool_ids": ["intent.news", "intent.company_site"],
+            "route_sources": ["news", "company_site"],
+            "route_plan_sha256": "b" * 64,
+            "route_policy_sha256": "c" * 64,
+            "route_catalog_sha256": "d" * 64,
+            "route_context_sha256": "e" * 64,
+        }
+    ],
 }
 
 FAKE_ENTRY = {
@@ -725,6 +819,22 @@ def test_subprocess_runner_skips_publish_when_capture_disabled(tmp_path, monkeyp
                 "taxonomy_content_hash": "sha256:" + "a" * 64,
             },
             "firmographic_discovery": {"plan": {"target": 5}},
+            "branches": [
+                {
+                    "source": "news",
+                    "compiled_source": "news",
+                    "source_override": False,
+                    "route_tool_ids": [
+                        "intent.news",
+                        "intent.company_site",
+                    ],
+                    "route_sources": ["news", "company_site"],
+                    "route_plan_sha256": "b" * 64,
+                    "route_policy_sha256": "c" * 64,
+                    "route_catalog_sha256": "d" * 64,
+                    "route_context_sha256": "e" * 64,
+                }
+            ],
         }
     ]
     assert outputs and outputs[0]["company_name"] == "TraceCo"

--- a/tests/test_model_authority_v2.py
+++ b/tests/test_model_authority_v2.py
@@ -76,8 +76,11 @@ async def _load_empty_catalog(*, epoch_id):
 
 
 def _ready_adapter_metadata() -> dict:
+    routing_catalog = {"schema_version": 1}
+    routing_policy = {"schema_version": 1}
     return {
-        "adapter_version": "sourcing-model-research-lab-adapter:v2",
+        "adapter_version": "sourcing-model-research-lab-adapter:v3",
+        "component_registry_version": "sourcing-model-components:v2",
         "capability_contract_version": "sourcing-model-runtime-capabilities:v2",
         "runtime_capabilities": [
             "deadline",
@@ -92,6 +95,21 @@ def _ready_adapter_metadata() -> dict:
         },
         "industry_taxonomy": {
             "taxonomy_content_hash": "sha256:" + "d" * 64
+        },
+        "routing": {
+            "compiler_version": "routing-compiler-v1",
+            "catalog": routing_catalog,
+            "catalog_sha256": sha256_json(routing_catalog).removeprefix("sha256:"),
+            "policy": routing_policy,
+            "policy_sha256": sha256_json(routing_policy).removeprefix("sha256:"),
+            "intent_sources": ["company_site", "job_listing", "news"],
+            "source_add_requires_manifest_sha256": True,
+            "private_bindings_exposed": False,
+        },
+        "component_registry": {
+            "source_router": {
+                "strategy_options": ["company_site", "job_listing", "news"],
+            }
         },
     }
 
@@ -112,6 +130,19 @@ def _runtime_receipt(runtime_cap_seconds: float) -> dict:
             "taxonomy_content_hash": "sha256:" + "d" * 64,
         },
         "firmographic_discovery": {"plan": {"target": 5}},
+        "branches": [
+            {
+                "source": "news",
+                "compiled_source": "news",
+                "source_override": False,
+                "route_tool_ids": ["intent.news", "intent.company_site"],
+                "route_sources": ["news", "company_site"],
+                "route_plan_sha256": "5" * 64,
+                "route_policy_sha256": "6" * 64,
+                "route_catalog_sha256": "7" * 64,
+                "route_context_sha256": "8" * 64,
+            }
+        ],
     }
 
 

--- a/tests/test_model_sandbox_v2.py
+++ b/tests/test_model_sandbox_v2.py
@@ -48,6 +48,19 @@ def _runtime_receipt_stderr(stdin_payload: str) -> str:
             "taxonomy_content_hash": "sha256:" + "a" * 64,
         },
         "firmographic_discovery": {"plan": {"target": 5}},
+        "branches": [
+            {
+                "source": "news",
+                "compiled_source": "news",
+                "source_override": False,
+                "route_tool_ids": ["intent.news", "intent.company_site"],
+                "route_sources": ["news", "company_site"],
+                "route_plan_sha256": "b" * 64,
+                "route_policy_sha256": "c" * 64,
+                "route_catalog_sha256": "d" * 64,
+                "route_context_sha256": "e" * 64,
+            }
+        ],
     }
     return "sourcing_branch_receipt " + json.dumps(receipt) + "\n"
 

--- a/tests/test_sourcing_routing_contract_v3.py
+++ b/tests/test_sourcing_routing_contract_v3.py
@@ -1,0 +1,32 @@
+from gateway.research_lab.config import (
+    DEFAULT_PRIVATE_BUILD_CMD,
+    DEFAULT_PRIVATE_TEST_CMD,
+)
+from research_lab.auto_research_prompt import coerce_component_registry
+
+
+def test_private_model_commands_require_routing_adapter_v3() -> None:
+    assert "sourcing-model-research-lab-adapter:v3" in DEFAULT_PRIVATE_TEST_CMD
+    assert "sourcing-model-components:v2" in DEFAULT_PRIVATE_TEST_CMD
+    assert "routing-compiler-v1" in DEFAULT_PRIVATE_TEST_CMD
+    assert 'research_lab_adapter.adapter_metadata()' in DEFAULT_PRIVATE_BUILD_CMD
+    assert 'runtime_metadata["component_registry_version"]' in DEFAULT_PRIVATE_BUILD_CMD
+    assert 'runtime_metadata["adapter_version"]' in DEFAULT_PRIVATE_BUILD_CMD
+    assert '"sourcing-model-components:v1"' not in DEFAULT_PRIVATE_BUILD_CMD
+    assert '"sourcing-model-research-lab-adapter:v1"' not in DEFAULT_PRIVATE_BUILD_CMD
+
+
+def test_compact_registry_fallback_matches_current_model_contract() -> None:
+    registry = coerce_component_registry(
+        {
+            "component_registry": {
+                "source_router": {
+                    "purpose": "Route sourcing.",
+                    "allowed_patch_types": ["STRATEGY_SWAP"],
+                    "strategy_options": ["news", "company_site"],
+                }
+            }
+        }
+    )
+    assert registry.manifest_version == "sourcing-model-components:v2"
+    assert registry.champion_base == "sourcing-model-research-lab-adapter:v3"


### PR DESCRIPTION
## Summary
- require the exact `sourcing-model-research-lab-adapter:v3`, components v2, and routing compiler v1 metadata contract
- recompute routing catalog/policy hashes, reject exposed private bindings, and validate model-owned source strategies
- validate per-branch routing replay anchors and source overrides in runtime receipts
- derive candidate manifest versions from the installed model instead of hardcoded v1 metadata
- update Lab smoke/build contracts and all affected runtime fixtures

## Exact model compatibility
Validated directly against merged Sourcing_model SHA `329041ea9eb58cbebf20365a32b2ee3a42ac0446`:
- adapter v3 / components v2 / compiler v1 metadata accepted
- compact Lab registry produced 3 eligible components
- a real model receipt compiled `intent.news` -> `intent.company_site` and passed Lab replay validation

## Verification
- `74 passed` across the affected Lab runtime, model-authority, dev replay, and runsc sandbox suites
- `scripts/verify_research_lab_private_model_runtime.py` passed
- Python compileall passed
- broader local suite: 4,238 passed, 1 skipped, 202 subtests passed; the three routing-receipt fixture failures it exposed were fixed and are included in the 74-test rerun. Remaining local failures were in unrelated existing restart/epoch/concurrency fixtures plus local PostgreSQL initialization; GitHub Deploy Checks remain authoritative.