### PR TITLE
Stop provider checkpoint contention amplification

### DIFF
--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -682,7 +682,7 @@
       "symbol": "provider_registry_document"
     },
     {
-      "ast_sha256": "sha256:ce39b42e2bc49b89e22d37cee1189d2ec8749c03abd4ee9c0b6afc62f8544a78",
+      "ast_sha256": "sha256:9608f9a644a2c6301370b2118a7e5c9cdb27b7c65aaf46aea0af8295b4fac0f7",
       "path": "gateway/tee/provider_semantics_v2.py",
       "symbol": "ProviderSemanticsAuthorityV2"
     },
@@ -1262,7 +1262,7 @@
       "symbol": "validate_source_add_reward_record"
     }
   ],
-  "manifest_hash": "sha256:82fe12a10bab6682a446e501bb5064786740637d70a65d766e60c807be66dad7",
+  "manifest_hash": "sha256:90d32aa0ea6657ff66725aaf4dfe315972c6312768e44cc7f5005819c00e3395",
   "protected_source_commit": "243db83f115f4f1497b9640f5ebaf7d97e483b84",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/provider_outcome_store_v2.py
+++ b/gateway/tee/provider_outcome_store_v2.py
@@ -150,13 +150,43 @@ class ProviderOutcomeStoreV2:
             purpose=purpose,
         )
         self._collect_evidence(result, attempts, transport_artifacts)
-        if self._append_conflicted(result):
+        append_result = self._append_result(
+            result,
+            expected_checkpoint_hash=payload["checkpoint_hash"],
+        )
+        append_status = str(append_result["status"])
+        if append_status == "busy":
             self._vault.release_transient(str(descriptor["artifact_id"]))
             return {
+                "status": "busy",
+                "transport_attempts": attempts,
+                "evidence_artifact_hashes": sorted(transport_artifacts),
+            }
+        if append_status == "conflict":
+            conflict_result: Dict[str, Any] = {
                 "status": "conflict",
                 "transport_attempts": attempts,
                 "evidence_artifact_hashes": sorted(transport_artifacts),
             }
+            head_row = append_result.get("head_checkpoint_row")
+            if isinstance(head_row, Mapping):
+                restored = self._restore_row(
+                    head_row,
+                    expected_utc_day=utc_day,
+                    attempts=attempts,
+                    artifacts=transport_artifacts,
+                )
+                conflict_result.update(
+                    {
+                        "head_checkpoint_hash": restored["checkpoint_hash"],
+                        "head_state_document": restored["state_document"],
+                        "evidence_artifact_hashes": restored[
+                            "evidence_artifact_hashes"
+                        ],
+                    }
+                )
+            self._vault.release_transient(str(descriptor["artifact_id"]))
+            return conflict_result
         rows, read_attempts, read_artifacts = self._read_rows(
             utc_day=utc_day,
             sequence=sequence,
@@ -168,7 +198,7 @@ class ProviderOutcomeStoreV2:
         attempts.extend(read_attempts)
         transport_artifacts.update(read_artifacts)
         if len(rows) != 1 or rows[0] != row:
-            if rows or self._append_conflicted(result):
+            if rows:
                 self._vault.release_transient(str(descriptor["artifact_id"]))
                 return {
                     "status": "conflict",
@@ -232,7 +262,22 @@ class ProviderOutcomeStoreV2:
             raise ProviderOutcomeStoreV2Error(
                 "provider outcome latest checkpoint is ambiguous"
             )
-        row = self._validate_row(rows[0])
+        return self._restore_row(
+            rows[0],
+            expected_utc_day=normalized_day,
+            attempts=attempts,
+            artifacts=artifacts,
+        )
+
+    def _restore_row(
+        self,
+        value: Mapping[str, Any],
+        *,
+        expected_utc_day: str,
+        attempts: list[Dict[str, Any]],
+        artifacts: set[str],
+    ) -> Dict[str, Any]:
+        row = self._validate_row(value)
         plaintext = self._vault.decrypt_storage_document(
             row["encrypted_checkpoint_doc"]
         )
@@ -248,7 +293,7 @@ class ProviderOutcomeStoreV2:
             )
         normalized_payload = self._validate_payload(payload)
         if (
-            normalized_payload["utc_day"] != normalized_day
+            normalized_payload["utc_day"] != expected_utc_day
             or normalized_payload["sequence"] != row["sequence"]
             or normalized_payload["checkpoint_hash"] != row["checkpoint_hash"]
             or normalized_payload["previous_checkpoint_hash"]
@@ -285,18 +330,69 @@ class ProviderOutcomeStoreV2:
         }
 
     @staticmethod
-    def _append_conflicted(result: Mapping[str, Any]) -> bool:
+    def _append_result(
+        result: Mapping[str, Any],
+        *,
+        expected_checkpoint_hash: str,
+    ) -> Dict[str, Any]:
         if result.get("terminal_status") != "authenticated_response":
-            return False
+            return {"status": "ambiguous"}
+        attempt = result.get("transport_attempt")
         try:
             body = base64.b64decode(
                 str(result.get("body_b64") or ""),
                 validate=True,
             )
             parsed = json.loads(body.decode("utf-8"))
-        except Exception:
-            return False
-        return isinstance(parsed, Mapping) and str(parsed.get("code") or "") == "40001"
+        except Exception as exc:
+            raise ProviderOutcomeStoreV2Error(
+                "provider outcome checkpoint append response is invalid"
+            ) from exc
+        if (
+            not isinstance(attempt, Mapping)
+            or sha256_bytes(body) != str(attempt.get("response_hash") or "")
+            or not isinstance(parsed, Mapping)
+        ):
+            raise ProviderOutcomeStoreV2Error(
+                "provider outcome checkpoint append response commitments differ"
+            )
+        http_status = int(result.get("http_status") or 0)
+        if not 200 <= http_status < 300:
+            if str(parsed.get("code") or "") == "40001":
+                return {"status": "conflict"}
+            raise ProviderOutcomeStoreV2Error(
+                "provider outcome checkpoint authenticated append failed "
+                "(http_status=%d code=%s)"
+                % (http_status, str(parsed.get("code") or "none"))
+            )
+        status = str(parsed.get("status") or "")
+        if status in {"inserted", "existing"}:
+            if (
+                set(parsed) != {"status", "checkpoint_hash"}
+                or _hash(parsed.get("checkpoint_hash"), "append checkpoint hash")
+                != expected_checkpoint_hash
+            ):
+                raise ProviderOutcomeStoreV2Error(
+                    "provider outcome checkpoint append result differs"
+                )
+            return {"status": status}
+        if status == "busy" and set(parsed) == {"status"}:
+            return {"status": "busy"}
+        if (
+            status == "conflict"
+            and set(parsed) == {"status", "head_checkpoint_row"}
+            and (
+                parsed.get("head_checkpoint_row") is None
+                or isinstance(parsed.get("head_checkpoint_row"), Mapping)
+            )
+        ):
+            return {
+                "status": "conflict",
+                "head_checkpoint_row": parsed.get("head_checkpoint_row"),
+            }
+        raise ProviderOutcomeStoreV2Error(
+            "provider outcome checkpoint append status is invalid"
+        )
 
     def _validate_payload(self, value: Mapping[str, Any]) -> Dict[str, Any]:
         fields = {

--- a/gateway/tee/provider_semantics_v2.py
+++ b/gateway/tee/provider_semantics_v2.py
@@ -80,9 +80,9 @@ _REQUEST_FIELDS = {
 _OPTIONAL_REQUEST_FIELDS = {"dynamic_route"}
 _LOCAL_RESPONSE_SCHEMA_VERSION = "leadpoet.attested_local_provider_response.v2"
 _PROVIDER_PREFLIGHT_PURPOSE = "research_lab.provider_preflight.v2"
-_OUTCOME_APPEND_CONFLICT_ATTEMPTS = 64
-_OUTCOME_CONFLICT_BACKOFF_BASE_SECONDS = 0.01
-_OUTCOME_CONFLICT_BACKOFF_MAX_SECONDS = 0.25
+_OUTCOME_APPEND_CONFLICT_ATTEMPTS = 32
+_OUTCOME_CONFLICT_BACKOFF_BASE_SECONDS = 0.02
+_OUTCOME_CONFLICT_BACKOFF_MAX_SECONDS = 0.5
 TREE_PROVIDER_CALL_CAP_HEADER = "X-Research-Lab-Tree-Provider-Call-Cap"
 _LEGACY_PROVIDER_IDS = {
     "openrouter": "or",
@@ -608,12 +608,14 @@ class ProviderSemanticsAuthorityV2:
                         "transport_attempts": attempts,
                         "evidence_artifact_hashes": sorted(artifacts),
                     }
-                if status != "conflict":
+                if status not in {"busy", "conflict"}:
                     self._outcome_ledger.restore(base_document)
                     raise ProviderSemanticsV2Error(
                         "provider outcome checkpoint status is invalid"
                     )
                 self._outcome_ledger.restore(base_document)
+                if conflict_attempt + 1 >= _OUTCOME_APPEND_CONFLICT_ATTEMPTS:
+                    break
                 self._sleep(
                     _outcome_conflict_backoff_seconds(
                         job_id=job_id,
@@ -621,6 +623,17 @@ class ProviderSemanticsAuthorityV2:
                         conflict_attempt=conflict_attempt,
                     )
                 )
+                if status == "busy":
+                    continue
+                head_document = persisted.get("head_state_document")
+                head_checkpoint_hash = str(
+                    persisted.get("head_checkpoint_hash") or ""
+                )
+                if isinstance(head_document, Mapping) and head_checkpoint_hash:
+                    base_document = self._outcome_ledger.restore(head_document)
+                    self._outcome_checkpoint_hash = head_checkpoint_hash
+                    self._outcome_checkpoint_day = utc_day
+                    continue
                 try:
                     restored = dict(
                         self._outcome_store.load_latest(

--- a/gateway/tee/supabase_schema_preflight_v2.py
+++ b/gateway/tee/supabase_schema_preflight_v2.py
@@ -255,7 +255,7 @@ REQUIRED_SUPABASE_V2_RPCS = (
         "research_lab_attested_transport_terminal_contract_v2",
     ),
     (
-        "scripts/131-research-lab-provider-outcome-backpressure.sql",
+        "scripts/133-research-lab-provider-outcome-contention-contract.sql",
         "append_research_lab_provider_outcome_checkpoint_v2",
     ),
     (

--- a/scripts/133-research-lab-provider-outcome-contention-contract.sql
+++ b/scripts/133-research-lab-provider-outcome-contention-contract.sql
@@ -1,0 +1,170 @@
+-- Make expected provider-outcome contention a non-exceptional RPC contract.
+--
+-- Migration 131 made the lineage lock non-blocking, but represented both a
+-- held lock and a stale lineage head as SQLSTATE 40001. Under rolling restart
+-- overlap, every rejected append therefore rolled back a transaction and the
+-- gateway performed a separate read to discover the durable head. Return
+-- authenticated JSON outcomes instead: busy callers back off without reading,
+-- while stale callers receive the encrypted durable head needed to rebase.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.append_research_lab_provider_outcome_checkpoint_v2(
+    checkpoint_row JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+    required_fields CONSTANT TEXT[] := ARRAY[
+        'schema_version',
+        'artifact_master_key_ref_hash',
+        'utc_day',
+        'sequence',
+        'checkpoint_hash',
+        'previous_checkpoint_hash',
+        'state_document_hash',
+        'checkpoint_artifact_id',
+        'encrypted_checkpoint_doc'
+    ];
+    key_ref_hash TEXT;
+    checkpoint_day DATE;
+    checkpoint_sequence BIGINT;
+    incoming_checkpoint_hash TEXT;
+    incoming_previous_hash TEXT;
+    current_row JSONB;
+    current_sequence BIGINT;
+    current_checkpoint_hash TEXT;
+    existing_row JSONB;
+    inserted_row JSONB;
+BEGIN
+    IF jsonb_typeof(checkpoint_row) IS DISTINCT FROM 'object'
+       OR NOT checkpoint_row ?& required_fields
+       OR (
+           SELECT pg_catalog.count(*)
+           FROM pg_catalog.jsonb_object_keys(checkpoint_row)
+       ) <> cardinality(required_fields)
+    THEN
+        RAISE EXCEPTION 'provider outcome checkpoint fields are invalid'
+            USING ERRCODE = '22023';
+    END IF;
+
+    key_ref_hash := checkpoint_row->>'artifact_master_key_ref_hash';
+    checkpoint_day := (checkpoint_row->>'utc_day')::DATE;
+    checkpoint_sequence := (checkpoint_row->>'sequence')::BIGINT;
+    incoming_checkpoint_hash := checkpoint_row->>'checkpoint_hash';
+    incoming_previous_hash := COALESCE(
+        checkpoint_row->>'previous_checkpoint_hash',
+        ''
+    );
+
+    IF key_ref_hash !~ '^sha256:[0-9a-f]{64}$'
+       OR incoming_checkpoint_hash !~ '^sha256:[0-9a-f]{64}$'
+       OR checkpoint_sequence <= 0
+    THEN
+        RAISE EXCEPTION 'provider outcome checkpoint identity is invalid'
+            USING ERRCODE = '22023';
+    END IF;
+
+    IF NOT pg_catalog.pg_try_advisory_xact_lock(
+        pg_catalog.hashtext('research_lab_provider_outcome_checkpoint_v2'),
+        pg_catalog.hashtext(key_ref_hash || ':' || checkpoint_day::TEXT)
+    ) THEN
+        RETURN pg_catalog.jsonb_build_object('status', 'busy');
+    END IF;
+
+    SELECT pg_catalog.to_jsonb(c) - 'created_at'
+      INTO existing_row
+      FROM public.research_lab_provider_outcome_checkpoints_v2 c
+     WHERE c.checkpoint_hash = incoming_checkpoint_hash;
+
+    IF existing_row IS NOT NULL THEN
+        IF existing_row IS DISTINCT FROM checkpoint_row THEN
+            RAISE EXCEPTION 'provider outcome checkpoint hash already identifies another row'
+                USING ERRCODE = '23505';
+        END IF;
+        RETURN pg_catalog.jsonb_build_object(
+            'status', 'existing',
+            'checkpoint_hash', incoming_checkpoint_hash
+        );
+    END IF;
+
+    SELECT
+        pg_catalog.to_jsonb(c) - 'created_at',
+        c.sequence,
+        c.checkpoint_hash
+      INTO current_row, current_sequence, current_checkpoint_hash
+      FROM public.research_lab_provider_outcome_checkpoints_v2 c
+     WHERE c.artifact_master_key_ref_hash = key_ref_hash
+       AND c.utc_day = checkpoint_day
+     ORDER BY c.sequence DESC
+     LIMIT 1;
+
+    IF current_sequence IS NULL THEN
+        IF checkpoint_sequence <> 1 OR incoming_previous_hash <> '' THEN
+            RETURN pg_catalog.jsonb_build_object(
+                'status', 'conflict',
+                'head_checkpoint_row', NULL
+            );
+        END IF;
+    ELSIF checkpoint_sequence <> current_sequence + 1
+       OR incoming_previous_hash <> current_checkpoint_hash
+    THEN
+        RETURN pg_catalog.jsonb_build_object(
+            'status', 'conflict',
+            'head_checkpoint_row', current_row
+        );
+    END IF;
+
+    INSERT INTO public.research_lab_provider_outcome_checkpoints_v2 (
+        schema_version,
+        artifact_master_key_ref_hash,
+        utc_day,
+        sequence,
+        checkpoint_hash,
+        previous_checkpoint_hash,
+        state_document_hash,
+        checkpoint_artifact_id,
+        encrypted_checkpoint_doc
+    )
+    VALUES (
+        checkpoint_row->>'schema_version',
+        key_ref_hash,
+        checkpoint_day,
+        checkpoint_sequence,
+        incoming_checkpoint_hash,
+        incoming_previous_hash,
+        checkpoint_row->>'state_document_hash',
+        checkpoint_row->>'checkpoint_artifact_id',
+        checkpoint_row->'encrypted_checkpoint_doc'
+    );
+
+    SELECT pg_catalog.to_jsonb(c) - 'created_at'
+      INTO inserted_row
+      FROM public.research_lab_provider_outcome_checkpoints_v2 c
+     WHERE c.checkpoint_hash = incoming_checkpoint_hash;
+
+    IF inserted_row IS DISTINCT FROM checkpoint_row THEN
+        RAISE EXCEPTION 'provider outcome checkpoint durable insert differs'
+            USING ERRCODE = '23514';
+    END IF;
+
+    RETURN pg_catalog.jsonb_build_object(
+        'status', 'inserted',
+        'checkpoint_hash', incoming_checkpoint_hash
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.append_research_lab_provider_outcome_checkpoint_v2(JSONB)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.append_research_lab_provider_outcome_checkpoint_v2(JSONB)
+    TO service_role;
+
+COMMENT ON FUNCTION public.append_research_lab_provider_outcome_checkpoint_v2(JSONB) IS
+    'Atomically extends one encrypted provider-outcome lineage and returns non-exceptional busy/conflict backpressure with the durable head.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/tests/restart_rehearsal/postgres_v2_contract_probe.py
+++ b/tests/restart_rehearsal/postgres_v2_contract_probe.py
@@ -67,6 +67,9 @@ PROVIDER_OUTCOME_APPEND_MIGRATION = (
 PROVIDER_OUTCOME_BACKPRESSURE_MIGRATION = (
     "131-research-lab-provider-outcome-backpressure.sql"
 )
+PROVIDER_OUTCOME_CONTENTION_CONTRACT_MIGRATION = (
+    "133-research-lab-provider-outcome-contention-contract.sql"
+)
 CHAMPION_LIFETIME_CREDIT_MIGRATION = (
     "132-research-lab-champion-lifetime-credit.sql"
 )
@@ -355,6 +358,19 @@ def _provider_outcome_append_contract(
 ) -> dict[str, Any]:
     key_hash = "sha256:" + "a" * 64
 
+    def rollback_count() -> int:
+        database.psql("SELECT pg_catalog.pg_stat_clear_snapshot();")
+        return int(
+            database.psql(
+                """
+                SELECT xact_rollback
+                FROM pg_catalog.pg_stat_database
+                WHERE datname = pg_catalog.current_database();
+                """,
+                tuples_only=True,
+            ).stdout.strip()
+        )
+
     def row(
         *,
         sequence: int,
@@ -404,6 +420,7 @@ def _provider_outcome_append_contract(
         raise PostgresContractProbeError(
             "provider outcome idempotent append result differs"
         )
+    rollback_count_before_contention = rollback_count()
 
     siblings = (
         row(
@@ -430,21 +447,29 @@ def _provider_outcome_append_contract(
                 siblings,
             )
         )
-    accepted = [result for result in results if result.returncode == 0]
-    rejected = [result for result in results if result.returncode != 0]
+    if any(result.returncode != 0 for result in results):
+        raise PostgresContractProbeError(
+            "provider outcome expected contention raised an exception"
+        )
+    parsed_results = [json.loads(result.stdout.strip()) for result in results]
+    accepted = [
+        result for result in parsed_results if result.get("status") == "inserted"
+    ]
+    rejected = [
+        result
+        for result in parsed_results
+        if result.get("status") in {"busy", "conflict"}
+    ]
     if len(accepted) != 1 or len(rejected) != 1:
         raise PostgresContractProbeError(
             "provider outcome concurrent append did not select one head"
         )
-    if not any(
-        marker in rejected[0].stderr
-        for marker in (
-            "does not extend the current head",
-            "checkpoint append is busy",
-        )
+    if rejected[0]["status"] == "conflict" and not isinstance(
+        rejected[0].get("head_checkpoint_row"),
+        Mapping,
     ):
         raise PostgresContractProbeError(
-            "provider outcome stale append failed for the wrong reason"
+            "provider outcome stale append omitted its durable head"
         )
     row_count = int(
         database.psql(
@@ -463,7 +488,7 @@ def _provider_outcome_append_contract(
             "provider outcome lineage contains an unexpected row count"
         )
 
-    accepted_hash = json.loads(accepted[0].stdout.strip())["checkpoint_hash"]
+    accepted_hash = accepted[0]["checkpoint_hash"]
     third_hash = "sha256:" + "2" * 64
     third = row(
         sequence=3,
@@ -481,7 +506,7 @@ def _provider_outcome_append_contract(
             )
         );
         SELECT pg_catalog.pg_sleep(2);
-        ROLLBACK;
+        COMMIT;
     """
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         holder = executor.submit(database.psql, lock_sql)
@@ -507,13 +532,13 @@ def _provider_outcome_append_contract(
         started = time.monotonic()
         busy = database.psql(
             _provider_outcome_append_sql(third),
-            check=False,
             tuples_only=True,
         )
         busy_elapsed = time.monotonic() - started
-        if busy.returncode == 0 or "checkpoint append is busy" not in busy.stderr:
+        busy_result = json.loads(busy.stdout.strip())
+        if busy_result != {"status": "busy"}:
             raise PostgresContractProbeError(
-                "provider outcome contention did not fail with the busy contract"
+                "provider outcome contention did not return the busy contract"
             )
         if busy_elapsed >= 1.0:
             raise PostgresContractProbeError(
@@ -534,6 +559,11 @@ def _provider_outcome_append_contract(
         raise PostgresContractProbeError(
             "provider outcome append did not recover after contention"
         )
+    rollback_count_after_contention = rollback_count()
+    if rollback_count_after_contention != rollback_count_before_contention:
+        raise PostgresContractProbeError(
+            "provider outcome expected contention rolled back a transaction"
+        )
     return {
         "first_checkpoint_hash": first_hash,
         "candidate_sibling_hashes": sorted(
@@ -542,6 +572,10 @@ def _provider_outcome_append_contract(
         "accepted_count": len(accepted),
         "rejected_count": len(rejected),
         "row_count": row_count + 1,
+        "contention_rollback_delta": (
+            rollback_count_after_contention
+            - rollback_count_before_contention
+        ),
     }
 
 
@@ -1188,6 +1222,10 @@ def _run_probe(args: argparse.Namespace) -> dict[str, Any]:
             scripts / PROVIDER_OUTCOME_BACKPRESSURE_MIGRATION
         )
         applied.append(PROVIDER_OUTCOME_BACKPRESSURE_MIGRATION)
+        database.apply_migration(
+            scripts / PROVIDER_OUTCOME_CONTENTION_CONTRACT_MIGRATION
+        )
+        applied.append(PROVIDER_OUTCOME_CONTENTION_CONTRACT_MIGRATION)
         provider_outcome_append = _provider_outcome_append_contract(database)
 
         rows, verified, fixture = _settlement_fixture(

--- a/tests/test_gateway_restart_preflight_v2.py
+++ b/tests/test_gateway_restart_preflight_v2.py
@@ -494,7 +494,7 @@ def test_required_supabase_v2_schema_probes_tables_and_columns() -> None:
         "scripts/127-research-lab-chain-unattributed-settlement.sql",
         "scripts/128-research-lab-chain-settlement-transport-purposes.sql",
         "scripts/129-research-lab-attested-local-transport.sql",
-        "scripts/131-research-lab-provider-outcome-backpressure.sql",
+        "scripts/133-research-lab-provider-outcome-contention-contract.sql",
         "scripts/132-research-lab-champion-lifetime-credit.sql",
     }.issubset(set(result["migration_files"]))
     assert "service-role-value" not in str(result)
@@ -656,7 +656,7 @@ def test_required_supabase_v2_schema_requires_provider_outcome_append_migration(
         schema_preflight.SupabaseSchemaPreflightV2Error,
         match=(
             r"append_research_lab_provider_outcome_checkpoint_v2.*"
-            r"131-research-lab-provider-outcome-backpressure"
+            r"133-research-lab-provider-outcome-contention-contract"
         ),
     ):
         schema_preflight.verify_required_supabase_v2_schema(

--- a/tests/test_provider_outcome_store_v2.py
+++ b/tests/test_provider_outcome_store_v2.py
@@ -33,6 +33,9 @@ class _Broker:
         self.calls = []
         self.fail_reads = False
         self.fail_committed_appends = 0
+        self.busy_appends = 0
+        self.append_http_failure = None
+        self.legacy_conflicts = False
 
     def execute(self, request):
         self.calls.append(dict(request))
@@ -40,6 +43,20 @@ class _Broker:
         if request["method"] == "POST":
             payload = json.loads(base64.b64decode(request["body_b64"]))
             row = payload["checkpoint_row"]
+            if self.append_http_failure is not None:
+                status, code = self.append_http_failure
+                return self._result(
+                    request,
+                    status=status,
+                    body=json.dumps({"code": code}).encode(),
+                )
+            if self.busy_appends > 0:
+                self.busy_appends -= 1
+                return self._result(
+                    request,
+                    status=200,
+                    body=b'{"status":"busy"}',
+                )
             lineage = (
                 row["artifact_master_key_ref_hash"],
                 row["utc_day"],
@@ -62,7 +79,14 @@ class _Broker:
                 return self._result(
                     request,
                     status=200,
-                    body=b'{"status":"existing"}',
+                    body=json.dumps(
+                        {
+                            "status": "existing",
+                            "checkpoint_hash": row["checkpoint_hash"],
+                        },
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode(),
                 )
             current = sorted(
                 (
@@ -79,6 +103,21 @@ class _Broker:
                 int(row["sequence"]) != expected_sequence
                 or row["previous_checkpoint_hash"] != expected_previous
             ):
+                if not self.legacy_conflicts:
+                    return self._result(
+                        request,
+                        status=200,
+                        body=json.dumps(
+                            {
+                                "status": "conflict",
+                                "head_checkpoint_row": (
+                                    current[0] if current else None
+                                ),
+                            },
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ).encode(),
+                    )
                 return self._result(
                     request,
                     status=409,
@@ -97,7 +136,14 @@ class _Broker:
             return self._result(
                 request,
                 status=200,
-                body=b'{"status":"inserted"}',
+                body=json.dumps(
+                    {
+                        "status": "inserted",
+                        "checkpoint_hash": row["checkpoint_hash"],
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode(),
             )
         if self.fail_reads:
             return self._failure(request)
@@ -278,10 +324,84 @@ def test_outcome_checkpoint_chain_is_monotonic_and_collision_fails_closed() -> N
         purpose="research_lab.company_score.v2",
     )
     assert conflict["status"] == "conflict"
+    assert conflict["head_checkpoint_hash"] == second["checkpoint_hash"]
+    assert conflict["head_state_document"]["sequence"] == 2
     assert len(conflict["transport_attempts"]) == 1
     assert len(broker.calls) == 6
     assert vault.job_artifacts(
         job_id="job-3",
+        purpose="research_lab.company_score.v2",
+    ) == ()
+
+
+def test_outcome_checkpoint_busy_does_not_issue_readback() -> None:
+    broker = _Broker()
+    broker.busy_appends = 1
+    vault = _vault()
+    store = ProviderOutcomeStoreV2(broker=broker, vault=vault)
+
+    result = store.persist(
+        _document(),
+        previous_checkpoint_hash="",
+        job_id="job-busy",
+        purpose="research_lab.company_score.v2",
+    )
+
+    assert result["status"] == "busy"
+    assert len(result["transport_attempts"]) == 1
+    assert [call["method"] for call in broker.calls] == ["POST"]
+    assert vault.job_artifacts(
+        job_id="job-busy",
+        purpose="research_lab.company_score.v2",
+    ) == ()
+
+
+def test_outcome_checkpoint_supports_legacy_40001_during_rolling_upgrade() -> None:
+    broker = _Broker()
+    store = ProviderOutcomeStoreV2(broker=broker, vault=_vault())
+    first = store.persist(
+        _document(),
+        previous_checkpoint_hash="",
+        job_id="job-first",
+        purpose="research_lab.company_score.v2",
+    )
+    broker.legacy_conflicts = True
+
+    conflict = store.persist(
+        _document("2026-07-10T12:00:01Z"),
+        previous_checkpoint_hash=first["checkpoint_hash"],
+        job_id="job-legacy",
+        purpose="research_lab.company_score.v2",
+    )
+
+    assert conflict["status"] == "conflict"
+    assert "head_state_document" not in conflict
+    assert broker.calls[-1]["method"] == "POST"
+
+
+def test_outcome_checkpoint_postgrest_unavailable_fails_without_read_amplification() -> None:
+    broker = _Broker()
+    broker.append_http_failure = (503, "PGRST002")
+    vault = _vault()
+    store = ProviderOutcomeStoreV2(broker=broker, vault=vault)
+
+    with pytest.raises(
+        ProviderOutcomeStoreV2Error,
+        match=(
+            "authenticated append failed "
+            r"\(http_status=503 code=PGRST002\)"
+        ),
+    ):
+        store.persist(
+            _document(),
+            previous_checkpoint_hash="",
+            job_id="job-unavailable",
+            purpose="research_lab.company_score.v2",
+        )
+
+    assert [call["method"] for call in broker.calls] == ["POST"]
+    assert vault.job_artifacts(
+        job_id="job-unavailable",
         purpose="research_lab.company_score.v2",
     ) == ()
 

--- a/tests/test_provider_outcome_store_v2_sql.py
+++ b/tests/test_provider_outcome_store_v2_sql.py
@@ -3,6 +3,9 @@ from pathlib import Path
 
 SQL = Path("scripts/90-research-lab-provider-outcome-checkpoints-v2.sql")
 APPEND_SQL = Path("scripts/131-research-lab-provider-outcome-backpressure.sql")
+CONTENTION_SQL = Path(
+    "scripts/133-research-lab-provider-outcome-contention-contract.sql"
+)
 
 
 def test_provider_outcome_checkpoint_migration_is_append_only_and_private() -> None:
@@ -41,6 +44,23 @@ def test_provider_outcome_checkpoint_append_is_atomic_and_private() -> None:
     assert "checkpoint_sequence <> current_sequence + 1" in text
     assert "incoming_previous_hash <> current_checkpoint_hash" in text
     assert "ERRCODE = '40001'" in text
+    assert "GRANT EXECUTE" in text
+    assert "TO service_role" in text
+    assert "FROM PUBLIC, anon, authenticated" in text
+    assert "UPDATE public.research_lab_provider_outcome_checkpoints_v2" not in text
+    assert "DELETE FROM public.research_lab_provider_outcome_checkpoints_v2" not in text
+
+
+def test_provider_outcome_contention_is_a_nonexceptional_authenticated_contract() -> None:
+    text = CONTENTION_SQL.read_text()
+    assert "append_research_lab_provider_outcome_checkpoint_v2" in text
+    assert "pg_try_advisory_xact_lock" in text
+    assert "jsonb_build_object('status', 'busy')" in text
+    assert "'status', 'conflict'" in text
+    assert "'head_checkpoint_row', current_row" in text
+    assert "provider outcome checkpoint append is busy" not in text
+    assert "ERRCODE = '40001'" not in text
+    assert "pg_advisory_xact_lock(" not in text
     assert "GRANT EXECUTE" in text
     assert "TO service_role" in text
     assert "FROM PUBLIC, anon, authenticated" in text

--- a/tests/test_provider_semantics_v2.py
+++ b/tests/test_provider_semantics_v2.py
@@ -648,7 +648,7 @@ def test_provider_outcome_busy_empty_head_backs_off_and_retries() -> None:
             if self.busy:
                 self.busy = False
                 return {
-                    "status": "conflict",
+                    "status": "busy",
                     "transport_attempts": [],
                     "evidence_artifact_hashes": [],
                 }
@@ -672,7 +672,7 @@ def test_provider_outcome_busy_empty_head_backs_off_and_retries() -> None:
     assert outcome_store.persist_count == 1
     assert outcome_store.document["sequence"] == 1
     assert len(sleeps) == 1
-    assert 0.01 <= sleeps[0] <= 0.02
+    assert 0.02 <= sleeps[0] <= 0.04
 
 
 def test_provider_outcome_persistent_contention_is_bounded_and_fails_closed() -> None:
@@ -693,7 +693,7 @@ def test_provider_outcome_persistent_contention_is_bounded_and_fails_closed() ->
             del document, previous_checkpoint_hash, job_id, purpose
             self.persist_attempts += 1
             return {
-                "status": "conflict",
+                "status": "busy",
                 "transport_attempts": [],
                 "evidence_artifact_hashes": [],
             }
@@ -727,9 +727,9 @@ def test_provider_outcome_persistent_contention_is_bounded_and_fails_closed() ->
     ):
         authority.execute(_request(job_id="job-persistent-contention"))
 
-    assert outcome_store.persist_attempts == 64
-    assert outcome_store.load_attempts == 65  # one startup restore plus 64 retries
-    assert len(sleeps) == 64
+    assert outcome_store.persist_attempts == 32
+    assert outcome_store.load_attempts == 1  # startup restore only
+    assert len(sleeps) == 31
     assert (
         authority.provider_outcome_snapshot()["provider_outcome_digest"].get(
             "providers", {}
@@ -850,6 +850,78 @@ def test_provider_outcome_contention_converges_across_25_writers() -> None:
     assert outcome_store.persist_count == writer_count
     assert outcome_store.document["sequence"] == writer_count
     assert outcome_store.document["totals"]["call_count"] == writer_count
+
+
+def test_provider_outcome_structured_conflict_rebases_without_head_read() -> None:
+    class EmbeddedHeadOutcomeStore(_OutcomeStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.load_attempts = 0
+
+        def load_latest(
+            self,
+            *,
+            utc_day,
+            job_id,
+            purpose,
+            operation_suffix="restore",
+        ):
+            self.load_attempts += 1
+            return super().load_latest(
+                utc_day=utc_day,
+                job_id=job_id,
+                purpose=purpose,
+                operation_suffix=operation_suffix,
+            )
+
+        def persist(
+            self,
+            document,
+            *,
+            previous_checkpoint_hash,
+            job_id,
+            purpose,
+        ):
+            result = super().persist(
+                document,
+                previous_checkpoint_hash=previous_checkpoint_hash,
+                job_id=job_id,
+                purpose=purpose,
+            )
+            if result["status"] == "conflict":
+                return {
+                    **result,
+                    "head_checkpoint_hash": self.checkpoint_hash,
+                    "head_state_document": dict(self.document),
+                }
+            return result
+
+    outcome_store = EmbeddedHeadOutcomeStore()
+    first, _broker, _cache, _artifacts = _authority(
+        outcome_store=outcome_store
+    )
+    stale, _broker, _cache, _artifacts = _authority(
+        outcome_store=outcome_store
+    )
+    assert outcome_store.load_attempts == 2
+
+    first.execute(_request(job_id="job-embedded-first"))
+    stale.execute(
+        _request(
+            job_id="job-embedded-stale",
+            logical_operation_id="provider-operation-embedded-stale",
+            body=b'{"query":"embedded-second"}',
+        )
+    )
+
+    assert outcome_store.load_attempts == 2
+    assert outcome_store.document["sequence"] == 2
+    assert (
+        stale.provider_outcome_snapshot()["provider_outcome_digest"]["providers"][
+            "exa"
+        ]["call_count"]
+        == 2
+    )
 
 
 def test_provider_outcome_rollback_preserves_original_error_across_midnight() -> None:


### PR DESCRIPTION
## Summary

- return authenticated `busy` and `conflict` checkpoint outcomes as normal RPC results instead of expected transaction aborts
- remove read-after-conflict amplification by carrying the durable encrypted head in structured conflict responses
- bound coordinator retries and apply contention backoff without additional head reads
- retain compatibility with legacy SQLSTATE `40001` responses during rolling upgrades
- extend the restart/Postgres contract probe to require zero rollback growth during expected contention

## Root cause

Production was running an older coordinator against a newer provider-outcome checkpoint contract. Concurrent checkpoint writers could enter a 64-attempt conflict loop, and every conflict performed another head read. This amplified normal contention into approximately 8,700 transaction rollbacks per second, starved PostgREST/database capacity, and surfaced as HTTP 504s in the admin dashboard.

## Impact

Expected checkpoint contention no longer creates rollback storms or read amplification. Ambiguous transport-after-commit cases still perform the required reconciliation read, while database-unavailable responses fail fast.

## Validation

- `49 passed` across provider-outcome store, SQL contract, coordinator semantics, schema preflight, and protected-workflow tests
- full Python `compileall` passed
- protected-workflow manifest regeneration and verification passed
- `git diff --check` passed
- Python 3.7 finalization probe passed
- drand rehearsal stages passed

## Remaining release gate

The exact N-1-to-N release rehearsal was attempted but could not complete on the current host:

- release profile requires 6 Docker CPUs; Colima exposes 4
- the host data volume reached 100% capacity with only ~124 MiB free
- Docker then failed with a `containerd metadata.db: input/output error`

A broader host suite reached 473 passing tests before disk exhaustion prevented pytest from creating temporary directories, so that run is not treated as release evidence.

Before deployment, free disk space, provide the required 6 Docker CPUs, and rerun the exact restart rehearsal from deployed commit `652cad29b833b91bd28e42e9fcf87cea305aa148` to candidate `869715f21615924446e7e3f9428878db619a34a4`.
