### PR TITLE
Disable fulfillment leaderboard emissions

### DIFF
--- a/gateway/tee/coordinator_weight_source_v2.py
+++ b/gateway/tee/coordinator_weight_source_v2.py
@@ -54,6 +54,15 @@ def _allocation_share(calculation: Mapping[str, Any]) -> float:
     return float(calculation["research_lab_fallback_share"])
 
 
+def _leaderboard_emissions_enabled(calculation: Mapping[str, Any]) -> bool:
+    value = calculation.get("leaderboard_emissions_enabled", True)
+    if not isinstance(value, bool):
+        raise CoordinatorWeightSourceV2Error(
+            "leaderboard_emissions_enabled must be boolean"
+        )
+    return value
+
+
 class CoordinatorWeightSourceV2:
     def __init__(self, reader: SupabaseSourceReaderV2) -> None:
         self._reader = reader
@@ -430,6 +439,25 @@ class CoordinatorWeightSourceV2:
         window_end: str,
         context: ExecutionContextV2,
     ) -> Dict[str, Any]:
+        leaderboard_enabled = _leaderboard_emissions_enabled(calculation)
+        if not bool(calculation["ff_enabled"]) or not leaderboard_enabled:
+            value = {
+                "leaderboard_bonus_share": calculation[
+                    "leaderboard_bonus_share"
+                ],
+                "leaderboard_rank_shares": list(
+                    calculation["leaderboard_rank_shares"]
+                ),
+                "leaderboard_entries": [],
+                "leaderboard_fetch_ok": True,
+            }
+            if "leaderboard_emissions_enabled" in calculation:
+                value["leaderboard_emissions_enabled"] = leaderboard_enabled
+            return {
+                **{key: proposed[key] for key in proposed if key != "value"},
+                "value": value,
+            }
+
         winner_rows = self._read(
             "fulfillment_leaderboard_winners",
             {"window_start": window_start, "window_end": window_end},
@@ -465,18 +493,17 @@ class CoordinatorWeightSourceV2:
             if bool(calculation["ff_enabled"])
             else []
         )
+        value = {
+            "leaderboard_bonus_share": calculation["leaderboard_bonus_share"],
+            "leaderboard_rank_shares": list(calculation["leaderboard_rank_shares"]),
+            "leaderboard_entries": entries,
+            "leaderboard_fetch_ok": True,
+        }
+        if "leaderboard_emissions_enabled" in calculation:
+            value["leaderboard_emissions_enabled"] = leaderboard_enabled
         return {
             **{key: proposed[key] for key in proposed if key != "value"},
-            "value": {
-                "leaderboard_bonus_share": calculation[
-                    "leaderboard_bonus_share"
-                ],
-                "leaderboard_rank_shares": list(
-                    calculation["leaderboard_rank_shares"]
-                ),
-                "leaderboard_entries": entries,
-                "leaderboard_fetch_ok": True,
-            },
+            "value": value,
         }
 
     def _sourcing_document(

--- a/leadpoet_canonical/weight_authority_v2.py
+++ b/leadpoet_canonical/weight_authority_v2.py
@@ -287,6 +287,15 @@ def _weight_input_value_documents_v2(
                 "leaderboard_bonus_share": calculation[
                     "leaderboard_bonus_share"
                 ],
+                **(
+                    {
+                        "leaderboard_emissions_enabled": calculation[
+                            "leaderboard_emissions_enabled"
+                        ]
+                    }
+                    if "leaderboard_emissions_enabled" in calculation
+                    else {}
+                ),
                 "leaderboard_rank_shares": list(
                     calculation["leaderboard_rank_shares"]
                 ),
@@ -348,7 +357,18 @@ def _weight_input_value_documents_v2(
         ),
         "feature_flags": document(
             "feature_flags",
-            {"ff_enabled": calculation["ff_enabled"]},
+            {
+                "ff_enabled": calculation["ff_enabled"],
+                **(
+                    {
+                        "leaderboard_emissions_enabled": calculation[
+                            "leaderboard_emissions_enabled"
+                        ]
+                    }
+                    if "leaderboard_emissions_enabled" in calculation
+                    else {}
+                ),
+            },
         ),
         "constants": document(
             "constants",

--- a/leadpoet_canonical/weight_computation.py
+++ b/leadpoet_canonical/weight_computation.py
@@ -22,7 +22,7 @@ WEIGHT_SNAPSHOT_SCHEMA_VERSION = "leadpoet.weight_computation_request.v1"
 WEIGHT_RESULT_SCHEMA_VERSION = "leadpoet.weight_computation_result.v1"
 U16_MAX = 65535
 
-_SNAPSHOT_FIELDS = {
+_SNAPSHOT_FIELDS_CURRENT = {
     "schema_version",
     "netuid",
     "epoch_id",
@@ -44,6 +44,7 @@ _SNAPSHOT_FIELDS = {
     "research_lab_fallback_share",
     "research_lab_allocation_doc",
     "leaderboard_bonus_share",
+    "leaderboard_emissions_enabled",
     "leaderboard_rank_shares",
     "leaderboard_entries",
     "leaderboard_fetch_ok",
@@ -55,6 +56,10 @@ _SNAPSHOT_FIELDS = {
     "sourcing_floor_threshold",
     "min_total_rep_for_distribution",
 }
+_SNAPSHOT_FIELDS_LEGACY = _SNAPSHOT_FIELDS_CURRENT - {
+    "leaderboard_emissions_enabled"
+}
+_SNAPSHOT_FIELD_SETS = (_SNAPSHOT_FIELDS_CURRENT, _SNAPSHOT_FIELDS_LEGACY)
 
 _HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _COMMIT_RE = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
@@ -93,6 +98,15 @@ def weight_config_document(snapshot: Mapping[str, Any]) -> Dict[str, Any]:
         "champion_share": snapshot.get("champion_share"),
         "research_lab_fallback_share": snapshot.get("research_lab_fallback_share"),
         "leaderboard_bonus_share": snapshot.get("leaderboard_bonus_share"),
+        **(
+            {
+                "leaderboard_emissions_enabled": snapshot.get(
+                    "leaderboard_emissions_enabled"
+                )
+            }
+            if "leaderboard_emissions_enabled" in snapshot
+            else {}
+        ),
         "leaderboard_rank_shares": snapshot.get("leaderboard_rank_shares"),
         "sourcing_floor_threshold": snapshot.get("sourcing_floor_threshold"),
         "min_total_rep_for_distribution": snapshot.get("min_total_rep_for_distribution"),
@@ -118,6 +132,12 @@ def _non_negative_float(value: Any, field: str) -> float:
     if result < 0:
         raise WeightComputationError("%s must be non-negative" % field)
     return result
+
+
+def _bool_flag(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise WeightComputationError("%s must be boolean" % field)
+    return value
 
 
 def _int(value: Any, field: str, minimum: int = 0) -> int:
@@ -267,7 +287,9 @@ def _add_weight(uid_weights: Dict[int, float], uid: int, weight: float) -> None:
 
 
 def compute_final_weights(snapshot: Mapping[str, Any]) -> Dict[str, Any]:
-    if not isinstance(snapshot, Mapping) or set(snapshot) != _SNAPSHOT_FIELDS:
+    if not isinstance(snapshot, Mapping) or not any(
+        set(snapshot) == fields for fields in _SNAPSHOT_FIELD_SETS
+    ):
         raise WeightComputationError("weight snapshot fields do not match the canonical schema")
     if snapshot.get("schema_version") != WEIGHT_SNAPSHOT_SCHEMA_VERSION:
         raise WeightComputationError("unsupported weight snapshot schema")
@@ -310,6 +332,10 @@ def compute_final_weights(snapshot: Mapping[str, Any]) -> Dict[str, Any]:
     champion_uid_value = snapshot.get("champion_uid")
     champion_uid = None if champion_uid_value is None else _int(champion_uid_value, "champion_uid")
     leaderboard_share = _non_negative_float(snapshot["leaderboard_bonus_share"], "leaderboard_bonus_share")
+    leaderboard_emissions_enabled = _bool_flag(
+        snapshot.get("leaderboard_emissions_enabled", True),
+        "leaderboard_emissions_enabled",
+    )
     fulfillment_pool_share = max(0.0, 1.0 - research_lab_share - champion_share - leaderboard_share)
     max_sourcing_share = max(
         0.0,
@@ -380,10 +406,16 @@ def compute_final_weights(snapshot: Mapping[str, Any]) -> Dict[str, Any]:
     leaderboard_entries = snapshot["leaderboard_entries"]
     if not isinstance(rank_shares, list) or not isinstance(leaderboard_entries, list):
         raise WeightComputationError("leaderboard inputs must be lists")
+    if not leaderboard_emissions_enabled and leaderboard_entries:
+        raise WeightComputationError(
+            "disabled leaderboard emissions require empty leaderboard entries"
+        )
     rank_shares = [_non_negative_float(value, "leaderboard rank share") for value in rank_shares]
     leaderboard_weights = {}  # type: Dict[int, float]
-    leaderboard_burn = 0.0 if ff_enabled else leaderboard_share
-    if ff_enabled:
+    leaderboard_burn = (
+        0.0 if ff_enabled and leaderboard_emissions_enabled else leaderboard_share
+    )
+    if ff_enabled and leaderboard_emissions_enabled:
         if not snapshot["leaderboard_fetch_ok"]:
             leaderboard_burn = leaderboard_share
         else:
@@ -491,6 +523,7 @@ def compute_final_weights(snapshot: Mapping[str, Any]) -> Dict[str, Any]:
             "research_lab_paid": research_lab_breakdown["paid"],
             "fulfillment_pool_share": fulfillment_pool_share,
             "fulfillment_share": fulfillment_share,
+            "leaderboard_emissions_enabled": leaderboard_emissions_enabled,
             "leaderboard_burn": leaderboard_burn,
             "max_sourcing_share": max_sourcing_share,
             "effective_sourcing_share": effective_sourcing_share,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -4773,6 +4773,10 @@ class Validator(BaseValidatorNeuron):
             # broke once sourcing emissions were dropped to 0% (no incentive
             # → no rolling_scores → 100% burn even with active fulfillment).
             ff_enabled = os.environ.get("ENABLE_FULFILLMENT", "false").lower() == "true"
+            leaderboard_emissions_enabled = _env_flag(
+                "FULFILLMENT_LEADERBOARD_EMISSIONS_ENABLED",
+                True,
+            )
 
             # ═══════════════════════════════════════════════════════════════════
             # SOURCING EMISSIONS SYSTEM (Threshold-Based)
@@ -4811,9 +4815,10 @@ class Validator(BaseValidatorNeuron):
             CHAMPION_SHARE = 0.0           # 0% — model competition retired 2026-06-23; its 10% folded into the fulfillment pool
             # FULFILLMENT-FLAVORED TOTAL is the residual after Research Lab.
             # That residual is split into a per-epoch fulfillment pool and a top-3
-            # rolling-window leaderboard bonus.  The leaderboard is a permanent
-            # feature of the fulfillment track — it is NEVER toggled off; only
-            # the split ratio between per-epoch and weekly is tunable here.
+            # rolling-window leaderboard bonus. Operators may disable paying the
+            # leaderboard bucket with FULFILLMENT_LEADERBOARD_EMISSIONS_ENABLED=false,
+            # but the 9.5% reservation must remain carved out so it burns instead
+            # of inflating per-request fulfillment rewards.
             RESEARCH_LAB_FALLBACK_SHARE = _env_percent_share(
                 "RESEARCH_LAB_EMISSION_PERCENT",
                 float(DEFAULT_RESEARCH_LAB_EMISSION_PERCENT),
@@ -4925,6 +4930,9 @@ class Validator(BaseValidatorNeuron):
                     "research_lab_fallback_share": RESEARCH_LAB_FALLBACK_SHARE,
                     "research_lab_allocation_doc": research_lab_allocation_doc,
                     "leaderboard_bonus_share": LEADERBOARD_BONUS_SHARE,
+                    "leaderboard_emissions_enabled": bool(
+                        leaderboard_emissions_enabled
+                    ),
                     "leaderboard_rank_shares": [
                         LEADERBOARD_TOP1_PCT,
                         LEADERBOARD_TOP2_PCT,
@@ -4944,31 +4952,33 @@ class Validator(BaseValidatorNeuron):
                     "min_total_rep_for_distribution": MIN_TOTAL_REP_FOR_DISTRIBUTION,
                 })
 
-            try:
-                from Leadpoet.utils.cloud_db import (
-                    gateway_get_fulfillment_leaderboard_snapshot,
-                )
+            if ff_enabled and leaderboard_emissions_enabled:
+                try:
+                    from Leadpoet.utils.cloud_db import (
+                        gateway_get_fulfillment_leaderboard_snapshot,
+                    )
 
-                leaderboard_snapshot = await asyncio.to_thread(
-                    gateway_get_fulfillment_leaderboard_snapshot,
-                    self.wallet,
-                    3,
-                )
-                leaderboard_window_start = str(
-                    leaderboard_snapshot["period_start"]
-                )
-                leaderboard_window_end = str(leaderboard_snapshot["period_end"])
-                observed_leaders = (
-                    list(leaderboard_snapshot["leaderboard"])
-                    if ff_enabled
-                    else []
-                )
-            except Exception as exc:
-                print(
-                    "   ❌ Authoritative V2 leaderboard snapshot failed; "
-                    f"refusing weight publication: {exc}"
-                )
-                return False
+                    leaderboard_snapshot = await asyncio.to_thread(
+                        gateway_get_fulfillment_leaderboard_snapshot,
+                        self.wallet,
+                        3,
+                    )
+                    leaderboard_window_start = str(
+                        leaderboard_snapshot["period_start"]
+                    )
+                    leaderboard_window_end = str(leaderboard_snapshot["period_end"])
+                    observed_leaders = list(leaderboard_snapshot["leaderboard"])
+                except Exception as exc:
+                    print(
+                        "   ❌ Authoritative V2 leaderboard snapshot failed; "
+                        f"refusing weight publication: {exc}"
+                    )
+                    return False
+            else:
+                disabled_window = datetime.now(timezone.utc).isoformat()
+                leaderboard_window_start = disabled_window
+                leaderboard_window_end = disabled_window
+                observed_leaders = []
             
             # ═══════════════════════════════════════════════════════════════════
             # Check if we have ANYTHING to submit (current OR rolling)
@@ -5088,7 +5098,11 @@ class Validator(BaseValidatorNeuron):
                 - LEADERBOARD_BONUS_SHARE,
             )
             effective_fulfillment_pool = FULFILLMENT_POOL_SHARE
-            effective_leaderboard_share = LEADERBOARD_BONUS_SHARE if ff_enabled else 0.0
+            effective_leaderboard_share = (
+                LEADERBOARD_BONUS_SHARE
+                if ff_enabled and leaderboard_emissions_enabled
+                else 0.0
+            )
             print(
                 f"\n   📊 SPLIT: Sourcing={MAX_SOURCING_SHARE*100:.0f}%, "
                 f"Champion={effective_champion_share*100:.0f}%, "
@@ -5240,12 +5254,22 @@ class Validator(BaseValidatorNeuron):
             leaderboard_fetch_ok = True
             # When ff is disabled, the entire LEADERBOARD_BONUS_SHARE flows to
             # burn (mirroring how the fulfillment pool burns when disabled).
-            # When ff is enabled, the burn starts at 0 and grows for any
-            # rank slot that falls through (deregistered top-N or fewer than
-            # 3 weekly winners).
-            leaderboard_burn = 0.0 if ff_enabled else LEADERBOARD_BONUS_SHARE
+            # When leaderboard emissions are disabled, that same reservation
+            # burns while the per-request fulfillment pool remains active.
+            # When both are enabled, burn starts at 0 and grows for any rank
+            # slot that falls through (deregistered top-N or fewer than 3
+            # weekly winners).
+            leaderboard_burn = (
+                0.0
+                if ff_enabled and leaderboard_emissions_enabled
+                else LEADERBOARD_BONUS_SHARE
+            )
             try:
-                if ff_enabled and effective_leaderboard_share > 0:
+                if (
+                    ff_enabled
+                    and leaderboard_emissions_enabled
+                    and effective_leaderboard_share > 0
+                ):
                     leaders = observed_leaders
                     leaderboard_entries = [
                         {

--- a/tests/test_canonical_weight_computation.py
+++ b/tests/test_canonical_weight_computation.py
@@ -50,6 +50,7 @@ def _snapshot(**overrides):
             "queued_champion_allocations": [],
         },
         "leaderboard_bonus_share": 0.095,
+        "leaderboard_emissions_enabled": True,
         "leaderboard_rank_shares": [0.05, 0.03, 0.015],
         "leaderboard_entries": [{"miner_hotkey": "fulfillment-hotkey", "wins": 9}],
         "leaderboard_fetch_ok": True,
@@ -74,6 +75,18 @@ def test_full_two_host_allocation_matches_current_order_and_totals():
     assert sum(result["weights"]) == pytest.approx(1.0, abs=1e-15)
     assert result["sparse_uids"] == [0, 1, 2]
     assert len(result["weights_hash"]) == 64
+
+
+def test_disabled_leaderboard_emissions_burns_reserved_share_only():
+    result = compute_final_weights(
+        _snapshot(leaderboard_emissions_enabled=False, leaderboard_entries=[])
+    )
+    assert result["uids"] == [0, 1, 2]
+    assert result["weights"] == pytest.approx([0.245, 0.705, 0.05], abs=1e-15)
+    assert result["components"]["fulfillment_pool_share"] == pytest.approx(0.705)
+    assert result["components"]["fulfillment_share"] == pytest.approx(0.705)
+    assert result["components"]["leaderboard_burn"] == pytest.approx(0.095)
+    assert result["components"]["leaderboard_emissions_enabled"] is False
 
 
 def test_disabled_tracks_resolve_to_exact_full_burn():
@@ -187,6 +200,22 @@ def test_config_hash_binds_every_weight_behavior_setting():
     snapshot = _snapshot()
     snapshot["leaderboard_bonus_share"] = 0.1
     with pytest.raises(WeightComputationError, match="config_hash does not match"):
+        compute_final_weights(snapshot)
+    snapshot = _snapshot()
+    snapshot["leaderboard_emissions_enabled"] = False
+    with pytest.raises(WeightComputationError, match="config_hash does not match"):
+        compute_final_weights(snapshot)
+
+
+def test_leaderboard_emissions_flag_must_be_boolean():
+    snapshot = _snapshot(leaderboard_emissions_enabled="false")
+    with pytest.raises(WeightComputationError, match="must be boolean"):
+        compute_final_weights(snapshot)
+
+
+def test_disabled_leaderboard_emissions_requires_empty_entries():
+    snapshot = _snapshot(leaderboard_emissions_enabled=False)
+    with pytest.raises(WeightComputationError, match="require empty"):
         compute_final_weights(snapshot)
 
 

--- a/tests/test_coordinator_weight_source_v2.py
+++ b/tests/test_coordinator_weight_source_v2.py
@@ -25,6 +25,7 @@ from leadpoet_canonical.sourcing_history_v2 import (
 )
 from leadpoet_canonical.weight_computation import (
     WEIGHT_SNAPSHOT_SCHEMA_VERSION,
+    WeightComputationError,
     weight_config_hash,
 )
 from leadpoet_canonical.weight_authority_v2 import (
@@ -78,6 +79,7 @@ def _snapshot(**overrides):
             "queued_champion_allocations": [],
         },
         "leaderboard_bonus_share": 0.095,
+        "leaderboard_emissions_enabled": True,
         "leaderboard_rank_shares": [0.05, 0.03, 0.015],
         "leaderboard_entries": [],
         "leaderboard_fetch_ok": True,
@@ -225,6 +227,47 @@ def test_leaderboard_reconstructs_wins_tiebreak_and_ban_filter():
     ]
 
 
+def test_disabled_leaderboard_emissions_commits_empty_leaderboard_without_db_read():
+    reader = FakeReader(
+        {
+            "fulfillment_leaderboard_winners": [
+                {"miner_hotkey": "miner", "reward_pct": 0.5},
+            ],
+            "banned_hotkeys": [],
+        }
+    )
+    snapshot = _snapshot(
+        leaderboard_emissions_enabled=False,
+        leaderboard_entries=[],
+    )
+    source = CoordinatorWeightSourceV2(reader)
+    document = source.resolve(
+        payload=_payload("leaderboard", snapshot=snapshot),
+        context=_context("research_lab.leaderboard_input.v2"),
+    )
+    assert document["value"] == {
+        "leaderboard_bonus_share": 0.095,
+        "leaderboard_emissions_enabled": False,
+        "leaderboard_rank_shares": [0.05, 0.03, 0.015],
+        "leaderboard_entries": [],
+        "leaderboard_fetch_ok": True,
+    }
+    assert reader.calls == []
+
+
+def test_leaderboard_emissions_flag_rejects_non_boolean_values():
+    source = CoordinatorWeightSourceV2(FakeReader({}))
+    snapshot = _snapshot(
+        leaderboard_emissions_enabled="false",
+        leaderboard_entries=[],
+    )
+    with pytest.raises(WeightComputationError, match="must be boolean"):
+        source.resolve(
+            payload=_payload("leaderboard", snapshot=snapshot),
+            context=_context("research_lab.leaderboard_input.v2"),
+        )
+
+
 def test_disabled_fulfillment_commits_empty_leaderboard_without_paying_rows():
     reader = FakeReader(
         {
@@ -246,13 +289,7 @@ def test_disabled_fulfillment_commits_empty_leaderboard_without_paying_rows():
         context=_context("research_lab.leaderboard_input.v2"),
     )
     assert document["value"]["leaderboard_entries"] == []
-    assert reader.calls[0] == (
-        "fulfillment_leaderboard_winners",
-        {
-            "window_start": "2026-07-03T20:00:00Z",
-            "window_end": "2026-07-10T20:00:00Z",
-        },
-    )
+    assert reader.calls == []
 
 
 def test_sourcing_history_is_rebuilt_only_from_signed_epoch_receipts():

--- a/tests/test_validator_weight_differential.py
+++ b/tests/test_validator_weight_differential.py
@@ -86,13 +86,14 @@ def _legacy_current_host_formula(snapshot):
     sourcing_to_miners = effective_sourcing - dereg_burn
 
     ff_enabled = snapshot["ff_enabled"]
+    leaderboard_enabled = snapshot.get("leaderboard_emissions_enabled", True)
     fulfillment_share = snapshot["fulfillment_share"] if ff_enabled and snapshot["fulfillment_fetch_ok"] else 0.0
     fulfillment_rows = snapshot["fulfillment_rows"] if ff_enabled and snapshot["fulfillment_fetch_ok"] else []
     unused_fulfillment = fulfillment_pool - fulfillment_share
 
     leaderboard_by_uid = {}
-    leaderboard_burn = 0.0 if ff_enabled else leaderboard_share
-    if ff_enabled:
+    leaderboard_burn = 0.0 if ff_enabled and leaderboard_enabled else leaderboard_share
+    if ff_enabled and leaderboard_enabled:
         if not snapshot["leaderboard_fetch_ok"]:
             leaderboard_burn = leaderboard_share
         else:
@@ -150,6 +151,7 @@ def _random_snapshot(rng, case):
     size = rng.randint(4, 40)
     hotkeys = ["burn"] + ["hotkey-%s" % index for index in range(1, size)]
     ff_enabled = rng.choice([True, False])
+    leaderboard_enabled = rng.choice([True, False])
     lab_cap = rng.choice([0.0, 10.0, 20.0])
     leaderboard_share = 0.095
     champion_share = rng.choice([0.0, 0.1])
@@ -181,7 +183,7 @@ def _random_snapshot(rng, case):
     leaderboard_entries = [
         {"miner_hotkey": rng.choice(hotkeys[1:] + ["deregistered-lb"]), "wins": rng.randint(1, 20)}
         for _ in range(rng.randint(0, 3))
-    ]
+    ] if leaderboard_enabled else []
     rolling_scores = []
     for index in range(rng.randint(0, size + 4)):
         hotkey = hotkeys[rng.randrange(1, size)] if index < size else "deregistered-%s" % index
@@ -212,6 +214,7 @@ def _random_snapshot(rng, case):
         "research_lab_fallback_share": 0.2,
         "research_lab_allocation_doc": allocation,
         "leaderboard_bonus_share": leaderboard_share,
+        "leaderboard_emissions_enabled": leaderboard_enabled,
         "leaderboard_rank_shares": [0.05, 0.03, 0.015],
         "leaderboard_entries": leaderboard_entries,
         "leaderboard_fetch_ok": rng.choice([True, True, False]),

--- a/validator_tee/enclave/protected_workflows_v2.json
+++ b/validator_tee/enclave/protected_workflows_v2.json
@@ -142,7 +142,7 @@
       "symbol": "weight_input_value_documents_v2"
     },
     {
-      "ast_sha256": "sha256:d3526d7096028e89fc35a4f965e3c2988e0015f355c4e658ce95c47c8aa8a6d1",
+      "ast_sha256": "sha256:e929fb1d018a221cb7c9330701d9f0b2475a522a81c4d18164f9e42433b02c74",
       "path": "leadpoet_canonical/weight_computation.py",
       "symbol": "compute_final_weights"
     },
@@ -157,7 +157,7 @@
       "symbol": "research_lab_uid_weights_from_allocation"
     },
     {
-      "ast_sha256": "sha256:0e12bd12aae402b72cd56b242d92d586280b2ec622dd7fac00994df973224862",
+      "ast_sha256": "sha256:19bba14d86933edcd369bb391646ad1ad847ff4aced590ae672db6e75d53395c",
       "path": "leadpoet_canonical/weight_computation.py",
       "symbol": "weight_config_document"
     },
@@ -217,7 +217,7 @@
       "symbol": "Validator._set_weights_until_epoch_end"
     },
     {
-      "ast_sha256": "sha256:d5e3288b530c3f6596df7253a83981e97a3cc868d270f0911108ea54286b8610",
+      "ast_sha256": "sha256:aeee90cc68d9264ba1e3e30a5a80bbc9ca05c40f69f793c762b5eb28131a970e",
       "path": "neurons/validator.py",
       "symbol": "Validator._submit_weights_at_epoch_end_locked"
     },
@@ -327,7 +327,7 @@
       "symbol": "normalize_weight_protocol"
     }
   ],
-  "manifest_hash": "sha256:6b7dd8f90821464ff7f0b0f7590d3f367a591554a388d605ace9402bffb8dc17",
-  "protected_source_commit": "978c7677db00c416f1aaf1f9e7f66ffc9395b46d",
+  "manifest_hash": "sha256:c5706d45daa16378a6df1f749cd42a4534b4838a3ef6eb5c5fc115e04435eeeb",
+  "protected_source_commit": "9ceb26568746fc13dc1f1243126ef8ea6a42cf23",
   "schema_version": "leadpoet.validator_protected_workflows.v2"
 }


### PR DESCRIPTION
## Summary

- Add `FULFILLMENT_LEADERBOARD_EMISSIONS_ENABLED=false` as a committed validator/canonical switch to stop fulfillment leaderboard payouts.
- Preserve the 9.5% leaderboard reservation so it burns instead of expanding the per-request fulfillment pool.
- Carry the flag through V2 canonical weight computation, gateway coordinator input reconstruction, feature-flag/input documents, and protected workflow manifests.
- Fail closed on malformed disabled snapshots: the flag must be boolean and disabled snapshots must have empty leaderboard entries.

## Expected behavior

When unset or `true`, existing leaderboard payouts continue unchanged. When set to `false`, fulfillment rewards remain active, leaderboard miners receive 0%, and the full 9.5% leaderboard slice burns.

## Validation

Ran from a clean worktree based on `origin/main`:

- `PYTHONPYCACHEPREFIX=/tmp/codex_pycache_pr python3 -m compileall -q Leadpoet gateway leadpoet_audit leadpoet_canonical leadpoet_verifier miner_models qualification research_lab validator_models`
- `git diff --check`
- `PYTHONPYCACHEPREFIX=/tmp/codex_pycache_pr /opt/homebrew/bin/pytest -q tests/test_attested_weight_inputs_v2.py tests/test_coordinator_executor_v2.py tests/test_coordinator_weight_source_v2.py tests/test_exact_commit_restart_v2.py tests/test_research_lab_champion_replay.py tests/test_validator_protected_workflows_v2.py tests/test_validator_weight_authority_v2.py tests/test_validator_weight_differential.py tests/test_weight_authority_v2.py tests/test_weight_bundle_v2` → `111 passed`
- Selected canonical tests with local Bittensor import stub → `5 passed`

## Deployment note

This is a coordinated gateway + validator weight-path change. Setting the env var on an old runtime will not affect production; the patched gateway/coordinator and validator/canonical code must be released together before setting `FULFILLMENT_LEADERBOARD_EMISSIONS_ENABLED=false`.
