### PR TITLE
Fit weight submission inside degraded gateway latency

### DIFF
--- a/leadpoet_canonical/constants.py
+++ b/leadpoet_canonical/constants.py
@@ -20,10 +20,17 @@ model and must be coordinated across all deployments.
 EPOCH_LENGTH = 360
 
 # Block within the official subnet epoch when current-epoch weight authority
-# preparation and submission begin. Starting at block 300 leaves 60 blocks for
-# measured input reconstruction, bounded retries, chain finalization, and
-# current-epoch auditor mirroring.
-WEIGHT_SUBMISSION_BLOCK = 300
+# preparation and submission begin. Starting at block 240 leaves 120 blocks
+# (~24 minutes at 12s blocks) for measured input reconstruction, enclave
+# signing, durable gateway publication, bounded retries, chain finalization,
+# and current-epoch auditor mirroring. The 2026-07-30/31 outage (epochs
+# 24256-24270) measured the degraded end-to-end pipeline at ~947s (~79
+# blocks); the previous 60-block window closed the official epoch before the
+# extrinsic staleness gate every time, so signed bundles published durably
+# in-epoch but no set_weights reached the chain. The gateway's acceptance
+# windows derive from this constant, so the gateway must deploy at or before
+# the validator when this value changes.
+WEIGHT_SUBMISSION_BLOCK = 240
 
 # Begin the expensive, deterministic Research Lab allocation preparation well
 # before the submission window. This does not authorize or publish weights; it

--- a/tests/test_gateway_weight_inputs_client_v2.py
+++ b/tests/test_gateway_weight_inputs_client_v2.py
@@ -306,6 +306,99 @@ async def test_client_retries_gateway_500_with_same_authorization(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_client_attempt_budget_covers_slowest_observed_build(monkeypatch):
+    """Regression: 2026-07-31 epochs 24265-24266.
+
+    The gateway singleflight build took ~700s while each client attempt
+    timed out at 90s. The previous four-attempt budget (~374s of coverage)
+    exhausted mid-build, the caller restarted the flow, and every restart
+    forced a fresh build (24 receipts per epoch instead of 8). The budget
+    must keep re-attaching until the cached success is available.
+    """
+    monkeypatch.setattr(client_module, "validate_boot_identity", lambda _value: None)
+    monkeypatch.setattr(
+        client_module, "validate_signed_execution_receipt", lambda _value: None
+    )
+    monkeypatch.setattr(client_module, "validate_transport_attempt", lambda _value: None)
+    monkeypatch.setattr(
+        client_module, "validate_host_operation_record", lambda _value: None
+    )
+    payloads = []
+
+    async def post_json(_url, payload, _timeout):
+        payloads.append(payload)
+        if len(payloads) < 8:
+            raise TimeoutError()
+        return _response(payload["request"])
+
+    client = FakeClient()
+    result = await fetch_gateway_weight_inputs_v2(
+        gateway_url="https://gateway.example",
+        calculation_snapshot=_calculation(),
+        validator_hotkey=HOTKEY,
+        allocation_hash="sha256:" + "3" * 64,
+        leaderboard_window_start="2026-07-03T20:00:00Z",
+        leaderboard_window_end="2026-07-10T20:00:00Z",
+        client=client,
+        post_json=post_json,
+        retry_delay_seconds=0,
+    )
+
+    assert len(payloads) == 8
+    assert all(payload == payloads[0] for payload in payloads)
+    assert len(client.messages) == 1
+    assert result["gateway_authority_event_hash"] == "sha256:" + "4" * 64
+
+
+@pytest.mark.asyncio
+async def test_client_retry_delays_are_capped_for_singleflight_reattach(monkeypatch):
+    """A timed-out attempt must re-attach within seconds of build completion.
+
+    Uncapped exponential backoff (2, 4, 8, 16, 32, ...) leaves minute-long
+    gaps in which a completed, cached gateway result sits unread while the
+    submission window burns down.
+    """
+    monkeypatch.setattr(client_module, "validate_boot_identity", lambda _value: None)
+    monkeypatch.setattr(
+        client_module, "validate_signed_execution_receipt", lambda _value: None
+    )
+    monkeypatch.setattr(client_module, "validate_transport_attempt", lambda _value: None)
+    monkeypatch.setattr(
+        client_module, "validate_host_operation_record", lambda _value: None
+    )
+    real_sleep = client_module.asyncio.sleep
+    observed_delays = []
+
+    async def recording_sleep(delay, *args, **kwargs):
+        observed_delays.append(delay)
+        await real_sleep(0)
+
+    monkeypatch.setattr(client_module.asyncio, "sleep", recording_sleep)
+    attempts = 0
+
+    async def post_json(_url, payload, _timeout):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 7:
+            raise TimeoutError()
+        return _response(payload["request"])
+
+    await fetch_gateway_weight_inputs_v2(
+        gateway_url="https://gateway.example",
+        calculation_snapshot=_calculation(),
+        validator_hotkey=HOTKEY,
+        allocation_hash="sha256:" + "3" * 64,
+        leaderboard_window_start="2026-07-03T20:00:00Z",
+        leaderboard_window_end="2026-07-10T20:00:00Z",
+        client=FakeClient(),
+        post_json=post_json,
+    )
+
+    assert observed_delays == [2.0, 4.0, 8.0, 8.0, 8.0, 8.0]
+    assert max(observed_delays) <= client_module._MAX_RETRY_DELAY_SECONDS
+
+
+@pytest.mark.asyncio
 async def test_client_does_not_retry_semantic_gateway_400():
     calls = 0
 

--- a/tests/test_weight_submission_window_regression.py
+++ b/tests/test_weight_submission_window_regression.py
@@ -1,0 +1,123 @@
+"""Regression guards for the 2026-07-30/31 weight-submission outage.
+
+After the 2026-07-30 18:25 UTC gateway redeploy, the attested weight-input
+builds in the gateway coordinator enclave slowed from ~1s to 145-700s per
+epoch and the measured end-to-end primary pipeline reached ~959s. With
+submission starting at epoch block 300 of 360 (a 720s window), the extrinsic
+staleness gate evaluated after the official epoch closed on every attempt:
+epochs 24256-24270 published signed bundles durably in-epoch, yet no
+set_weights reached the chain for 18+ hours and every watched validator went
+stale together (auditors mirror the primary's published bundle).
+
+These tests pin the submission window and the inputs-client retry budget to
+the timings measured during the incident. If either shrinks below what
+production demonstrated is required — or the pipeline constants regress —
+this file fails before the chain does.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from leadpoet_canonical.constants import (
+    ALLOCATION_PREPARATION_BLOCK,
+    EPOCH_LENGTH,
+    MAX_BLOCK_DRIFT,
+    WEIGHT_SUBMISSION_BLOCK,
+)
+from validator_tee.host.gateway_weight_inputs_v2 import (
+    _MAX_RETRY_DELAY_SECONDS,
+    fetch_gateway_weight_inputs_v2,
+)
+
+# Finney block cadence.
+SECONDS_PER_BLOCK = 12
+
+# Stage timings measured for settlement epoch 24270 on 2026-07-31 (dockerd
+# receive timestamps on the primary and Supabase row timestamps), the first
+# fully-instrumented epoch after the frame-limit fix restored publication:
+#   gateway /weights/inputs/v2 request -> response   11:52:21 -> 11:57:56
+#   enclave signing + publication preparation        11:57:56 -> 11:59:37
+#   durable Supabase row -> gateway submit response  11:59:37 -> 12:07:02
+#   extrinsic + chain finalization (healthy 2026-07-30 baseline:
+#   bundle 17:52:06 -> finalization 17:53:24)
+MEASURED_INPUTS_SECONDS = 335
+MEASURED_SIGN_AND_PREPARE_SECONDS = 101
+MEASURED_PUBLICATION_ACK_SECONDS = 445
+MEASURED_EXTRINSIC_FINALIZATION_SECONDS = 78
+
+MEASURED_PIPELINE_SECONDS = (
+    MEASURED_INPUTS_SECONDS
+    + MEASURED_SIGN_AND_PREPARE_SECONDS
+    + MEASURED_PUBLICATION_ACK_SECONDS
+    + MEASURED_EXTRINSIC_FINALIZATION_SECONDS
+)
+
+# Slowest attested input build observed during the incident (epochs
+# 24265-24266, receipt-span measurement from
+# research_lab_attested_execution_receipts_v2).
+SLOWEST_OBSERVED_BUILD_SECONDS = 700
+
+# Headroom multiplier: the window must not merely equal the observed worst
+# case, because every stage above degrades further under coordinator-enclave
+# contention.
+SAFETY_MARGIN = 1.2
+
+
+def test_submission_window_covers_measured_degraded_pipeline():
+    window_seconds = (EPOCH_LENGTH - WEIGHT_SUBMISSION_BLOCK) * SECONDS_PER_BLOCK
+    assert window_seconds >= MEASURED_PIPELINE_SECONDS * SAFETY_MARGIN, (
+        "The weight submission window no longer covers the end-to-end "
+        "pipeline duration measured during the 2026-07-31 outage; every "
+        "submission would reach the extrinsic staleness gate after the "
+        "official epoch closes."
+    )
+
+
+def test_allocation_preparation_retains_head_start():
+    # Allocation preparation must still complete before the submission
+    # window opens; the preparation itself runs through the same degraded
+    # coordinator enclave.
+    assert ALLOCATION_PREPARATION_BLOCK + 30 <= WEIGHT_SUBMISSION_BLOCK
+
+
+def test_submission_window_stays_inside_official_epoch():
+    assert 0 < WEIGHT_SUBMISSION_BLOCK < EPOCH_LENGTH
+    assert MAX_BLOCK_DRIFT < WEIGHT_SUBMISSION_BLOCK
+
+
+def test_inputs_client_attempt_budget_covers_slowest_observed_build():
+    signature = inspect.signature(fetch_gateway_weight_inputs_v2)
+    timeout_seconds = signature.parameters["timeout_seconds"].default
+    max_attempts = signature.parameters["max_attempts"].default
+    retry_delay_seconds = signature.parameters["retry_delay_seconds"].default
+
+    delays = sum(
+        min(retry_delay_seconds * (2 ** (attempt - 1)), _MAX_RETRY_DELAY_SECONDS)
+        for attempt in range(1, max_attempts)
+    )
+    attempt_coverage_seconds = max_attempts * timeout_seconds + delays
+
+    assert (
+        attempt_coverage_seconds
+        >= SLOWEST_OBSERVED_BUILD_SECONDS * SAFETY_MARGIN
+    ), (
+        "The gateway inputs client exhausts its attempts before the slowest "
+        "observed singleflight build completes; the caller then restarts the "
+        "flow and forces a rebuild, which is how epochs 24265-24266 tripled "
+        "their build work."
+    )
+    # Even the slowest observed build must leave room in the submission
+    # window for signing, durable publication, and the chain extrinsic. The
+    # client re-attaches to the singleflight, so its actual spend tracks the
+    # build duration, not the full attempt budget.
+    window_seconds = (EPOCH_LENGTH - WEIGHT_SUBMISSION_BLOCK) * SECONDS_PER_BLOCK
+    non_input_pipeline_seconds = (
+        MEASURED_SIGN_AND_PREPARE_SECONDS
+        + MEASURED_PUBLICATION_ACK_SECONDS
+        + MEASURED_EXTRINSIC_FINALIZATION_SECONDS
+    )
+    assert (
+        SLOWEST_OBSERVED_BUILD_SECONDS + non_input_pipeline_seconds
+        <= window_seconds
+    )

--- a/validator_tee/host/gateway_weight_inputs_v2.py
+++ b/validator_tee/host/gateway_weight_inputs_v2.py
@@ -36,6 +36,10 @@ logger = logging.getLogger(__name__)
 _RETRYABLE_HTTP_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
 _MAX_WEIGHT_INPUT_RESPONSE_FRAME_BYTES = 16 * 1024 * 1024
 _MAX_WEIGHT_INPUT_RESPONSE_BYTES = 64 * 1024 * 1024
+# Retry delays are capped so a timed-out attempt re-attaches to the gateway's
+# in-flight singleflight build (which caches its exact success) within seconds
+# of completion instead of drifting into minute-long exponential gaps.
+_MAX_RETRY_DELAY_SECONDS = 8.0
 
 
 class GatewayWeightInputsV2Error(RuntimeError):
@@ -224,7 +228,13 @@ async def fetch_gateway_weight_inputs_v2(
         [str, Mapping[str, Any], float], Awaitable[Mapping[str, Any]]
     ] = _post_json,
     timeout_seconds: float = 90.0,
-    max_attempts: int = 4,
+    # The gateway coalesces concurrent input requests into one singleflight
+    # build and caches the exact success, so a timed-out attempt re-attaches
+    # cheaply rather than triggering a rebuild. The attempt budget must cover
+    # the slowest observed production build (~700s, 2026-07-31 epochs
+    # 24265-24266): exhausting it makes the caller restart the whole flow,
+    # which does force a rebuild and compounds the delay.
+    max_attempts: int = 10,
     retry_delay_seconds: float = 2.0,
 ) -> Dict[str, Any]:
     """Request one exact, enclave-signed gateway input set and verify its shape."""
@@ -285,7 +295,10 @@ async def fetch_gateway_weight_inputs_v2(
         except Exception as exc:
             if attempt >= max_attempts or not _is_retryable_gateway_error(exc):
                 raise
-            delay = float(retry_delay_seconds) * (2 ** (attempt - 1))
+            delay = min(
+                float(retry_delay_seconds) * (2 ** (attempt - 1)),
+                _MAX_RETRY_DELAY_SECONDS,
+            )
             logger.warning(
                 "gateway_weight_inputs_v2_retry attempt=%d/%d "
                 "delay_seconds=%.1f type=%s error=%s",


### PR DESCRIPTION
## Problem

No `set_weights` has reached the chain since block 8736464 (Jul 30 17:53:24 UTC). All four watched validators' `last_update` froze together and the metagraph now reports them inactive. The auditors mirror the primary's published bundle, so the primary's miss is everyone's miss.

**Root cause:** the Jul 30 18:25 UTC gateway redeploy slowed the coordinator-enclave attested weight-input builds from **~1s to 145-700s per epoch** (measured from `research_lab_attested_execution_receipts_v2` receipt spans; the receipt graphs also outgrew the old 8 MiB frame, already addressed by 4933b94c). The measured end-to-end primary pipeline is now **~959s**:

| stage (settlement epoch 24270, Jul 31) | measured |
|---|---|
| `/weights/inputs/v2` request -> response | 335s |
| enclave signing + publication preparation | 101s |
| durable Supabase row -> gateway submit response | 445s |
| extrinsic + chain finalization (healthy Jul 30 baseline) | 78s |

Submission starts at epoch block 300/360, a **720s window**. The pipeline overruns it every epoch, so `_weight_submission_epoch_is_current` correctly refuses the extrinsic ("Refusing stale weight submission"), the journal is quarantined `unsigned_epoch_closed`, and auditors polling `/weights/v2/published/...` in-epoch get 404. Epochs 24256-24270: signed bundles published durably in-epoch, zero chain submissions.

## Fix

Two changes, host/shared-constant level only — no enclave or gateway logic touched:

1. **`WEIGHT_SUBMISSION_BLOCK` 300 -> 240.** The 120-block (~24 min) window covers the measured pipeline with >=20% margin. The gateway's acceptance windows (`live_window`, finalized-snapshot lag buffer) and the auditor mirror schedule all derive from this constant and widen coherently. Auditors on the *old* schedule also recover: the primary now publishes by ~block 282, before their ~block 330 poll.
2. **Inputs client attempt budget 4 -> 10, retry delays capped at 8s.** The gateway coalesces concurrent input requests into one singleflight build and caches the exact success, so timed-out attempts re-attach cheaply. Exhausting the old budget (~374s of coverage vs 700s builds) restarted the whole flow and forced rebuilds — epochs 24265-24266 show 24 receipts instead of 8 (3 full builds each).

## Rollout order

**Deploy the gateway at or before the validator.** An old gateway rejects submissions earlier than block ~270 (`blocks_remaining > live_window`). A new gateway accepts both old (300) and new (240) validators.

## Verification

- New regression tests pin the window and retry budget to the incident measurements. On the **old** values they fail exactly as intended: `test_submission_window_covers_measured_degraded_pipeline`, `test_inputs_client_attempt_budget_covers_slowest_observed_build`, and both new client tests (attempt-budget, delay-cap). On this branch: green.
- Full `tests/` suite on this branch: **4,641 passed, 7 skipped (pre-existing), 202 subtests passed, 0 failures** (5m19s), plus the 4 new regression tests run separately: green.

## Not in this PR (follow-ups)

- The enclave-side 1s -> 150s+ execution regression from the Jul 30 gateway deploy is the underlying disease; this PR makes the validator survive it. 374d32f9 ("Index allocation receipt graph roots") appears to be attacking the graph-size side already.
- Receipt-graph growth (journal 3.6MB Jul 23 -> 74MB Jul 31) needs pruning/checkpointing regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
