### PR TITLE
Reclaim stale transient artifacts so a vault leak can't brick the weight path

### DIFF
--- a/gateway/tee/artifact_vault_v2.py
+++ b/gateway/tee/artifact_vault_v2.py
@@ -23,6 +23,14 @@ ARTIFACT_MASTER_KEY_SLOT = "artifact_master_key"
 ARTIFACT_MASTER_KEY_HASH_DOMAIN = b"leadpoet-artifact-master-key-v2:"
 MAX_ARTIFACT_BYTES = 64 * 1024 * 1024
 MAX_IN_MEMORY_ARTIFACTS = 2048
+# Minimum age before a still-transient artifact may be evicted to admit a new
+# seal when the vault is full. In-flight artifacts are persisted within seconds
+# of sealing, so this window keeps a concurrent execution's about-to-persist
+# artifact safe while reclaiming orphans stranded by a failed execution
+# (see the inter-enclave seal path, which strands transients on any pre-persist
+# raise). Without this, an accumulated leak fills the vault and fails EVERY
+# execute_scoring_v2 closed — including the weight-path allocation build.
+TRANSIENT_EVICTION_MIN_AGE_SECONDS = 600.0
 _HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 ARTIFACT_PERSISTENCE_RETRYABLE_HTTP_STATUSES = frozenset(
     {408, 429, 500, 502, 503, 504}
@@ -82,6 +90,7 @@ class EncryptedArtifactVaultV2:
         self._clock = clock
         self._artifacts = {}  # type: Dict[str, Dict[str, Any]]
         self._persisted_artifacts = {}  # type: Dict[str, Dict[str, Any]]
+        self._evicted_transient_count = 0
         self._lock = threading.RLock()
         self._transaction_state = threading.local()
 
@@ -158,6 +167,7 @@ class EncryptedArtifactVaultV2:
             "object_lock_mode": "COMPLIANCE",
             "retain_until": retain_until,
             "persistence": None,
+            "_sealed_at": now,
         }
         created = False
         with self._lock:
@@ -165,13 +175,46 @@ class EncryptedArtifactVaultV2:
             if existing is not None:
                 return self.descriptor(artifact_id)
             if len(self._artifacts) >= MAX_IN_MEMORY_ARTIFACTS:
-                raise ArtifactVaultV2Error("artifact vault capacity is full")
+                self._evict_stale_transients(now)
+                if len(self._artifacts) >= MAX_IN_MEMORY_ARTIFACTS:
+                    raise ArtifactVaultV2Error("artifact vault capacity is full")
             self._artifacts[artifact_id] = record
             created = True
         if created:
             for transaction in getattr(self._transaction_state, "stack", ()):
                 transaction.add(artifact_id)
         return self.descriptor(artifact_id)
+
+    def _evict_stale_transients(self, now) -> int:
+        """Reclaim orphaned transients so a leak can't fail the vault closed.
+
+        Must be called holding self._lock. Every record in self._artifacts is
+        transient (persistence is None until confirm_persistence moves it to
+        self._persisted_artifacts), so eviction here never removes a persisted
+        artifact a durable receipt relies on. Only artifacts older than
+        TRANSIENT_EVICTION_MIN_AGE_SECONDS are eligible, so an in-flight
+        artifact seconds from persistence is never dropped. Oldest-first, only
+        as many as needed to admit one new seal.
+        """
+
+        eligible = sorted(
+            (
+                (record["_sealed_at"], artifact_id)
+                for artifact_id, record in self._artifacts.items()
+                if (now - record["_sealed_at"]).total_seconds()
+                >= TRANSIENT_EVICTION_MIN_AGE_SECONDS
+            ),
+            key=lambda item: item[0],
+        )
+        needed = len(self._artifacts) - MAX_IN_MEMORY_ARTIFACTS + 1
+        freed = 0
+        for _sealed_at, artifact_id in eligible:
+            if freed >= needed:
+                break
+            if self._artifacts.pop(artifact_id, None) is not None:
+                freed += 1
+        self._evicted_transient_count += freed
+        return freed
 
     def descriptor(self, artifact_id: str) -> Dict[str, Any]:
         with self._lock:

--- a/tests/test_artifact_vault_eviction.py
+++ b/tests/test_artifact_vault_eviction.py
@@ -1,0 +1,96 @@
+"""Age-guarded transient eviction: the vault must reclaim orphaned transients
+instead of failing every seal closed once full — while never dropping a still
+in-flight artifact (one seconds from persistence).
+
+Root cause this guards: inter-enclave sealed transients strand on any
+pre-persist failure of execute_scoring_v2, accumulating until the vault hits
+MAX_IN_MEMORY_ARTIFACTS and then fails EVERY execution closed, including the
+weight-path allocation build.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from gateway.tee import artifact_vault_v2 as vault_mod
+from gateway.tee.artifact_vault_v2 import (
+    ArtifactVaultV2Error,
+    EncryptedArtifactVaultV2,
+)
+
+MASTER_KEY = bytes(range(32))
+BOOT_HASH = "sha256:" + "a" * 64
+
+
+class _Clock:
+    def __init__(self):
+        self.now = datetime(2026, 7, 27, 12, 0, 0, tzinfo=timezone.utc)
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now = self.now + timedelta(seconds=seconds)
+
+
+def _vault(clock):
+    return EncryptedArtifactVaultV2(
+        master_key=MASTER_KEY, boot_identity_hash=BOOT_HASH, clock=clock
+    )
+
+
+def _fill(vault, n, clock, kind="orphan"):
+    for i in range(n):
+        vault.seal(
+            b"x" * (i + 1),  # distinct plaintext -> distinct artifact_id
+            job_id="job-%d" % i,
+            purpose="p",
+            artifact_kind=kind,
+        )
+
+
+def test_stale_transients_are_evicted_to_admit_new_seal(monkeypatch):
+    # Shrink the cap so the test is fast; keep the real age guard.
+    monkeypatch.setattr(vault_mod, "MAX_IN_MEMORY_ARTIFACTS", 4)
+    clock = _Clock()
+    vault = _vault(clock)
+    _fill(vault, 4, clock)                       # 4 orphaned transients, full
+    clock.advance(vault_mod.TRANSIENT_EVICTION_MIN_AGE_SECONDS + 1)  # now stale
+
+    # The 5th seal would have raised "capacity is full"; now it evicts one
+    # stale orphan and succeeds.
+    desc = vault.seal(b"new", job_id="job-new", purpose="p", artifact_kind="k")
+    assert desc["artifact_id"]
+    assert vault._evicted_transient_count == 1
+
+
+def test_in_flight_transients_are_never_evicted(monkeypatch):
+    monkeypatch.setattr(vault_mod, "MAX_IN_MEMORY_ARTIFACTS", 4)
+    clock = _Clock()
+    vault = _vault(clock)
+    _fill(vault, 4, clock)                        # 4 RECENT transients, full
+    # No time advance: all are in-flight (younger than the guard). A new seal
+    # must fail closed rather than evict an about-to-persist artifact.
+    with pytest.raises(ArtifactVaultV2Error, match="capacity is full"):
+        vault.seal(b"new", job_id="j", purpose="p", artifact_kind="k")
+    assert vault._evicted_transient_count == 0
+
+
+def test_eviction_is_oldest_first_and_only_as_needed(monkeypatch):
+    monkeypatch.setattr(vault_mod, "MAX_IN_MEMORY_ARTIFACTS", 4)
+    clock = _Clock()
+    vault = _vault(clock)
+    # Seal 4 at staggered ages; only 2 are past the guard.
+    old2 = []
+    for i in range(2):
+        d = vault.seal(b"old%d" % i, job_id="old-%d" % i, purpose="p", artifact_kind="k")
+        old2.append(d["artifact_id"])
+    clock.advance(vault_mod.TRANSIENT_EVICTION_MIN_AGE_SECONDS + 10)
+    for i in range(2):
+        vault.seal(b"young%d" % i, job_id="yng-%d" % i, purpose="p", artifact_kind="k")
+    # Full (4). New seal frees exactly ONE (the oldest), leaves the rest.
+    vault.seal(b"new", job_id="j", purpose="p", artifact_kind="k")
+    assert vault._evicted_transient_count == 1
+    # The single freed one is the oldest (old2[0]); old2[1] and youngs remain.
+    with pytest.raises(ArtifactVaultV2Error):
+        vault.descriptor(old2[0])          # evicted -> unavailable
+    assert vault.descriptor(old2[1])       # still present


### PR DESCRIPTION
## Root cause (proven from live gateway logs + a full code trace)

The 2026-07-27 missed weight sets are a **coordinator-enclave artifact-vault** failure, not a validator or transport problem. Gateway is healthy, but every `GET /research-lab/allocations/attested` 500s:
`build_research_lab_allocation_bundle → build_allocation_v2 → execute_coordinator_v2 → execute_scoring_v2 (attested_scoring_v2.py:1056)` → `AttestedScoringV2Error: V2 scoring failed closed: execution_artifactvaultv2error`. The validator's pre-weight guard then aborts → miss every epoch.

The enclave vault (`gateway/tee/artifact_vault_v2.py`) caps `_artifacts` at `MAX_IN_MEMORY_ARTIFACTS=2048` and raises **"artifact vault capacity is full"** when full. A transient leaves `_artifacts` only via `release_transient`, `confirm_persistence`, or a **thread-local** transaction rollback.

**The leak (traced to file:line):** `inter_enclave_artifact_v2.finish():228` seals a transient on the coordinator RPC handler thread with **no transaction and no release**. It is freed only if the host orchestrator `execute_scoring_v2` reaches its persist call and succeeds. Any pre-persist raise (receipt/ancestry/artifact-root checks, graph validation) or the empty-`job_artifact_hashes` failure branch strands it permanently — and because it was sealed on a different thread, `transient_artifact_transaction` (thread-local) cannot roll it back. Stranded transients accumulate to 2048 → **every** `execute_scoring_v2` fails closed, including the weight-path allocation build.

## What this PR does (the resilience fix — "so it can't break later")

When the vault is full, `seal()` now **reclaims transient artifacts older than `TRANSIENT_EVICTION_MIN_AGE_SECONDS` (600s)** — oldest-first, only as many as needed — instead of failing closed. Safety, verified in the trace:
- Every `_artifacts` record is transient (persisted ones live in `_persisted_artifacts`), so eviction **never** drops an artifact a durable attested receipt relies on.
- The **age guard** never drops an in-flight artifact (seconds old, whose `export_ciphertext` still reads it out of `_artifacts` to persist). Orphans from failed executions are minutes old.
- `_sealed_at` is internal only — it never enters `artifact_id`, any hash, or `descriptor`/`export_ciphertext`. An eviction counter is exposed for observability.

**Tests:** `tests/test_artifact_vault_eviction.py` — evicts stale orphans to admit a new seal, never evicts in-flight (fails closed instead), oldest-first only-as-needed. Existing `test_artifact_vault_v2.py` still passes (20/20).

## Honest scope + what's needed from the CTO

- **Re-attestation-gated.** The gateway enclave Dockerfile copies the entire gateway tree for code_hash verification, so this changes PCR0 → needs the gateway restart + paired validator restart to the same commit for alignment. There is no host-only fix (the whole tree is measured).
- **Unit-tested in isolation only.** The vault logic is pure-Python and fully covered, but I cannot run the enclave integration harness locally — please validate in the enclave build.
- **Exact production error unconfirmed.** The enclave classifies all `ArtifactVaultV2Error` subtypes to the same code `artifactvaultv2error`, discarding the message, so I could not confirm from host logs that it is specifically "capacity is full" vs another vault condition. The **leak that fills the vault is proven regardless**; please confirm via the coordinator enclave log which condition fired before relying on this as the complete fix.

## Recommended complement (not in this PR — deeper enclave work)

This resilience net stops the vault from ever bricking the weight path, but the **targeted leak fix** should follow: have `execute_scoring_v2` reclaim (persist-or-release) every `vault.job_artifacts(job_id, purpose)` on **all** exit paths — including the pre-persist raises and the empty-`job_artifact_hashes` branch — e.g. a `finally`, or a job-teardown hook that reclaims a job's transients inside the enclave. Also close two minor no-transaction seal paths (`openrouter_credential_v2._seal_storage_document`, `source_add_credential_ingress_v2`) by wrapping them in `transient_artifact_transaction`, matching the cache/outcome stores.

## Immediate unblock (ops, not this PR)

A gateway restart resets the in-memory vault and restores weights now (+ paired validator restart, start ≤ block 300). Also check provider health — `provider_preflight_unhealthy` workers indicate a provider outage that likely drove the failed executions that stranded the artifacts.
