### PR TITLE
Keep the validator chain relay serving after a transient accept() error

### DIFF
--- a/tests/test_chain_relay_accept_supervision.py
+++ b/tests/test_chain_relay_accept_supervision.py
@@ -222,3 +222,36 @@ def test_supervisor_restarts_dead_relay_but_respects_stop(monkeypatch):
     relay.stop()
     relay._thread = None
     assert supervise_once() is False
+
+
+def test_control_handshake_has_a_timeout_and_cleans_up_on_stall():
+    # A client that connects and stalls during the control handshake must not
+    # pin the handler thread/fd: the accepted connection gets a timeout, and a
+    # timeout during the read is cleaned up by the finally (both sockets closed).
+    import socket as _socket
+
+    events = {"settimeouts": [], "closed": False}
+
+    class _StalledConn:
+        def settimeout(self, v):
+            events["settimeouts"].append(v)
+
+        def recv(self, _n):
+            # Simulate the socket timeout firing during the handshake read.
+            raise _socket.timeout("timed out")
+
+        def sendall(self, _b):
+            raise AssertionError("must not reach send on a stalled handshake")
+
+        def close(self):
+            events["closed"] = True
+
+    # Should not hang, should not raise out (finally swallows via close), and
+    # must have armed the handshake timeout before reading.
+    try:
+        relay_mod.handle_chain_relay_connection(_StalledConn(), connector=lambda h: None)
+    except _socket.timeout:
+        pass  # acceptable: propagated after cleanup
+    assert events["settimeouts"], "handshake timeout was never armed"
+    assert events["settimeouts"][0] == relay_mod.CONTROL_HANDSHAKE_TIMEOUT_SECONDS
+    assert events["closed"] is True

--- a/tests/test_chain_relay_accept_supervision.py
+++ b/tests/test_chain_relay_accept_supervision.py
@@ -149,3 +149,76 @@ def test_handler_spawn_failure_does_not_kill_the_loop(monkeypatch):
     t.join(2)
     assert alive              # spawn failure did not kill the loop
     assert closed == [True]   # the orphaned connection was closed
+
+
+class _FakeSock:
+    """Minimal listener stand-in for start()/re-entrancy tests (no real vsock)."""
+    open_count = 0
+    close_count = 0
+
+    def __init__(self, *_a, **_k):
+        type(self).open_count += 1
+        self.closed = False
+
+    def bind(self, _addr):
+        pass
+
+    def listen(self, _backlog):
+        pass
+
+    def accept(self):
+        # Block until closed so the loop thread stays alive but idle.
+        while not self.closed:
+            time.sleep(0.02)
+        raise OSError("listener closed")
+
+    def close(self):
+        if not self.closed:
+            self.closed = True
+            type(self).close_count += 1
+
+
+def test_start_is_reentrant_and_closes_stale_listener_on_restart(monkeypatch):
+    _FakeSock.open_count = 0
+    _FakeSock.close_count = 0
+    relay = ValidatorChainRelayV2(socket_factory=lambda *a, **k: _FakeSock())
+    relay.start()
+    first_listener = relay._listener
+    assert relay.status()["status"] == "running"
+
+    # Simulate an unexpected loop-thread death WITHOUT a stop() (the case
+    # main()'s supervisor must recover). The stale listener is still open.
+    relay._thread = None
+    assert not relay._stop.is_set()
+
+    relay.start()  # recovery restart
+    assert relay.status()["status"] == "running"
+    assert relay._listener is not first_listener          # rebound fresh
+    assert first_listener.closed                           # stale one closed
+    assert _FakeSock.open_count == 2 and _FakeSock.close_count >= 1
+    relay.stop()
+
+
+def test_supervisor_restarts_dead_relay_but_respects_stop(monkeypatch):
+    # Exercise the exact decision main()'s loop makes, without its infinite loop.
+    relay = ValidatorChainRelayV2(socket_factory=lambda *a, **k: _FakeSock())
+    relay.start()
+
+    def supervise_once():
+        if relay._stop.is_set():
+            return False
+        if relay.status().get("status") != "running":
+            relay.start()
+            return True
+        return False
+
+    # Healthy -> no restart.
+    assert supervise_once() is False
+    # Dead (no stop) -> restart.
+    relay._thread = None
+    assert supervise_once() is True
+    assert relay.status()["status"] == "running"
+    # Intentional stop -> supervisor must NOT resurrect it.
+    relay.stop()
+    relay._thread = None
+    assert supervise_once() is False

--- a/tests/test_chain_relay_accept_supervision.py
+++ b/tests/test_chain_relay_accept_supervision.py
@@ -94,3 +94,58 @@ def test_stop_exits_cleanly_even_mid_error(monkeypatch):
     relay.stop()
     t.join(2)
     assert not t.is_alive()          # stop() cleanly ended it
+
+
+def test_handler_spawn_failure_does_not_kill_the_loop(monkeypatch):
+    # If starting the per-connection handler thread raises (thread exhaustion),
+    # the loop must close the connection and keep accepting, not die. Fail the
+    # spawn ONLY for the handler target so the test's own loop thread is real.
+    closed = []
+
+    class _Conn:
+        def close(self):
+            closed.append(True)
+
+    real_thread = relay_mod.threading.Thread
+
+    class _SelectiveThread:
+        def __init__(self, *a, target=None, **k):
+            self._is_handler = target is relay_mod.handle_chain_relay_connection
+            self._real = None if self._is_handler else real_thread(*a, target=target, **k)
+
+        def start(self):
+            if self._is_handler:
+                raise RuntimeError("can't start thread")
+            self._real.start()
+
+        def join(self, *a):
+            return self._real.join(*a) if self._real else None
+
+        def is_alive(self):
+            return bool(self._real and self._real.is_alive())
+
+    monkeypatch.setattr(relay_mod.threading, "Thread", _SelectiveThread)
+    relay = ValidatorChainRelayV2()
+
+    calls = {"n": 0}
+
+    class _OneConnThenBlock:
+        def accept(self):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return (_Conn(), ("cid", 0))
+            time.sleep(0.05)
+            raise BlockingIOError("idle")
+
+        def close(self):
+            pass
+
+    relay._listener = _OneConnThenBlock()
+    t = real_thread(target=relay._accept_loop, daemon=True)
+    t.start()
+    time.sleep(0.3)
+    alive = t.is_alive()
+    relay.stop()
+    t.join(2)
+    assert alive              # spawn failure did not kill the loop
+    assert closed == [True]   # the orphaned connection was closed

--- a/tests/test_chain_relay_accept_supervision.py
+++ b/tests/test_chain_relay_accept_supervision.py
@@ -1,0 +1,96 @@
+"""The chain relay's accept loop must survive transient accept() errors.
+
+The relay is the enclave's only chain-RPC path (every weight-extrinsic
+signature routes through it). Before this fix, one transient accept() error
+returned from the loop and main() never relaunched it — signing died
+silently every epoch until a manual restart. These tests pin: a transient
+error keeps the loop serving, a genuine connection is still handled after
+one, and stop() still exits cleanly.
+"""
+import importlib.util
+import pathlib
+import socket
+import threading
+import time
+
+_spec = importlib.util.spec_from_file_location(
+    "chain_relay_v2",
+    pathlib.Path(__file__).resolve().parents[1]
+    / "validator_tee" / "host" / "chain_relay_v2.py",
+)
+relay_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(relay_mod)
+ValidatorChainRelayV2 = relay_mod.ValidatorChainRelayV2
+
+
+class _FakeListener:
+    def __init__(self, script):
+        # script: list of ("raise", exc) or ("conn",) or ("block",)
+        self._script = list(script)
+        self._i = 0
+        self.accept_calls = 0
+
+    def accept(self):
+        self.accept_calls += 1
+        if self._i >= len(self._script):
+            # Nothing left: block briefly so the loop doesn't busy-spin the test.
+            time.sleep(0.05)
+            raise BlockingIOError("no more")
+        step = self._script[self._i]
+        self._i += 1
+        if step[0] == "raise":
+            raise step[1]
+        return (object(), ("cid", 0))
+
+    def close(self):
+        pass
+
+
+def _run_loop(relay, listener, stop_after=1.0):
+    relay._listener = listener
+    t = threading.Thread(target=relay._accept_loop, daemon=True)
+    t.start()
+    time.sleep(stop_after)
+    relay.stop()
+    t.join(2)
+    return t
+
+
+def test_transient_accept_error_does_not_kill_the_loop(monkeypatch):
+    handled = []
+    monkeypatch.setattr(
+        relay_mod, "handle_chain_relay_connection",
+        lambda conn, connector=None: handled.append(conn),
+    )
+    relay = ValidatorChainRelayV2()
+    # One transient error, THEN a real connection: the old code would have
+    # returned on the error and never reached the connection.
+    listener = _FakeListener([("raise", OSError("EMFILE")), ("conn",)])
+    t = _run_loop(relay, listener)
+    assert not t.is_alive()          # exited only because stop() was called
+    assert len(handled) == 1         # served the connection after the error
+    assert listener.accept_calls >= 2  # kept accepting past the transient error
+
+
+def test_stop_exits_cleanly_even_mid_error(monkeypatch):
+    monkeypatch.setattr(
+        relay_mod, "handle_chain_relay_connection",
+        lambda conn, connector=None: None,
+    )
+    relay = ValidatorChainRelayV2()
+    # Listener that always raises: without stop() the loop keeps serving;
+    # stop() must break it out.
+    class _AlwaysRaise:
+        def accept(self):
+            time.sleep(0.02)
+            raise OSError("ECONNABORTED")
+        def close(self):
+            pass
+    relay._listener = _AlwaysRaise()
+    t = threading.Thread(target=relay._accept_loop, daemon=True)
+    t.start()
+    time.sleep(0.2)
+    assert t.is_alive()              # survived repeated transient errors
+    relay.stop()
+    t.join(2)
+    assert not t.is_alive()          # stop() cleanly ended it

--- a/validator_tee/host/chain_relay_v2.py
+++ b/validator_tee/host/chain_relay_v2.py
@@ -29,6 +29,7 @@ VMADDR_CID_ANY = 0xFFFFFFFF
 logger = logging.getLogger(__name__)
 
 CHAIN_RELAY_VSOCK_PORT = 5002
+CHAIN_RELAY_SUPERVISION_INTERVAL_SECONDS = 15
 MAX_CONTROL_BYTES = 16 * 1024
 MAX_BYTES_PER_DIRECTION = 32 * 1024 * 1024
 RELAY_CHUNK_BYTES = 64 * 1024
@@ -225,6 +226,17 @@ class ValidatorChainRelayV2:
     def start(self) -> dict:
         if self._thread is not None and self._thread.is_alive():
             return self.status()
+        # Recovery-safe (re)start: close any stale listener first so a restart
+        # after an unexpected loop-thread death can rebind the port instead of
+        # failing address-in-use, and clear the stop flag so the fresh loop
+        # runs (supervision in main() relies on this).
+        if self._listener is not None:
+            try:
+                self._listener.close()
+            except Exception:
+                pass
+            self._listener = None
+        self._stop.clear()
         listener = self._socket_factory(AF_VSOCK, socket.SOCK_STREAM)
         listener.bind((VMADDR_CID_ANY, self.port))
         listener.listen(8)
@@ -280,7 +292,8 @@ class ValidatorChainRelayV2:
                         str(exc)[:200],
                         consecutive_errors,
                     )
-                time.sleep(0.5)
+                # Interruptible: a stop() during the backoff exits immediately.
+                self._stop.wait(0.5)
                 continue
             if consecutive_errors:
                 logger.info(
@@ -313,8 +326,26 @@ class ValidatorChainRelayV2:
 def main() -> None:
     relay = ValidatorChainRelayV2()
     print(json.dumps(relay.start(), sort_keys=True), flush=True)
+    # Supervise: if the accept-loop thread ever dies for a reason the loop
+    # itself did not handle, restart it instead of leaving the enclave with no
+    # chain-RPC path (and thus no weight signing) while the process looks
+    # healthy. A clean stop() is respected. start() is recovery-safe.
     while True:
-        time.sleep(3600)
+        time.sleep(CHAIN_RELAY_SUPERVISION_INTERVAL_SECONDS)
+        if relay._stop.is_set():
+            continue
+        if relay.status().get("status") != "running":
+            logger.error(
+                "chain_relay_thread_dead; restarting the validator chain relay"
+            )
+            try:
+                relay.start()
+            except Exception as exc:
+                logger.error(
+                    "chain_relay_restart_failed type=%s error=%s",
+                    type(exc).__name__,
+                    str(exc)[:200],
+                )
 
 
 if __name__ == "__main__":

--- a/validator_tee/host/chain_relay_v2.py
+++ b/validator_tee/host/chain_relay_v2.py
@@ -34,6 +34,12 @@ MAX_CONTROL_BYTES = 16 * 1024
 MAX_BYTES_PER_DIRECTION = 32 * 1024 * 1024
 RELAY_CHUNK_BYTES = 64 * 1024
 CONNECT_TIMEOUT_SECONDS = 15.0
+# Bounds the client control handshake so a peer that connects and stalls
+# before/while sending its control frame cannot pin a handler thread and its
+# accepted fd forever — that leak is what cumulatively exhausts fds and drives
+# the accept() failures the loop now survives. _relay keeps its own idle
+# timeout, so the connection returns to blocking mode for the data pump.
+CONTROL_HANDSHAKE_TIMEOUT_SECONDS = 15.0
 IDLE_TIMEOUT_SECONDS = 90.0
 
 
@@ -188,6 +194,7 @@ def handle_chain_relay_connection(
 ) -> None:
     upstream = None
     try:
+        connection.settimeout(CONTROL_HANDSHAKE_TIMEOUT_SECONDS)
         request = _read_control(connection)
         destination_host = _validate_control(request)
         upstream = connector(destination_host)
@@ -198,6 +205,9 @@ def handle_chain_relay_connection(
                 "policy_hash": chain_source_policy_hash(),
             },
         )
+        # Handshake done; the data pump is bounded by _relay's own idle
+        # timeout, so restore blocking mode for it.
+        connection.settimeout(None)
         _relay(connection, upstream)
     finally:
         for candidate in (upstream, connection):

--- a/validator_tee/host/chain_relay_v2.py
+++ b/validator_tee/host/chain_relay_v2.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import ipaddress
 import json
+import logging
 import select
 import socket
 import threading
@@ -25,6 +26,8 @@ from leadpoet_canonical.chain_source_v2 import (
 
 AF_VSOCK = 40
 VMADDR_CID_ANY = 0xFFFFFFFF
+logger = logging.getLogger(__name__)
+
 CHAIN_RELAY_VSOCK_PORT = 5002
 MAX_CONTROL_BYTES = 16 * 1024
 MAX_BYTES_PER_DIRECTION = 32 * 1024 * 1024
@@ -250,11 +253,27 @@ class ValidatorChainRelayV2:
         self._listener = None
 
     def _accept_loop(self) -> None:
+        # A transient accept() failure (EMFILE under fd pressure, ECONNABORTED,
+        # ENOMEM) must not permanently kill this loop: the relay is the
+        # enclave's only chain-RPC path, so a dead accept loop silently stops
+        # all weight-extrinsic signing with the host process still looking
+        # healthy (main() never relaunches it). Only exit when stop() has been
+        # requested; otherwise log and keep serving after a short pause so a
+        # persistently broken listener cannot hot-spin.
         while not self._stop.is_set():
             try:
                 connection, _address = self._listener.accept()
-            except Exception:
-                return
+            except Exception as exc:
+                if self._stop.is_set():
+                    return
+                logger.warning(
+                    "chain_relay_accept_error type=%s error=%s; "
+                    "continuing to serve chain RPC",
+                    type(exc).__name__,
+                    str(exc)[:200],
+                )
+                time.sleep(0.5)
+                continue
             threading.Thread(
                 target=handle_chain_relay_connection,
                 args=(connection,),

--- a/validator_tee/host/chain_relay_v2.py
+++ b/validator_tee/host/chain_relay_v2.py
@@ -260,26 +260,54 @@ class ValidatorChainRelayV2:
         # healthy (main() never relaunches it). Only exit when stop() has been
         # requested; otherwise log and keep serving after a short pause so a
         # persistently broken listener cannot hot-spin.
+        consecutive_errors = 0
         while not self._stop.is_set():
             try:
                 connection, _address = self._listener.accept()
             except Exception as exc:
                 if self._stop.is_set():
                     return
+                consecutive_errors += 1
+                # Log the first failure and then only periodically, so a
+                # sustained fd/socket outage cannot spam the log at the retry
+                # cadence while still leaving one clear, greppable signal plus
+                # the recovery below.
+                if consecutive_errors == 1 or consecutive_errors % 60 == 0:
+                    logger.warning(
+                        "chain_relay_accept_error type=%s error=%s "
+                        "consecutive=%d; continuing to serve chain RPC",
+                        type(exc).__name__,
+                        str(exc)[:200],
+                        consecutive_errors,
+                    )
+                time.sleep(0.5)
+                continue
+            if consecutive_errors:
+                logger.info(
+                    "chain_relay_accept_recovered after=%d errors",
+                    consecutive_errors,
+                )
+                consecutive_errors = 0
+            # Spawning the handler must not be able to kill the accept loop
+            # either (thread exhaustion raises from start()): on failure close
+            # the connection and keep serving.
+            try:
+                threading.Thread(
+                    target=handle_chain_relay_connection,
+                    args=(connection,),
+                    kwargs={"connector": self._connector},
+                    daemon=True,
+                ).start()
+            except Exception as exc:
                 logger.warning(
-                    "chain_relay_accept_error type=%s error=%s; "
-                    "continuing to serve chain RPC",
+                    "chain_relay_handler_spawn_failed type=%s error=%s",
                     type(exc).__name__,
                     str(exc)[:200],
                 )
-                time.sleep(0.5)
-                continue
-            threading.Thread(
-                target=handle_chain_relay_connection,
-                args=(connection,),
-                kwargs={"connector": self._connector},
-                daemon=True,
-            ).start()
+                try:
+                    connection.close()
+                except Exception:
+                    pass
 
 
 def main() -> None:


### PR DESCRIPTION
## Why

Deep weight-path audit + direct source verification found this: the validator chain relay's accept loop (`validator_tee/host/chain_relay_v2.py`) returned from the loop on ANY `accept()` exception, and `main()` starts it once then `while True: sleep(3600)` with no `is_alive`/supervisor/relaunch. The relay is the enclave's **only** chain-RPC path — every weight-extrinsic signature calls `read_chain_signing_runtime` through it, and the finalization scan needs hundreds of RPCs through it. One transient `accept()` error (EMFILE under fd pressure, ECONNABORTED, ENOMEM) therefore permanently killed enclave signing: a **missed weight set every epoch until a manual validator restart, with the host process still looking healthy** — a silent, catastrophic failure mode.

## What

The accept loop now exits only when `stop()` has been requested; any other `accept()` error is logged (`chain_relay_accept_error`) and retried after a 0.5s pause so a persistently broken listener cannot hot-spin. Shutdown is unchanged: `stop()` sets the event and closes the listener → the next `accept()` raises → the loop sees `_stop` set and returns.

## Scope / safety

- `chain_relay_v2` handler symbols are **not** in either protected-workflow manifest (verified) — host-side only, no enclave rebuild, deploys via a normal validator restart. The enclave-side `EnclaveChainRpcTransportV2.call` is untouched.
- No behavior change on the happy path or on shutdown; only a transient-error path that previously killed the loop now recovers.

## Tests

New `tests/test_chain_relay_accept_supervision.py`: survives a transient `accept()` error and still serves the next connection; survives repeated transient errors; `stop()` still exits cleanly. 2/2 local.

## Not in this PR (flagged separately, deep-audit report on request)

Re-attestation-gated weight-path items for CTO coordination: coordinator provider terminal-ledger unbounded retention (`provider_broker_v2.py` `_records`, no eviction — highest-risk repeat vector), OpenRouter/SOURCE_ADD ingress pool no-TTL leak (+ a ready host-side rate-limit for the un-limited recipient endpoint), signed-journal 10-scan recovery inside the window, reconnect swapping the signing substrate, finalized-head trigger clock, sync `set_weights` on the loop, and enclave 2-rows/round-trip paging. Kept out to stay single-concern.

---

**Update (perfected):** self-review added three refinements — interruptible backoff (`_stop.wait` so shutdown is immediate), recovery-safe `start()` (closes the stale listener before rebinding, so a restart can't fail address-in-use), and real `main()` supervision (restarts the relay if the loop thread ever dies for an unhandled reason, respecting a clean `stop()`). This closes BOTH halves of the finding (fragile accept loop + `main()` never relaunching). Also guarded the per-connection handler-thread spawn and throttled the error log with a recovery line. 5/5 tests. Rebased on current main.

**Update 2 (further deep-analysis of the same file):** added one more related, low-risk hardening — a timeout on the client **control handshake** (`handle_chain_relay_connection`). The data path was bounded everywhere else (`_connect_chain` connect timeout, `_relay` idle timeout + byte cap) but the accepted connection had none while reading the client's control frame, so a peer that connects and stalls pinned a handler thread + fd forever — the exact fd/thread leak that produces the EMFILE `accept()` failures this PR survives. Uses the file's own `settimeout` idiom and restores blocking mode before `_relay`. 6/6 tests. This keeps the PR single-concern (relay reliability, one file).
