### PR TITLE
Retry primary weight submission on transient finney transport faults

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -4506,64 +4506,118 @@ class Validator(BaseValidatorNeuron):
         )
 
         attempt = 0
-        with AuthoritativeSetWeightsContextV2(
-            substrate=self.subtensor.substrate,
-            wallet=self.wallet,
-            weight_authorization_id=weight_authorization_id,
-            weight_submission_event_hash=weight_submission_event_hash,
-            on_signed_extrinsic=on_signed_extrinsic,
-            expected_era_period=extrinsic_period,
-        ) as signing_context:
-            while True:
-                # Re-read Supabase after entering the signing context and again
-                # before every retry. A fence/activation racing with preparation
-                # must win before the SDK receives any extrinsic.
-                if not await self._weight_submission_lifecycle_is_open(
-                    epoch_id=epoch_id,
-                ):
-                    self._last_weight_extrinsic_receipts_v2 = list(
-                        signing_context.extrinsic_signature_results
-                    )
-                    print(
-                        f"   ⏹️ Durable epoch authority closed before weight "
-                        f"submission for epoch {epoch_id}"
-                    )
-                    return False
-                attempt += 1
-                outcome = ExtrinsicOutcome.from_sdk(
-                    self.subtensor.set_weights(
-                        netuid=self.config.netuid,
-                        wallet=self.wallet,
-                        uids=uids,
-                        weights=weights,
-                        wait_for_finalization=True,
-                        mechid=0,
-                        period=extrinsic_period,
-                    )
-                )
-                if outcome.success:
-                    self._last_weight_extrinsic_receipts_v2 = list(
-                        signing_context.extrinsic_signature_results
-                    )
-                    return True
+        # Outer loop: (re)create the enclave signing context. A finney transport
+        # failure below needs a fresh Subtensor, and the reconnect helper swaps
+        # self.subtensor for a new instance — so the context, which patches one
+        # specific substrate for enclave signing, must be rebuilt around the new
+        # substrate rather than reconnected in place.
+        while True:
+            transport_error: Optional[BaseException] = None
+            with AuthoritativeSetWeightsContextV2(
+                substrate=self.subtensor.substrate,
+                wallet=self.wallet,
+                weight_authorization_id=weight_authorization_id,
+                weight_submission_event_hash=weight_submission_event_hash,
+                on_signed_extrinsic=on_signed_extrinsic,
+                expected_era_period=extrinsic_period,
+            ) as signing_context:
+                while True:
+                    # Re-read Supabase after entering the signing context and again
+                    # before every retry. A fence/activation racing with preparation
+                    # must win before the SDK receives any extrinsic.
+                    if not await self._weight_submission_lifecycle_is_open(
+                        epoch_id=epoch_id,
+                    ):
+                        self._last_weight_extrinsic_receipts_v2 = list(
+                            signing_context.extrinsic_signature_results
+                        )
+                        print(
+                            f"   ⏹️ Durable epoch authority closed before weight "
+                            f"submission for epoch {epoch_id}"
+                        )
+                        return False
+                    attempt += 1
+                    try:
+                        sdk_result = self.subtensor.set_weights(
+                            netuid=self.config.netuid,
+                            wallet=self.wallet,
+                            uids=uids,
+                            weights=weights,
+                            wait_for_finalization=True,
+                            mechid=0,
+                            period=extrinsic_period,
+                        )
+                    except Exception as exc:
+                        # A finney transport failure (WebSocket 503, request
+                        # timeout, dropped connection) raises here instead of
+                        # returning a rejection outcome. Without this guard the
+                        # exception escapes the whole retry loop and the epoch's
+                        # weight submission is abandoned — the sole cause of the
+                        # chronic intermittent primary weight-set misses. The
+                        # auditor submission path already handles this identically
+                        # (classify transport error, reconnect, retry within the
+                        # epoch). Only transport faults are retried; any other
+                        # exception is re-raised so real signing/auth failures are
+                        # never masked. A dead websocket needs a fresh Subtensor,
+                        # which the reconnect below rebuilds outside this context.
+                        if not _is_subtensor_connection_error(exc):
+                            raise
+                        self._last_weight_extrinsic_receipts_v2 = list(
+                            signing_context.extrinsic_signature_results
+                        )
+                        print(
+                            f"   ⚠️ Weight submission attempt {attempt} hit a chain "
+                            f"transport error ({type(exc).__name__}); reconnecting "
+                            f"and retrying within epoch {epoch_id}"
+                        )
+                        transport_error = exc
+                        break
+                    outcome = ExtrinsicOutcome.from_sdk(sdk_result)
+                    if outcome.success:
+                        self._last_weight_extrinsic_receipts_v2 = list(
+                            signing_context.extrinsic_signature_results
+                        )
+                        return True
 
-                print(
-                    f"   ❌ Bittensor rejected weight submission attempt {attempt}: "
-                    f"{outcome.message}"
-                )
-                await asyncio.sleep(12)
-                if not await self._weight_submission_epoch_is_current(
-                    epoch_id=epoch_id,
-                    subnet_epoch_index=subnet_epoch_index,
-                ):
-                    self._last_weight_extrinsic_receipts_v2 = list(
-                        signing_context.extrinsic_signature_results
-                    )
                     print(
-                        f"   ⏹️ Epoch {epoch_id} ended before the weight "
-                        "submission was accepted"
+                        f"   ❌ Bittensor rejected weight submission attempt {attempt}: "
+                        f"{outcome.message}"
                     )
-                    return False
+                    await asyncio.sleep(12)
+                    if not await self._weight_submission_epoch_is_current(
+                        epoch_id=epoch_id,
+                        subnet_epoch_index=subnet_epoch_index,
+                    ):
+                        self._last_weight_extrinsic_receipts_v2 = list(
+                            signing_context.extrinsic_signature_results
+                        )
+                        print(
+                            f"   ⏹️ Epoch {epoch_id} ended before the weight "
+                            "submission was accepted"
+                        )
+                        return False
+
+            # Reached only when the inner loop broke on a transport error: the
+            # signing context has exited (extrinsic-signing patch restored and the
+            # global signing lock released), so it is now safe to replace the
+            # live-chain source and rebuild a fresh context for the next attempt.
+            if transport_error is None:
+                return False
+            await asyncio.sleep(12)
+            if not await self._weight_submission_epoch_is_current(
+                epoch_id=epoch_id,
+                subnet_epoch_index=subnet_epoch_index,
+            ):
+                print(
+                    f"   ⏹️ Epoch {epoch_id} ended before the weight "
+                    "submission was accepted"
+                )
+                return False
+            await asyncio.to_thread(
+                self._reconnect_subtensor_sync,
+                expected_source=self.subtensor,
+                reason="weight_submission_transport",
+            )
 
     async def submit_weights_at_epoch_end(self):
         """Run at most one automatic weight publication attempt at a time."""

--- a/tests/test_weight_submission_retry.py
+++ b/tests/test_weight_submission_retry.py
@@ -1176,3 +1176,110 @@ def test_all_active_submission_paths_use_epoch_bounded_helpers():
     assert "_submit_weights_v2" not in primary_source
     assert "VALIDATOR_ATTESTED_WEIGHT_MODE" not in primary_source
     assert "VALIDATOR_WEIGHT_PROTOCOL" in primary_source
+
+
+def test_primary_retries_within_epoch_after_transport_exception(
+    monkeypatch, capsys
+):
+    """A transient finney transport failure (WebSocket 503 / timeout) raises out
+    of ``set_weights`` instead of returning a rejection. It must be classified,
+    reconnected, and retried inside the epoch window — never allowed to escape
+    and abandon the whole epoch's weight submission (the chronic-miss bug)."""
+
+    validator = _primary([], blocks=[345, 346])
+
+    outcomes = [
+        TimeoutError("server rejected WebSocket connection: HTTP 503"),
+        _SdkResponse(True, "accepted"),
+    ]
+
+    def set_weights(**kwargs):
+        validator.subtensor.calls.append(dict(kwargs))
+        result = outcomes.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    validator.subtensor.set_weights = set_weights
+
+    async def no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(validator_module.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(
+        validator_module, "AuthoritativeSetWeightsContextV2", _AuthoritativeContext
+    )
+
+    async def current(**_kwargs):
+        return True
+
+    validator._weight_submission_epoch_is_current = current
+
+    reconnects = []
+
+    def reconnect(*, expected_source, reason):
+        reconnects.append(reason)
+        return True
+
+    validator._reconnect_subtensor_sync = reconnect
+
+    result = asyncio.run(
+        validator._set_weights_until_epoch_end(
+            epoch_id=0,
+            uids=[0],
+            weights=[1.0],
+            **_authoritative_args(),
+        )
+    )
+
+    assert result is True
+    # Two chain calls: the transport failure, then the successful retry.
+    assert len(validator.subtensor.calls) == 2
+    # Exactly one reconnect, tagged for the weight-submission transport path.
+    assert reconnects == ["weight_submission_transport"]
+    assert "transport error" in capsys.readouterr().out
+
+
+def test_primary_reraises_non_transport_exception(monkeypatch):
+    """A non-transport exception (a real signing/auth failure) must propagate,
+    not be silently swallowed or retried — only transport faults are retried."""
+
+    validator = _primary([], blocks=[345])
+
+    def set_weights(**kwargs):
+        validator.subtensor.calls.append(dict(kwargs))
+        raise ValueError("enclave refused to sign")
+
+    validator.subtensor.set_weights = set_weights
+
+    async def no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(validator_module.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(
+        validator_module, "AuthoritativeSetWeightsContextV2", _AuthoritativeContext
+    )
+
+    async def current(**_kwargs):
+        return True
+
+    validator._weight_submission_epoch_is_current = current
+
+    reconnected = []
+    validator._reconnect_subtensor_sync = (
+        lambda **kwargs: reconnected.append(kwargs) or True
+    )
+
+    with pytest.raises(ValueError, match="enclave refused to sign"):
+        asyncio.run(
+            validator._set_weights_until_epoch_end(
+                epoch_id=0,
+                uids=[0],
+                weights=[1.0],
+                **_authoritative_args(),
+            )
+        )
+
+    # A non-transport error must not trigger a reconnect or a silent retry.
+    assert reconnected == []
+    assert len(validator.subtensor.calls) == 1

--- a/validator_tee/enclave/protected_workflows_v2.json
+++ b/validator_tee/enclave/protected_workflows_v2.json
@@ -212,7 +212,7 @@
       "symbol": "Validator._research_lab_pre_weight_submission_guard"
     },
     {
-      "ast_sha256": "sha256:1a51da0e7e77f5ee73ac234a1439b99b08bd582576d8f57c32524d09b884d2da",
+      "ast_sha256": "sha256:ccaf002a2dc32e9573f169179aa4f478c9d66bbf0046e19d6007268412098fcf",
       "path": "neurons/validator.py",
       "symbol": "Validator._set_weights_until_epoch_end"
     },
@@ -327,7 +327,7 @@
       "symbol": "normalize_weight_protocol"
     }
   ],
-  "manifest_hash": "sha256:3ec2fe713fcadf401578d3fbb84126354699b7d92005762c18f65b3d2b281437",
-  "protected_source_commit": "d55b98ee8305b9da1e22f52d61cde5f0e47ef81a",
+  "manifest_hash": "sha256:0462027d2cdc6b2e06073dbb452bfff6a095a9b32760a3e447af23cd044cd9bd",
+  "protected_source_commit": "2b214b27f69e27e7dc5802a1363a0ebb846ddd21",
   "schema_version": "leadpoet.validator_protected_workflows.v2"
 }


### PR DESCRIPTION
## Incident
SN71 primary (Leadpoet, UID 0) intermittently missed on-chain weight sets for 3+ days; auditors copy the primary bundle, so all four validators went stale (428 blocks at alert time). `weights_alert.log` shows primary staleness repeatedly climbing to 1000–4000 blocks since 2026-07-25, with `WebSocket ... HTTP 503` and `timed out` faults against finney.

## Root cause (proven)
`Validator._set_weights_until_epoch_end` retried **only on a returned rejection** (`outcome.success is False`). Transient finney transport faults — WebSocket 503, timeout, dropped connection — are not returned; the SDK **raises** them. The raised exception escaped the retry loop, hit the outer `except Exception: return False`, and **abandoned the whole epoch's submission with zero intra-epoch retry**. Any transport blip in the ~15-block window missed that epoch.

Evidence: gateway healthy (every bundle POST `200`; auditor GETs of recent published epochs `404`); validator process alive (`Ssl`); the **auditor** path already wraps `set_weights` in try/except → reconnect → retry, which the primary lacked.

## Fix
Brings the primary to parity with the auditor. `set_weights` is wrapped so a transport fault (classified by the existing `_is_subtensor_connection_error`) is treated as a failed attempt: capture receipts, reconnect via the existing `_reconnect_subtensor_sync`, retry within the epoch. Reconnect swaps `self.subtensor`, so the enclave signing context (which patches one substrate) is rebuilt in an outer loop around the fresh substrate. Non-transport exceptions re-raise unchanged. No double-submit (chain rate limit rejects a duplicate if a prior extrinsic landed; the publication journal keeps reconciling). Returned-rejection retry, epoch-currency vetoes, and lifecycle fences preserved.

## Verification status
- ✅ **CI green** (Python 3.11): full pytest suite 4326 passed, including the checklist's mandatory weight/auditor tests and two new tests — transient transport error reconnects + retries to success within the epoch; non-transport error propagates.
- ✅ Protected-workflow manifest regenerated + self-verified; rebased onto latest `origin/main`.
- ✅ `py_compile` clean; `set_weights` call-site invariant preserved; read-only diagnosis only.
- ◐ **Local prepush rehearsal** (`run_local_restart_rehearsal.py`): candidate image built with full deps (bittensor 10.5.0), and the CPython 3.7 enclave finalization probe **passed** (`PYTHON37_FINALIZATION_PROBE_SUCCESS`). It could not complete on this macOS+colima host due to Docker-in-VM limitations unrelated to the candidate (temp bind-mount path not shared into the VM — worked around via `TMPDIR`; then a legacy-builder image-export `content digest not found` on the drand C-ABI build). These are host/Docker-VM issues, not code.

## Before deploy (native-Docker Linux host — NOT the live validator/gateway)
Run the full gate on a native-Docker Linux box:
```
python3 scripts/run_local_restart_rehearsal.py --from-sha 1d2e69aae4aec9491529546b9eb5d8a6b6131eea --candidate-sha <this-branch-HEAD> --transition forward --profile prepush
python3 scripts/run_local_restart_rehearsal.py --from-sha 1d2e69aae4aec9491529546b9eb5d8a6b6131eea --candidate-sha <this-branch-HEAD> --transition forward --profile release
```
(`from-sha` = currently-deployed validator = current `origin/main` `1d2e69aa`.) `release` runs forward/rollback/roll-forward + fault/concurrency matrix + 100 accelerated epochs. PR for review only — not merged, not deployed.