### PR TITLE
Accept model-owned Routerverse runtime contract

### DIFF
--- a/research_lab/eval/private_runtime.py
+++ b/research_lab/eval/private_runtime.py
@@ -84,6 +84,20 @@ SOURCING_MODEL_MAX_AGENT_TIMEOUT_SECONDS = 900
 EXPECTED_SOURCING_ADAPTER_VERSION = "sourcing-model-research-lab-adapter:v3"
 EXPECTED_COMPONENT_REGISTRY_VERSION = "sourcing-model-components:v2"
 EXPECTED_ROUTING_COMPILER_VERSION = "routing-compiler-v1"
+REQUIRED_RUNTIME_CANDIDATE_TOOLS = {
+    "candidate.backlog",
+    "candidate.registry_feed",
+    "candidate.jobs_feed",
+    "candidate.deepline_firmographic",
+    "candidate.model_semantic",
+}
+REQUIRED_RUNTIME_INTENT_TOOLS = {
+    "intent.existing_evidence",
+    "intent.jobs_feed",
+    "intent.company_search",
+    "intent.first_party",
+    "intent.newsroom",
+}
 LAB_CONSUMER_CONTRACT_PATH = (
     Path(__file__).resolve().parents[1] / "sourcing_model_contract.json"
 )
@@ -1110,6 +1124,67 @@ def validate_sourcing_adapter_metadata(
     if routing.get("source_add_requires_manifest_sha256") is not True:
         raise PrivateModelRuntimeError(
             "private model routing does not require source manifest attestation"
+        )
+    runtime_routing = document.get("runtime_routing")
+    if not isinstance(runtime_routing, Mapping):
+        raise PrivateModelRuntimeError(
+            "private model does not declare runtime routing metadata"
+        )
+    if (
+        runtime_routing.get("compiler_version")
+        != EXPECTED_ROUTING_COMPILER_VERSION
+    ):
+        raise PrivateModelRuntimeError(
+            "private model runtime routing compiler version is unsupported"
+        )
+    for field in ("catalog_sha256", "policy_sha256"):
+        if not re.fullmatch(
+            r"[0-9a-f]{64}", str(runtime_routing.get(field) or "")
+        ):
+            raise PrivateModelRuntimeError(
+                f"private model runtime routing {field} is invalid"
+            )
+    runtime_catalog = runtime_routing.get("catalog")
+    runtime_policy = runtime_routing.get("policy")
+    if not isinstance(runtime_catalog, Mapping) or not isinstance(
+        runtime_policy, Mapping
+    ):
+        raise PrivateModelRuntimeError(
+            "private model runtime routing catalog and policy must be structured"
+        )
+    for name, payload in (
+        ("catalog", runtime_catalog),
+        ("policy", runtime_policy),
+    ):
+        expected_hash = sha256_json(payload).removeprefix("sha256:")
+        if runtime_routing.get(f"{name}_sha256") != expected_hash:
+            raise PrivateModelRuntimeError(
+                f"private model runtime routing {name} hash does not match its payload"
+            )
+    candidate_tools = set(
+        dict(runtime_routing.get("candidate_tool_lanes") or {})
+    )
+    intent_tools = set(dict(runtime_routing.get("intent_tool_tiers") or {}))
+    if not REQUIRED_RUNTIME_CANDIDATE_TOOLS <= candidate_tools:
+        raise PrivateModelRuntimeError(
+            "private model runtime candidate tool catalog is missing required tools"
+        )
+    if not REQUIRED_RUNTIME_INTENT_TOOLS <= intent_tools:
+        raise PrivateModelRuntimeError(
+            "private model runtime intent tool catalog is missing required tools"
+        )
+    catalog_tool_ids = {
+        str(item.get("tool_id") or "")
+        for item in runtime_catalog.get("tools") or ()
+        if isinstance(item, Mapping)
+    }
+    if not candidate_tools | intent_tools <= catalog_tool_ids:
+        raise PrivateModelRuntimeError(
+            "private model runtime routing mappings reference uncataloged tools"
+        )
+    if runtime_routing.get("private_bindings_exposed") is not False:
+        raise PrivateModelRuntimeError(
+            "private model runtime routing metadata exposes private bindings"
         )
     intent_sources = routing.get("intent_sources")
     if (

--- a/research_lab/sourcing_model_contract.json
+++ b/research_lab/sourcing_model_contract.json
@@ -23,6 +23,7 @@
     "sourcing_model/routing/contracts.py",
     "sourcing_model/routing/defaults.py",
     "sourcing_model/routing/policy.py",
+    "sourcing_model/routing/runtime.py",
     "sourcing_model/runtime_capabilities.py",
     "sourcing_model/scoring.py",
     "sourcing_model/validation.py"
@@ -179,6 +180,27 @@
         "source"
       ]
     },
+    "sourcing_model/routing/runtime.py": {
+      "candidate_lane_for_tool": [
+        "tool_id"
+      ],
+      "candidate_route_eligibility": [
+        "qualification_plan"
+      ],
+      "compile_candidate_acquisition_route": [
+        "qualification_plan"
+      ],
+      "compile_intent_evidence_route": [
+        "category"
+      ],
+      "intent_tier_for_tool": [
+        "tool_id"
+      ],
+      "runtime_catalog": [],
+      "runtime_policy": [],
+      "runtime_routing_metadata": [],
+      "runtime_tool_definitions": []
+    },
     "sourcing_model/runtime_capabilities.py": {
       "capability_metadata": [],
       "deadline": [],
@@ -290,6 +312,42 @@
       "catalog",
       "policy",
       "cohort"
+    ],
+    "sourcing_model/routing/runtime.py:candidate_route_eligibility": [
+      "qualification_plan",
+      "deepline_available"
+    ],
+    "sourcing_model/routing/runtime.py:compile_candidate_acquisition_route": [
+      "qualification_plan",
+      "backlog_available",
+      "registry_available",
+      "jobs_available",
+      "deepline_available",
+      "remaining_seconds",
+      "remaining_calls",
+      "remaining_results",
+      "credit_cap",
+      "cohort",
+      "catalog",
+      "policy"
+    ],
+    "sourcing_model/routing/runtime.py:compile_intent_evidence_route": [
+      "category",
+      "existing_evidence",
+      "available_tools",
+      "remaining_seconds",
+      "remaining_calls",
+      "credit_cap",
+      "cohort",
+      "catalog",
+      "policy"
+    ],
+    "sourcing_model/routing/runtime.py:runtime_catalog": [
+      "availability",
+      "state_overrides",
+      "additional_tools",
+      "additional_states",
+      "catalog_version"
     ]
   },
   "required_keyword_only": {
@@ -309,6 +367,26 @@
       "remaining_seconds",
       "remaining_calls",
       "remaining_results",
+      "credit_cap"
+    ],
+    "sourcing_model/routing/runtime.py:candidate_route_eligibility": [
+      "deepline_available"
+    ],
+    "sourcing_model/routing/runtime.py:compile_candidate_acquisition_route": [
+      "backlog_available",
+      "registry_available",
+      "jobs_available",
+      "deepline_available",
+      "remaining_seconds",
+      "remaining_calls",
+      "remaining_results",
+      "credit_cap"
+    ],
+    "sourcing_model/routing/runtime.py:compile_intent_evidence_route": [
+      "existing_evidence",
+      "available_tools",
+      "remaining_seconds",
+      "remaining_calls",
       "credit_cap"
     ]
   },
@@ -360,6 +438,10 @@
     "sourcing_model/routing/defaults.py": {
       "DEFAULT_CATALOG_VERSION": "sourcing-model-tools:v1",
       "DEFAULT_POLICY_VERSION": "sourcing-model-routing:v1"
+    },
+    "sourcing_model/routing/runtime.py": {
+      "RUNTIME_CATALOG_VERSION": "sourcing-model-runtime-tools:v1",
+      "RUNTIME_POLICY_VERSION": "sourcing-model-runtime-routing:v1"
     },
     "sourcing_model/normalized_icp_discovery_plan.py": {
       "CONTACT_PERSONA_SENIORITY_LEVELS": [

--- a/tests/restart_rehearsal/test_rehearsal_integrity.py
+++ b/tests/restart_rehearsal/test_rehearsal_integrity.py
@@ -147,7 +147,7 @@ def test_gateway_rehearsal_chain_adapter_enforces_exact_cutover_reads(
             archive=False,
         )
     )
-    assert response["result"]["specVersion"] == 438
+    assert response["result"]["specVersion"] == 440
     assert response["result"]["transactionVersion"] == 1
 
     request["params"] = [
@@ -267,7 +267,7 @@ def test_validator_enclave_chain_tls_boundary_runs_real_signing_reads(
 
     assert result["runtime_block"] == rehearsal_sitecustomize.CURRENT_BLOCK
     assert result["finalized_block"] == rehearsal_sitecustomize.CURRENT_BLOCK
-    assert result["spec_version"] == 438
+    assert result["spec_version"] == 440
     assert result["transaction_version"] == 1
     assert result["genesis_hash"] == (
         rehearsal_sitecustomize.GENESIS_HASH.removeprefix("0x")

--- a/tests/test_incontainer_capture.py
+++ b/tests/test_incontainer_capture.py
@@ -215,6 +215,25 @@ def test_sourcing_receipts_and_events_are_collected_and_stripped() -> None:
 def test_adapter_metadata_gate_requires_all_runtime_readiness_proofs() -> None:
     routing_catalog = {"schema_version": 1}
     routing_policy = {"schema_version": 1}
+    runtime_catalog = {
+        "schema_version": 1,
+        "tools": [
+            {"tool_id": tool_id}
+            for tool_id in (
+                "candidate.backlog",
+                "candidate.registry_feed",
+                "candidate.jobs_feed",
+                "candidate.deepline_firmographic",
+                "candidate.model_semantic",
+                "intent.existing_evidence",
+                "intent.jobs_feed",
+                "intent.company_search",
+                "intent.first_party",
+                "intent.newsroom",
+            )
+        ],
+    }
+    runtime_policy = {"schema_version": 1}
     ready = {
         "adapter_version": "sourcing-model-research-lab-adapter:v3",
         "component_registry_version": "sourcing-model-components:v2",
@@ -239,6 +258,28 @@ def test_adapter_metadata_gate_requires_all_runtime_readiness_proofs() -> None:
             "policy_sha256": sha256_json(routing_policy).removeprefix("sha256:"),
             "intent_sources": ["company_site", "job_listing", "news"],
             "source_add_requires_manifest_sha256": True,
+            "private_bindings_exposed": False,
+        },
+        "runtime_routing": {
+            "compiler_version": "routing-compiler-v1",
+            "catalog": runtime_catalog,
+            "catalog_sha256": sha256_json(runtime_catalog).removeprefix("sha256:"),
+            "policy": runtime_policy,
+            "policy_sha256": sha256_json(runtime_policy).removeprefix("sha256:"),
+            "candidate_tool_lanes": {
+                "candidate.backlog": "backlog",
+                "candidate.registry_feed": "registry_signal",
+                "candidate.jobs_feed": "jobs_signal",
+                "candidate.deepline_firmographic": "deepline_firmographic",
+                "candidate.model_semantic": "model_semantic",
+            },
+            "intent_tool_tiers": {
+                "intent.existing_evidence": "fused",
+                "intent.jobs_feed": "jobs_feed",
+                "intent.company_search": "company_search",
+                "intent.first_party": "first_party",
+                "intent.newsroom": "newsroom",
+            },
             "private_bindings_exposed": False,
         },
         "component_registry": {
@@ -266,6 +307,30 @@ def test_adapter_metadata_gate_requires_all_runtime_readiness_proofs() -> None:
     broken = json.loads(json.dumps(ready))
     broken["routing"]["catalog"]["schema_version"] = 2
     with pytest.raises(PrivateModelRuntimeError, match="catalog hash"):
+        private_runtime.validate_sourcing_adapter_metadata(broken)
+
+    broken = json.loads(json.dumps(ready))
+    broken["runtime_routing"]["candidate_tool_lanes"].pop(
+        "candidate.jobs_feed"
+    )
+    with pytest.raises(PrivateModelRuntimeError, match="missing required tools"):
+        private_runtime.validate_sourcing_adapter_metadata(broken)
+
+    extended = json.loads(json.dumps(ready))
+    extended["runtime_routing"]["candidate_tool_lanes"][
+        "candidate.future_provider"
+    ] = "future_provider"
+    extended["runtime_routing"]["catalog"]["tools"].append(
+        {"tool_id": "candidate.future_provider"}
+    )
+    extended["runtime_routing"]["catalog_sha256"] = sha256_json(
+        extended["runtime_routing"]["catalog"]
+    ).removeprefix("sha256:")
+    private_runtime.validate_sourcing_adapter_metadata(extended)
+
+    broken = json.loads(json.dumps(ready))
+    broken["runtime_routing"]["private_bindings_exposed"] = True
+    with pytest.raises(PrivateModelRuntimeError, match="private bindings"):
         private_runtime.validate_sourcing_adapter_metadata(broken)
 
 

--- a/tests/test_model_authority_v2.py
+++ b/tests/test_model_authority_v2.py
@@ -78,6 +78,25 @@ async def _load_empty_catalog(*, epoch_id):
 def _ready_adapter_metadata() -> dict:
     routing_catalog = {"schema_version": 1}
     routing_policy = {"schema_version": 1}
+    runtime_catalog = {
+        "schema_version": 1,
+        "tools": [
+            {"tool_id": tool_id}
+            for tool_id in (
+                "candidate.backlog",
+                "candidate.registry_feed",
+                "candidate.jobs_feed",
+                "candidate.deepline_firmographic",
+                "candidate.model_semantic",
+                "intent.existing_evidence",
+                "intent.jobs_feed",
+                "intent.company_search",
+                "intent.first_party",
+                "intent.newsroom",
+            )
+        ],
+    }
+    runtime_policy = {"schema_version": 1}
     return {
         "adapter_version": "sourcing-model-research-lab-adapter:v3",
         "component_registry_version": "sourcing-model-components:v2",
@@ -104,6 +123,28 @@ def _ready_adapter_metadata() -> dict:
             "policy_sha256": sha256_json(routing_policy).removeprefix("sha256:"),
             "intent_sources": ["company_site", "job_listing", "news"],
             "source_add_requires_manifest_sha256": True,
+            "private_bindings_exposed": False,
+        },
+        "runtime_routing": {
+            "compiler_version": "routing-compiler-v1",
+            "catalog": runtime_catalog,
+            "catalog_sha256": sha256_json(runtime_catalog).removeprefix("sha256:"),
+            "policy": runtime_policy,
+            "policy_sha256": sha256_json(runtime_policy).removeprefix("sha256:"),
+            "candidate_tool_lanes": {
+                "candidate.backlog": "backlog",
+                "candidate.registry_feed": "registry_signal",
+                "candidate.jobs_feed": "jobs_signal",
+                "candidate.deepline_firmographic": "deepline_firmographic",
+                "candidate.model_semantic": "model_semantic",
+            },
+            "intent_tool_tiers": {
+                "intent.existing_evidence": "fused",
+                "intent.jobs_feed": "jobs_feed",
+                "intent.company_search": "company_search",
+                "intent.first_party": "first_party",
+                "intent.newsroom": "newsroom",
+            },
             "private_bindings_exposed": False,
         },
         "component_registry": {

--- a/tests/test_sourcing_model_contract.py
+++ b/tests/test_sourcing_model_contract.py
@@ -223,6 +223,51 @@ def _conforming_tree(root: Path) -> None:
             return "intent.news"
     """)
     _write(root, "sourcing_model/routing/policy.py", "POLICY = True\n")
+    _write(root, "sourcing_model/routing/runtime.py", """
+        RUNTIME_CATALOG_VERSION = "sourcing-model-runtime-tools:v1"
+        RUNTIME_POLICY_VERSION = "sourcing-model-runtime-routing:v1"
+
+        def runtime_tool_definitions():
+            return ()
+
+        def runtime_policy():
+            return None
+
+        def runtime_catalog(
+            availability=None, *, state_overrides=None, additional_tools=(),
+            additional_states=(), catalog_version=RUNTIME_CATALOG_VERSION
+        ):
+            return None
+
+        def candidate_route_eligibility(
+            qualification_plan, *, deepline_available
+        ):
+            return False, ()
+
+        def compile_candidate_acquisition_route(
+            qualification_plan, *, backlog_available, registry_available,
+            jobs_available, deepline_available, remaining_seconds,
+            remaining_calls, remaining_results, credit_cap, cohort="control",
+            catalog=None, policy=None
+        ):
+            return None
+
+        def compile_intent_evidence_route(
+            category, *, existing_evidence, available_tools,
+            remaining_seconds, remaining_calls, credit_cap, cohort="control",
+            catalog=None, policy=None
+        ):
+            return None
+
+        def candidate_lane_for_tool(tool_id):
+            return None
+
+        def intent_tier_for_tool(tool_id):
+            return None
+
+        def runtime_routing_metadata():
+            return {}
+    """)
     _write(root, "sourcing_model/runtime_capabilities.py", """
         def capability_metadata():
             return {}


### PR DESCRIPTION
## What changed

- updates the Lab model contract snapshot for the canonical runtime tool catalog and compiler
- validates hash-bound runtime catalog and policy metadata before private evaluation
- requires the current candidate and intent tool baseline while allowing additive future tools
- rejects missing tools, uncataloged mappings, hash drift, and exposed private bindings

## Why

Routerverse routing now lives in `leadpoet/Sourcing_model`. Lab must consume and validate that exact branch-specific artifact instead of reimplementing router policy locally.

## Verification

- `git diff --check`
- `python3 -m pytest -q tests/test_sourcing_model_contract.py tests/test_model_authority_v2.py tests/test_incontainer_capture.py` — 70 passed
- broader local collection remains environment-limited by optional production dependencies; required GitHub checks must pass before merge

## Release ordering

Do not merge until `Sourcing_model/main` immutable artifact publication succeeds and the `leadpoet-lab` model branch has advanced to the exact Routerverse revision with its branch-specific artifact verified.
