### PR TITLE
Make the PCR0 allowlist refresh single-flight with failure backoff

### DIFF
--- a/gateway/utils/tee_kms_provision_v2.py
+++ b/gateway/utils/tee_kms_provision_v2.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import argparse
+import logging
 import base64
 import hashlib
 import json
@@ -23,6 +24,8 @@ from gateway.tee.kms_recipient_v2 import (
 )
 from gateway.utils.tee_client import coordinator_tee_client
 from leadpoet_canonical.attested_v2 import canonical_json, sha256_bytes, sha256_json
+
+logger = logging.getLogger(__name__)
 
 
 PROVIDER_ENVELOPE_SCHEMA_VERSION = "leadpoet.provider_credential_envelope.v2"
@@ -390,10 +393,22 @@ async def provision_job_provider_envelope_v2(
     except BaseException:
         # A recipient contains no plaintext, but it occupies bounded enclave
         # state until unwrap. Always discard it when KMS, validation, RPC, or
-        # cancellation aborts the handshake.
-        await asyncio.shield(
-            client.v2_release_job_credentials(normalized["job_id"])
-        )
+        # cancellation aborts the handshake. The release itself must never
+        # mask the original failure: when the coordinator is unreachable, the
+        # release RPC fails for the same reason the handshake did, and
+        # surfacing that secondary error instead of the root cause hid the
+        # real diagnosis (matching the guarded release in execute_scoring_v2).
+        try:
+            await asyncio.shield(
+                client.v2_release_job_credentials(normalized["job_id"])
+            )
+        except BaseException as release_error:
+            logger.warning(
+                "job_credential_release_after_failure_failed job_id=%s "
+                "error=%s",
+                normalized["job_id"],
+                str(release_error)[:200],
+            )
         raise
 
 

--- a/leadpoet_canonical/nitro.py
+++ b/leadpoet_canonical/nitro.py
@@ -210,26 +210,37 @@ def _refresh_pcr0_cache_if_needed() -> None:
         # Check if cache is still valid
         if current_time - _pcr0_cache["last_fetch"] < PCR0_CACHE_TTL_SECONDS:
             return  # Cache is still valid
-        
-        try:
-            # Fetch new allowlist
-            allowlist = _fetch_pcr0_allowlist_from_github()
-            
-            _pcr0_cache["gateway_pcr0"] = allowlist["gateway_pcr0"]
-            _pcr0_cache["validator_pcr0"] = allowlist["validator_pcr0"]
-            _pcr0_cache["last_fetch"] = current_time
-            _pcr0_cache["fetch_error"] = None
-            
-        except Exception as e:
-            logger.warning(f"[PCR0] Failed to refresh allowlist from GitHub: {e}")
+        # Reserve the refresh window BEFORE fetching. The fetch used to run
+        # while holding this lock and, on failure with a non-empty cache,
+        # last_fetch was never advanced — so with GitHub slow or down every
+        # PCR0 verification re-attempted the fetch and serialized behind a
+        # 10-second urlopen. Reserving first makes the refresh single-flight
+        # (concurrent verifiers keep using the previous allowlist instead of
+        # stalling) and turns a failed fetch into a TTL-length backoff. The
+        # allowlist values themselves only ever change under the lock, and a
+        # PCR0 mismatch still fails closed downstream exactly as before.
+        _pcr0_cache["last_fetch"] = current_time
+
+    try:
+        # Fetch new allowlist (network I/O outside the lock)
+        allowlist = _fetch_pcr0_allowlist_from_github()
+    except Exception as e:
+        logger.warning(f"[PCR0] Failed to refresh allowlist from GitHub: {e}")
+        with _pcr0_cache_lock:
             _pcr0_cache["fetch_error"] = str(e)
-            
+
             # If this is the first fetch (cache is empty), use fallback values
             if not _pcr0_cache["gateway_pcr0"] and not _pcr0_cache["validator_pcr0"]:
                 logger.warning("[PCR0] Using fallback PCR0 values")
                 _pcr0_cache["gateway_pcr0"] = FALLBACK_GATEWAY_PCR0_VALUES.copy()
                 _pcr0_cache["validator_pcr0"] = FALLBACK_VALIDATOR_PCR0_VALUES.copy()
-                _pcr0_cache["last_fetch"] = current_time  # Prevent immediate retry
+        return
+
+    with _pcr0_cache_lock:
+        _pcr0_cache["gateway_pcr0"] = allowlist["gateway_pcr0"]
+        _pcr0_cache["validator_pcr0"] = allowlist["validator_pcr0"]
+        _pcr0_cache["last_fetch"] = time.time()
+        _pcr0_cache["fetch_error"] = None
 
 
 def get_allowed_gateway_pcr0() -> List[str]:

--- a/tests/test_pcr0_allowlist_refresh.py
+++ b/tests/test_pcr0_allowlist_refresh.py
@@ -1,0 +1,82 @@
+"""The PCR0 allowlist refresh must be single-flight with failure backoff.
+
+The fetch used to run while holding the cache lock and, on failure with a
+non-empty cache, never advanced last_fetch — so with GitHub slow or down
+every PCR0 verification re-attempted the fetch, serialized behind a
+10-second urlopen. These tests pin the fixed semantics: a failed refresh
+backs off for a full TTL, concurrent callers keep the previous allowlist,
+and a successful refresh installs the new values.
+"""
+import threading
+import time
+
+import pytest
+
+from leadpoet_canonical import nitro
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache(monkeypatch):
+    monkeypatch.setattr(
+        nitro,
+        "_pcr0_cache",
+        {
+            "gateway_pcr0": ["aa" * 48],
+            "validator_pcr0": ["bb" * 48],
+            "last_fetch": 0,
+            "fetch_error": None,
+        },
+    )
+
+
+def test_failed_refresh_backs_off_and_keeps_previous_allowlist(monkeypatch):
+    calls = []
+
+    def failing_fetch():
+        calls.append(1)
+        raise RuntimeError("github down")
+
+    monkeypatch.setattr(nitro, "_fetch_pcr0_allowlist_from_github", failing_fetch)
+    nitro._refresh_pcr0_cache_if_needed()
+    nitro._refresh_pcr0_cache_if_needed()
+    nitro._refresh_pcr0_cache_if_needed()
+    # One fetch attempt only: the failure reserved the TTL window (backoff),
+    # and the previous allowlist survives for verification.
+    assert len(calls) == 1
+    assert nitro._pcr0_cache["gateway_pcr0"] == ["aa" * 48]
+    assert nitro._pcr0_cache["fetch_error"] == "github down"
+
+
+def test_successful_refresh_installs_new_values(monkeypatch):
+    monkeypatch.setattr(
+        nitro,
+        "_fetch_pcr0_allowlist_from_github",
+        lambda: {"gateway_pcr0": ["cc" * 48], "validator_pcr0": ["dd" * 48]},
+    )
+    nitro._refresh_pcr0_cache_if_needed()
+    assert nitro._pcr0_cache["gateway_pcr0"] == ["cc" * 48]
+    assert nitro._pcr0_cache["fetch_error"] is None
+    assert nitro._pcr0_cache["last_fetch"] > 0
+
+
+def test_slow_fetch_does_not_block_concurrent_readers(monkeypatch):
+    release = threading.Event()
+
+    def slow_fetch():
+        release.wait(5)
+        return {"gateway_pcr0": ["ee" * 48], "validator_pcr0": ["ff" * 48]}
+
+    monkeypatch.setattr(nitro, "_fetch_pcr0_allowlist_from_github", slow_fetch)
+    worker = threading.Thread(target=nitro._refresh_pcr0_cache_if_needed)
+    worker.start()
+    time.sleep(0.1)
+    # While the fetch is in flight, a reader must get the previous allowlist
+    # immediately instead of serializing behind the network call.
+    start = time.monotonic()
+    values = nitro.get_allowed_gateway_pcr0()
+    elapsed = time.monotonic() - start
+    assert values == ["aa" * 48]
+    assert elapsed < 1.0
+    release.set()
+    worker.join(10)
+    assert nitro._pcr0_cache["gateway_pcr0"] == ["ee" * 48]


### PR DESCRIPTION
The allowlist refresh held the cache lock across the GitHub fetch, and a failed fetch never advanced last_fetch on a non-empty cache — so with GitHub slow/down, every PCR0 verification re-attempted the fetch serialized behind a 10s urlopen, turning a GitHub blip into attestation stalls exactly when verifications cluster (restarts, weight submission). The refresh now reserves the TTL window before fetching: single-flight (concurrent verifiers use the previous allowlist immediately), and a failed fetch backs off for a full TTL. Allowlist values still change only under the lock; first-fetch fallback preserved; PCR0 mismatches fail closed downstream unchanged. nitro.py is in no protected-workflow manifest. Tests pin the backoff, the non-blocking concurrent read (live-thread test), and the successful install.

## Follow-up: deep audit of the incident-recovery commits (rolling updates per review agreement)

**Fixed in this PR (commit 2):** post-failure job-credential release could mask the original error — when the coordinator socket died, the release RPC failed for the same reason and its exception replaced the root cause. Release is now guarded + logged (`job_credential_release_after_failure_failed`), matching the guarded pattern in `execute_scoring_v2`. Cleanup semantics unchanged.

**Flagged for owner decision (not patched here):**
1. MED — `tee_egress_forwarder.py:226-242` (999e83b6/7a05c779): the parent forwarder now grants any-port/any-global-IP tunnels to any vsock peer presenting `purpose=upstream_proxy` + the (publicly computable) policy_hash, where it previously enforced hostname-only:443. If in-enclave candidate containers can open vsock sockets, this is an egress-policy bypass (raw TCP from the gateway IP). Needs confirmation of vsock isolation; any change alters `destination_policy_hash` → paired enclave deploy.
2. MED — every restart (including byte-identical reuse) now runs the live proxy CONNECT probe before the reuse check (`prepare_gateway_envelopes_v2.py:805-818` vs :870), and deferral does not bypass it: a vendor or probe-destination outage blocks all restarts (fails pre-shutdown, so the running gateway survives — but no restart until a proxy passes all four probe hosts). Deliberate fail-closed with a sharp operational edge; suggest probe-after-reuse-check or an explicit operator override.
3. MED-LOW — proxy quarantine filters the sealed enclave profiles but not the host-side worker proxy env (`worker_autostart.py:426-438` assigns from the unfiltered plan): in multi-proxy fleets a quarantined proxy is still handed to its worker for non-enclave calls. Inert today (one proxy per role) but the feature is half-plumbed.
4. LOW — reuse comparison includes live-probe-derived profile counts, so a transient single-destination blip silently forces a full KMS re-seal instead of reuse (slow restart, correctness intact).
5. LOW — `gateway/tee/protected_workflows.py:380` uses `ast.Str` (removed in py3.12): latent break for any future Python bump; not touched here because the module computes manifest hashes.

**Verified correct by the audit (survived refutation):** the PCR0 warmer correction (deployed SHA cannot be evicted; aliases bind only to self-reproduced builds; fail-closed intact), the job-recipient pool fix (lock scope, TTL ordering, release idempotency), the complete worker-deferral (no crash loops, restart-only env), the CONNECT proxy URL validation (no gap found; credentials absent from all log/error/receipt paths), and both protected-workflow manifests match source under py3.11.
