### PR TITLE
Add opt-in fail-closed Sentry error monitoring across host runtimes

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -77,3 +77,14 @@ Code enforcement stops accidental leakage; it is not full security by
 itself. Operationally the collector token should be ingest-only and
 rotated, repository access stays scoped, and the telemetry vendor's
 retention / no-training / deletion terms should be agreed in writing.
+
+## Related: error monitoring (Sentry)
+
+Error capture (crashes and ERROR-level logs) is a separate, equally
+fail-closed integration with the same philosophy — namespaced
+`LEADPOET_SENTRY_*` variables, explicit options, host processes only, never
+the enclaves, and a scrubber that keeps trajectory/training data, prompts,
+benchmarks, and contact data out of every event. See
+[`docs/sentry_error_monitoring.md`](docs/sentry_error_monitoring.md) and
+`leadpoet_observability/sentry_bootstrap.py`;
+`tests/test_sentry_boundary_guard.py` enforces the boundary in CI.

--- a/docs/sentry_error_monitoring.md
+++ b/docs/sentry_error_monitoring.md
@@ -1,0 +1,138 @@
+# Sentry error monitoring (opt-in, fail-closed)
+
+One integration covers every Leadpoet HOST runtime. It exists to answer
+"what is breaking and where" — crashes, unhandled thread/task failures, and
+ERROR-level logs — while guaranteeing that trajectory/training data,
+prompts, benchmarks, model internals, and contact data never leave the
+process. It follows the same philosophy as the OTel bootstrap in
+`TELEMETRY.md`: namespaced env gate, explicit options, swallowed wiring
+failures, code-enforced boundary with a CI guard.
+
+## Coverage map
+
+`init_sentry(component=...)` is wired at every host entry point:
+
+| component | entry point |
+|---|---|
+| `gateway` | `gateway/main.py` (host FastAPI process; also covers in-process fulfillment/qualification/TEE-host code) |
+| `validator` | `neurons/validator.py` (all container modes; mode is tagged) |
+| `miner` | `neurons/miner.py` |
+| `auditor-validator` | `neurons/auditor_validator.py` |
+| `research-lab-worker` | `gateway/research_lab/worker_process.py` (hosted + scoring kinds, kind tagged) |
+| `research-lab-scoring-worker` | `scripts/run_research_lab_scoring_worker.py` |
+| `research-lab-scoring-worker-fleet` | `scripts/run_research_lab_scoring_worker_fleet.py` |
+
+Coverage inside a process is automatic, not per-module: the SDK's
+excepthook (crashes), threading hook (thread crashes), and stdlib logging
+integration (any `logging` / `bt.logging` / `uvicorn.error` record at
+ERROR or above becomes an event; asyncio's default handler logs unretrieved
+task exceptions at ERROR) reach every package in the codebase. One-off
+operator scripts can opt in with the same two lines wrapped in
+`try/except`.
+
+**Never wired**: the attested enclaves (`validator_tee/enclave/*`,
+`gateway/tee` enclave service). Enclave images are measured (PCR0) and
+have no general egress. `tests/test_sentry_boundary_guard.py` fails CI if
+Sentry references reach an enclave surface or enclave requirements file.
+
+## Enabling
+
+```bash
+export LEADPOET_SENTRY_ENABLED=1
+export LEADPOET_SENTRY_DSN="https://<key>@<org>.ingest.sentry.io/<project>"
+# optional
+export LEADPOET_SENTRY_ENVIRONMENT=production      # default: production
+export LEADPOET_SENTRY_RELEASE=<git sha>           # default: read from .git/HEAD
+export LEADPOET_SENTRY_EXTRA_PROTECTED_MODULES=    # comma-separated prefixes; widens redaction only
+export LEADPOET_SENTRY_MESSAGE_MODE=scrub          # or redact-all
+```
+
+Both gate variables are required; anything less is a complete no-op.
+Ambient `SENTRY_*` variables are never read — every option is passed to
+the SDK explicitly. `sentry-sdk` itself is optional at runtime: when the
+package is missing the wiring logs one line and stays off, so no runtime
+grows a hard dependency.
+
+## What an event may contain — and all it may ever contain
+
+- exception **type**, exception **module**, stack **file/function/line**
+- logger name, level, timestamp, `leadpoet.component` (+ low-cardinality
+  tags such as validator mode / worker kind), environment, release SHA,
+  server name, installed package versions
+- for non-protected surfaces only: the exception/log **message** after
+  regex scrubbing (emails, formatted phone numbers, secret-shaped values,
+  URL query strings removed; 500-char cap). UUID/sha256 join keys survive
+  verbatim so events stay correlatable with `execution_trace:` /
+  `cost_ledger:` refs.
+
+## What can never leave the process
+
+Enforced by `leadpoet_observability/sentry_scrubbing.py` (fail closed: an
+event that cannot be fully scrubbed is dropped, never sent partially):
+
+1. **Stack local variables** — `include_local_variables=False` at init, and
+   any residual `vars` deleted per frame. Locals are the main vector for
+   prompt/lead/trajectory payload leakage.
+2. **Source context lines** — stripped from every frame. An error inside
+   LLM-generated candidate code or a private model artifact must not export
+   source text.
+3. **Messages from protected surfaces** — events whose logger, exception
+   module, or ANY stack frame touches `research_lab`,
+   `gateway.research_lab`, `gateway.fulfillment`, `gateway.qualification`,
+   `qualification`, `leadpoet_verifier`, `miner_models`,
+   `validator_models`, the lead pool/queue utils, or the `langfuse` /
+   `openai` / `anthropic` / `openrouter` / `firecrawl` clients keep type,
+   stack, and logger but have every message replaced with
+   `[leadpoet-redacted:protected-surface]`. One protected link redacts the
+   whole exception chain (a wrapper message can embed the inner error).
+   Breadcrumbs from protected loggers are dropped outright.
+4. **Request/user envelopes, cookies, argv, request bodies** — dropped;
+   `send_default_pii=False`, `max_request_body_size="never"`.
+5. **Performance data** — no tracing, no profiling, no sessions; errors
+   only. Framework/DB/HTTP auto-instrumentation stays disabled so query
+   and payload data never becomes event context.
+6. **Secrets** — key-based redaction (`api_key`, `token`, `authorization`,
+   `service_role`, …) plus value-shape redaction (`sk-*`, AKIA keys, JWTs,
+   bearer tokens) plus the marker vocabulary shared with
+   `research_lab/observability/redaction.py` (`judge_prompt`,
+   `hidden_benchmark`, `icp_plaintext`, …).
+
+`LEADPOET_SENTRY_MESSAGE_MODE=redact-all` redacts every message and drops
+every breadcrumb regardless of surface, for maximum privacy at the cost of
+triage detail. The environment can only widen redaction, never narrow it.
+
+## The boundary is code-enforced
+
+`tests/test_sentry_boundary_guard.py` fails CI when:
+
+- `sentry_sdk` is imported or initialized anywhere outside
+  `leadpoet_observability/sentry_bootstrap.py`;
+- an enclave requirements file (`validator_tee/enclave/requirements.txt`,
+  `gateway/tee/requirements*.{txt,in,lock}`) gains `sentry-sdk`, or any
+  enclave/TEE module references the bootstrap;
+- a non-namespaced `SENTRY_*` variable is referenced anywhere;
+- the hard-off init options (`include_local_variables=False`,
+  `send_default_pii=False`, `max_request_body_size="never"`,
+  `traces_sample_rate=None`, `auto_enabling_integrations=False`, the
+  scrubbing hooks) drift out of the bootstrap;
+- the scrubber stops stripping source context/locals or dropping the
+  request envelope and argv;
+- a wired entry point loses its `init_sentry(` call.
+
+## Operational notes
+
+- **Activation is a release decision.** `sentry-sdk` is in
+  `requirements.txt`/`setup.py`, so first activation on gateway/validator
+  hosts changes installed dependency sets and follows the normal V2
+  release/rehearsal process. The code paths themselves are inert no-ops
+  until the env gate is set, so shipping them changes no behavior.
+- The DSN is not committed anywhere; it lives in the operator env files
+  (e.g. the gateway env secret). Rotate it like any ingest token, and
+  agree the vendor's retention / no-training / deletion terms in writing —
+  the same caveat as `TELEMETRY.md`.
+- Wiring failures never break a runtime; look for
+  `leadpoet_sentry_wiring_skipped` / `leadpoet_sentry_init_skipped` /
+  `leadpoet_sentry_scrub_failed` lines (exception class names only) in
+  process logs.
+- Public auditors and external miners simply leave the gate unset; nothing
+  initializes and nothing is sent.

--- a/env.example
+++ b/env.example
@@ -139,3 +139,25 @@ RESEARCH_LAB_EXECUTION_TRACE_TRAJECTORY_ID_ENABLED=true
 # RESEARCH_LAB_SOURCE_ADD_CREDENTIAL_KMS_KEY_ID=alias/your-kms-key
 # RESEARCH_LAB_SOURCE_ADD_SANDBOX_IMAGE=python:3.11-slim
 # RESEARCH_LAB_SOURCE_ADD_TRIAL_TIMEOUT_SECONDS=300
+
+# =============================================================================
+# Error monitoring — Sentry (OPTIONAL, host processes only)
+# =============================================================================
+# Fail-closed error capture for crashes and ERROR-level logs across the
+# gateway, validator, miner, auditor, and Research Lab worker processes.
+# It never captures trajectory/training data or contact data: protected
+# surfaces (research_lab, gateway.research_lab, fulfillment, qualification,
+# model code, LLM clients) keep only exception type + stack; stack locals,
+# source context lines, request bodies, and argv never leave the process.
+# See docs/sentry_error_monitoring.md. Inert unless BOTH gate variables are
+# set. NEVER set these inside an attested enclave.
+# LEADPOET_SENTRY_ENABLED=true
+# LEADPOET_SENTRY_DSN=your_sentry_dsn_here
+# Optional overrides: environment label (default "production"), release
+# (default: current git HEAD), extra protected module prefixes (comma
+# separated — can only widen redaction), and message mode
+# ("scrub" default | "redact-all" for maximum privacy).
+# LEADPOET_SENTRY_ENVIRONMENT=production
+# LEADPOET_SENTRY_RELEASE=
+# LEADPOET_SENTRY_EXTRA_PROTECTED_MODULES=
+# LEADPOET_SENTRY_MESSAGE_MODE=scrub

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -29,6 +29,20 @@ for _path in (_ATTESTED_RUNTIME_DIR, _PACKAGE_PARENT):
         sys.path.remove(_path)
     sys.path.insert(0, _path)
 
+# Opt-in, fail-closed error monitoring (docs/sentry_error_monitoring.md).
+# Wired before the config/service imports so an import-time crash of the
+# gateway host process is still captured. Complete no-op unless the
+# LEADPOET_SENTRY_* environment gate is satisfied.
+try:
+    from leadpoet_observability import init_sentry
+
+    init_sentry(component="gateway")
+except Exception as _sentry_exc:  # error monitoring must never break startup
+    print(
+        "leadpoet_sentry_wiring_skipped error=%s" % type(_sentry_exc).__name__,
+        flush=True,
+    )
+
 # Import configuration
 from gateway.build_info import get_build_info
 from gateway.config import BUILD_ID, GITHUB_COMMIT, TIMESTAMP_TOLERANCE_SECONDS

--- a/gateway/research_lab/worker_process.py
+++ b/gateway/research_lab/worker_process.py
@@ -21,6 +21,18 @@ for path in (ATTESTED_RUNTIME, PACKAGE_PARENT):
         sys.path.remove(str(path))
     sys.path.insert(0, str(path))
 
+# Opt-in, fail-closed error monitoring (docs/sentry_error_monitoring.md).
+# Complete no-op unless the LEADPOET_SENTRY_* environment gate is satisfied.
+try:
+    from leadpoet_observability import init_sentry  # noqa: E402
+
+    init_sentry(component="research-lab-worker")
+except Exception as _sentry_exc:  # must never break the worker
+    print(
+        "leadpoet_sentry_wiring_skipped error=%s" % type(_sentry_exc).__name__,
+        flush=True,
+    )
+
 from gateway.research_lab.config import ResearchLabGatewayConfig  # noqa: E402
 from gateway.research_lab.git_tree_models import TreePolicy  # noqa: E402
 from gateway.research_lab.logging_utils import format_worker_block  # noqa: E402
@@ -160,6 +172,13 @@ def main() -> int:
     parser.add_argument("--worker-prefix", default="")
     parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
+
+    try:  # low-cardinality triage tag; safe no-op when Sentry is inactive
+        from leadpoet_observability import set_sentry_tag
+
+        set_sentry_tag("worker.kind", args.kind)
+    except Exception:
+        pass
 
     build_research_lab_worker_environment()
     _configure_logging(args.log_level)

--- a/leadpoet_observability/__init__.py
+++ b/leadpoet_observability/__init__.py
@@ -1,0 +1,16 @@
+"""Cross-runtime observability helpers for Leadpoet HOST processes.
+
+Currently: opt-in, fail-closed Sentry error monitoring. See
+``docs/sentry_error_monitoring.md`` and ``sentry_bootstrap.py`` for the
+contract. This package must stay stdlib-only at import time so every entry
+point (gateway, validator, miner, auditor, Research Lab workers) can wire
+it unconditionally with zero side effects when disabled.
+"""
+
+from leadpoet_observability.sentry_bootstrap import (
+    init_sentry,
+    sentry_enabled,
+    set_sentry_tag,
+)
+
+__all__ = ["init_sentry", "sentry_enabled", "set_sentry_tag"]

--- a/leadpoet_observability/sentry_bootstrap.py
+++ b/leadpoet_observability/sentry_bootstrap.py
@@ -1,0 +1,235 @@
+"""Opt-in, fail-closed Sentry error monitoring for Leadpoet HOST processes.
+
+Same contract style as ``gateway/observability/otel_bootstrap.py``:
+
+- Complete no-op unless ``LEADPOET_SENTRY_ENABLED`` is truthy AND
+  ``LEADPOET_SENTRY_DSN`` is set. Only namespaced ``LEADPOET_SENTRY_*``
+  variables are read; ambient ``SENTRY_*`` variables are never consulted —
+  every option is passed to the SDK explicitly.
+- Wiring failures are swallowed (class name logged, never values): error
+  monitoring can never delay or break a runtime.
+- Host processes only. Never wire this inside an attested enclave: enclave
+  images are measured (PCR0) and have no general egress, and
+  ``tests/test_sentry_boundary_guard.py`` fails CI if an enclave surface or
+  enclave requirements file references Sentry.
+- Errors only. Performance tracing, profiling, session tracking, request
+  bodies, stack-local variables, and PII capture are hard-off, and
+  framework/client auto-instrumentation stays disabled — coverage comes
+  from the process-level excepthook, threading hook, and stdlib logging
+  (ERROR and above), which every runtime already uses (bittensor's
+  ``bt.logging``, uvicorn's ``uvicorn.error``, and asyncio's default task
+  exception handler all route through stdlib logging).
+- Every outgoing event and breadcrumb passes the fail-closed scrubber in
+  ``sentry_scrubbing``; a scrub failure DROPS the event so nothing
+  unscrubbed can leave the process. Training/trajectory data, prompts,
+  benchmarks, and contact data are protected surfaces there.
+
+Activation is an operator decision: installing ``sentry-sdk`` and setting
+the environment variables changes deployed dependency sets, so it follows
+the normal release process. Without the package or the variables every
+``init_sentry`` call is inert.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from . import sentry_scrubbing
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+ENABLED_ENV = "LEADPOET_SENTRY_ENABLED"
+DSN_ENV = "LEADPOET_SENTRY_DSN"
+ENVIRONMENT_ENV = "LEADPOET_SENTRY_ENVIRONMENT"
+RELEASE_ENV = "LEADPOET_SENTRY_RELEASE"
+EXTRA_PROTECTED_ENV = "LEADPOET_SENTRY_EXTRA_PROTECTED_MODULES"
+MESSAGE_MODE_ENV = "LEADPOET_SENTRY_MESSAGE_MODE"  # "scrub" (default) | "redact-all"
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_state = {"initialized": False, "active": False}
+
+
+def _safe_print(line: str) -> None:
+    try:
+        print(line, flush=True)
+    except Exception:
+        pass
+
+
+def sentry_enabled() -> bool:
+    return (
+        os.getenv(ENABLED_ENV, "").strip().lower() in _TRUTHY
+        and bool(os.getenv(DSN_ENV, "").strip())
+    )
+
+
+def _extra_protected_prefixes() -> Tuple[str, ...]:
+    """Operator-supplied ADDITIONAL protected module prefixes.
+
+    The environment can only widen redaction, never narrow the built-in set.
+    """
+    raw = os.getenv(EXTRA_PROTECTED_ENV, "")
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
+def _redact_all() -> bool:
+    return os.getenv(MESSAGE_MODE_ENV, "").strip().lower() == "redact-all"
+
+
+def _read_git_release(repo_root: Path) -> Optional[str]:
+    """Best-effort release identity from ``.git`` without subprocesses."""
+    try:
+        head = (repo_root / ".git" / "HEAD").read_text(encoding="utf-8").strip()
+        if head.startswith("ref:"):
+            ref = head.split(" ", 1)[1].strip()
+            ref_path = repo_root / ".git" / ref
+            if ref_path.is_file():
+                candidate = ref_path.read_text(encoding="utf-8").strip()
+                return candidate if _looks_like_sha(candidate) else None
+            packed = repo_root / ".git" / "packed-refs"
+            if packed.is_file():
+                for line in packed.read_text(encoding="utf-8").splitlines():
+                    line = line.strip()
+                    if line.endswith(" " + ref):
+                        candidate = line.split(" ", 1)[0]
+                        return candidate if _looks_like_sha(candidate) else None
+            return None
+        return head if _looks_like_sha(head) else None
+    except Exception:
+        return None
+
+
+def _looks_like_sha(value: str) -> bool:
+    return len(value) == 40 and all(c in "0123456789abcdef" for c in value.lower())
+
+
+def _build_before_send(
+    extra_prefixes: Tuple[str, ...], redact_all: bool
+) -> Callable[[Any, Any], Optional[Dict[str, Any]]]:
+    def _before_send(event: Any, hint: Any) -> Optional[Dict[str, Any]]:
+        try:
+            return sentry_scrubbing.scrub_event(
+                event, extra_prefixes=extra_prefixes, redact_all=redact_all
+            )
+        except BaseException as exc:
+            # Fail closed: an event we cannot fully scrub is never sent.
+            _safe_print(
+                "leadpoet_sentry_scrub_failed error=%s" % type(exc).__name__
+            )
+            return None
+
+    return _before_send
+
+
+def _build_before_breadcrumb(
+    extra_prefixes: Tuple[str, ...], redact_all: bool
+) -> Callable[[Any, Any], Optional[Dict[str, Any]]]:
+    def _before_breadcrumb(crumb: Any, hint: Any) -> Optional[Dict[str, Any]]:
+        try:
+            return sentry_scrubbing.scrub_breadcrumb(
+                crumb, extra_prefixes=extra_prefixes, redact_all=redact_all
+            )
+        except BaseException:
+            # Fail closed: a breadcrumb we cannot scrub is dropped silently
+            # (breadcrumbs are high-volume; no log line per drop).
+            return None
+
+    return _before_breadcrumb
+
+
+def init_sentry(component: str, tags: Optional[Dict[str, str]] = None) -> bool:
+    """Initialize error monitoring for this process. Never raises.
+
+    Returns True only when a live client was installed. The first call wins;
+    later calls in the same process are no-ops that return the first result.
+    Complete no-op (False) when the ``LEADPOET_SENTRY_*`` gate is not
+    satisfied or ``sentry-sdk`` is not installed.
+    """
+    if _state["initialized"]:
+        return bool(_state["active"])
+    _state["initialized"] = True
+    try:
+        if not sentry_enabled():
+            return False
+        try:
+            import sentry_sdk
+        except Exception as exc:
+            # Enabled by env but the optional dependency is missing: say so
+            # once (class only) instead of failing the runtime.
+            _safe_print(
+                "leadpoet_sentry_disabled sdk_import=%s" % type(exc).__name__
+            )
+            return False
+
+        dsn = os.getenv(DSN_ENV, "").strip()
+        environment = os.getenv(ENVIRONMENT_ENV, "").strip() or "production"
+        release = os.getenv(RELEASE_ENV, "").strip() or _read_git_release(_REPO_ROOT)
+        extra_prefixes = _extra_protected_prefixes()
+        redact_all = _redact_all()
+
+        sentry_sdk.init(
+            # Explicit options only — ambient SENTRY_* variables never apply.
+            dsn=dsn,
+            environment=environment,
+            release=release,
+            # Errors only: no performance tracing, profiling, or sessions.
+            traces_sample_rate=None,
+            auto_session_tracking=False,
+            # Payload capture is hard-off; the scrubber is the second fence.
+            send_default_pii=False,
+            include_local_variables=False,
+            max_request_body_size="never",
+            attach_stacktrace=True,
+            max_breadcrumbs=50,
+            max_value_length=1024,
+            debug=False,
+            shutdown_timeout=2,
+            # Core integrations only (excepthook, threading, stdlib logging,
+            # dedupe, atexit, modules). Framework/DB/HTTP auto-instrumentation
+            # must never attach request or query payloads to events.
+            auto_enabling_integrations=False,
+            ignore_errors=[KeyboardInterrupt, asyncio.CancelledError, GeneratorExit],
+            before_send=_build_before_send(extra_prefixes, redact_all),
+            before_breadcrumb=_build_before_breadcrumb(extra_prefixes, redact_all),
+        )
+        sentry_sdk.set_tag("leadpoet.component", str(component))
+        for key, value in (tags or {}).items():
+            sentry_sdk.set_tag(
+                "leadpoet.%s" % key,
+                sentry_scrubbing.scrub_text(str(value), 200),
+            )
+        _state["active"] = True
+        _safe_print(
+            "leadpoet_sentry_initialized component=%s release=%s"
+            % (component, release or "unknown")
+        )
+        return True
+    except BaseException as exc:
+        # Never let error monitoring break the runtime. Class name only —
+        # the message could contain the DSN.
+        _safe_print("leadpoet_sentry_init_skipped error=%s" % type(exc).__name__)
+        _state["active"] = False
+        return False
+
+
+def set_sentry_tag(key: str, value: Any) -> None:
+    """Attach a low-cardinality tag to future events. Safe no-op when inactive."""
+    if not _state["active"]:
+        return
+    try:
+        import sentry_sdk
+
+        sentry_sdk.set_tag(
+            "leadpoet.%s" % key, sentry_scrubbing.scrub_text(str(value), 200)
+        )
+    except BaseException:
+        pass
+
+
+def _reset_for_tests() -> None:
+    _state["initialized"] = False
+    _state["active"] = False

--- a/leadpoet_observability/sentry_scrubbing.py
+++ b/leadpoet_observability/sentry_scrubbing.py
@@ -1,0 +1,399 @@
+"""Fail-closed scrubbing for Sentry error events.
+
+Pure stdlib on purpose: importable (and testable) without sentry-sdk
+installed, and auditable as the single place that decides what error
+telemetry may contain. The rules mirror the repository's existing
+protection boundaries (``research_lab/observability/redaction.py``,
+``TELEMETRY.md``):
+
+- Stack LOCALS never leave the process (``include_local_variables=False``
+  at init; any residual ``vars`` are deleted here as a second fence).
+- Source context lines are stripped from EVERY frame. An error raised
+  inside LLM-generated candidate code, a private model artifact, or a
+  prompt builder must never export source text; file/function/line survive
+  for debugging.
+- Events that touch a protected surface (Research Lab, trajectory/training
+  capture, model internals, fulfillment/qualification lead content, LLM
+  provider clients) keep exception TYPE, stack, and logger name — but their
+  messages are replaced with a redaction token. Regex scrubbing cannot be
+  trusted to recognize prompts, ICPs, trajectories, benchmarks, or lead
+  payloads, so those surfaces are redacted wholesale.
+- Every other string is regex-scrubbed (emails, formatted phone numbers,
+  secret-shaped values, URL query strings) and length-capped. Join keys
+  (UUIDs, sha256 refs) survive verbatim so events stay debuggable.
+- The request envelope, user envelope, cookies, and ``sys.argv`` are
+  dropped entirely.
+
+Helpers here never raise on well-formed input, but the bootstrap wraps
+every call anyway: a scrub failure DROPS the event (fail closed) rather
+than letting anything unscrubbed leave the process.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+REDACTED = "[leadpoet-redacted]"
+REDACTED_PROTECTED = "[leadpoet-redacted:protected-surface]"
+TRUNCATION_SUFFIX = "…[leadpoet-truncated]"
+
+MAX_MESSAGE_LENGTH = 500
+MAX_STRING_LENGTH = 500
+MAX_BREADCRUMB_MESSAGE_LENGTH = 200
+MAX_WALK_DEPTH = 8
+MAX_DICT_ITEMS = 100
+MAX_LIST_ITEMS = 50
+
+# Module prefixes whose events keep type/stack/logger but lose message
+# content entirely. A prefix matches itself and any dotted submodule.
+# These are the surfaces where messages can embed trajectory/training IP or
+# unredacted contact data: the Research Lab engine and capture pipeline,
+# model internals, lead fulfillment/qualification content paths, and the
+# LLM provider clients whose exceptions echo request/response fragments.
+PROTECTED_MODULE_PREFIXES: Tuple[str, ...] = (
+    "research_lab",
+    "gateway.research_lab",
+    "gateway.fulfillment",
+    "gateway.qualification",
+    "qualification",
+    "leadpoet_verifier",
+    "miner_models",
+    "validator_models",
+    "Leadpoet.base.utils.pool",
+    "Leadpoet.base.utils.queue",
+    "langfuse",
+    "openai",
+    "anthropic",
+    "openrouter",
+    "firecrawl",
+)
+
+# Path fragments that mark a stack frame as protected when the module name
+# is unavailable (scripts running as __main__, site-packages clients).
+PROTECTED_PATH_FRAGMENTS: Tuple[str, ...] = (
+    "/research_lab/",
+    "/fulfillment/",
+    "/qualification/",
+    "/leadpoet_verifier/",
+    "/miner_models/",
+    "/validator_models/",
+    "/langfuse/",
+    "/openai/",
+    "/anthropic/",
+    "/firecrawl/",
+    "/Leadpoet/base/utils/pool",
+    "/Leadpoet/base/utils/queue",
+)
+
+# Substrings that mark a whole string as unshippable (mirrors the marker
+# vocabulary in research_lab/observability/redaction.py). Redaction here
+# replaces the string instead of raising: an error event must still ship,
+# just without the material.
+_SECRET_MARKERS: Tuple[str, ...] = (
+    "sk-or-",
+    "openrouter_api_key",
+    "raw_openrouter_key",
+    "raw_secret",
+    "service_role",
+    "authorization: bearer",
+    "judge_prompt",
+    "hidden_benchmark",
+    "hidden_icp",
+    "icp_plaintext",
+    "private_repo",
+)
+
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
+
+# Deliberately stricter than a generic digit-run matcher: epoch ranges,
+# block numbers, and byte counts ("6553000-6553360") must survive. Only
+# strings with explicit phone formatting cues are treated as phone numbers.
+_PHONE_RE = re.compile(
+    r"(?:\+\d[\d\-\s().]{7,}\d)"
+    r"|(?:\(\d{3}\)[\s.-]?\d{3}[\s.-]?\d{4})"
+    r"|(?:\b\d{3}[-.]\d{3}[-.]\d{4}\b)"
+)
+
+# UUIDs, sha256 digests, and prefixed refs are join keys and must survive
+# scrubbing verbatim (same guard as redaction.py REF_LIKE_RE).
+_REF_LIKE_RE = re.compile(
+    r"^(?:[a-z0-9_.-]+:)*(?:sha256:[0-9a-f]{64}"
+    r"|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    r"|[0-9a-f]{16,64})$",
+    re.I,
+)
+
+_SECRET_VALUE_RE = re.compile(
+    r"(?:sk-[A-Za-z0-9\-_]{16,})"
+    r"|(?:AKIA[0-9A-Z]{16})"
+    r"|(?:eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{5,})"
+    r"|(?:(?i:bearer)\s+[A-Za-z0-9\-._~+/]{8,}=*)"
+)
+
+_URL_QUERY_RE = re.compile(r"\?[^\s'\"]+")
+
+_SECRET_KEY_RE = re.compile(
+    r"api[_-]?key|apikey|secret|token|credential|authorization|password"
+    r"|passwd|cookie|session|dsn|private[_-]?key|service[_-]?role",
+    re.I,
+)
+
+# Keys whose values are content, not operational metadata. Over-redaction
+# in extra/contexts is acceptable; under-redaction is not — but join keys
+# must survive ("leadpoet.component", "candidate_sha", "status_code",
+# "content_length" stay; "lead_email", "page_content", "candidate_code",
+# "request_body" are redacted), hence the word-boundary anchoring on the
+# ambiguous stems.
+_CONTENT_KEY_RE = re.compile(
+    r"prompt|completion|\bllm\b|llm_|_llm|trajector|\bicp\b|icp_|_icp"
+    r"|benchmark|sealed|page_content|\blead(s)?\b|lead_|_lead"
+    r"|\bcontact(s)?\b|contact_|_contact|email|phone|linkedin|payload"
+    r"|body\b|content\b|candidate_code|source_code|\bdiff\b|diff_|_diff"
+    r"|patch\b|messages\b|provider_response|response_text",
+    re.I,
+)
+
+
+def _is_protected_module(name: Any, extra_prefixes: Iterable[str] = ()) -> bool:
+    if not isinstance(name, str) or not name:
+        return False
+    for prefix in tuple(PROTECTED_MODULE_PREFIXES) + tuple(extra_prefixes):
+        if not prefix:
+            continue
+        if name == prefix or name.startswith(prefix + "."):
+            return True
+    return False
+
+
+def _is_protected_filename(filename: Any) -> bool:
+    if not isinstance(filename, str) or not filename:
+        return False
+    normalized = "/" + filename.replace("\\", "/").lstrip("/")
+    return any(fragment in normalized for fragment in PROTECTED_PATH_FRAGMENTS)
+
+
+def scrub_text(value: Any, max_length: int = MAX_STRING_LENGTH) -> Any:
+    """Regex-scrub one string; non-strings pass through unchanged."""
+    if not isinstance(value, str):
+        return value
+    lowered = value.lower()
+    for marker in _SECRET_MARKERS:
+        if marker in lowered:
+            return REDACTED
+    text = _SECRET_VALUE_RE.sub(REDACTED, value)
+    text = _EMAIL_RE.sub("[leadpoet-redacted:email]", text)
+    if not _REF_LIKE_RE.match(text.strip()):
+        text = _PHONE_RE.sub("[leadpoet-redacted:phone]", text)
+    text = _URL_QUERY_RE.sub("?[leadpoet-redacted:query]", text)
+    if len(text) > max_length:
+        text = text[:max_length] + TRUNCATION_SUFFIX
+    return text
+
+
+def _scrub_object(value: Any, depth: int = 0) -> Any:
+    """Key-aware recursive scrub for extra/contexts/tags/breadcrumb data."""
+    if depth > MAX_WALK_DEPTH:
+        return REDACTED
+    if isinstance(value, str):
+        return scrub_text(value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, dict):
+        out: Dict[str, Any] = {}
+        for index, (raw_key, item) in enumerate(value.items()):
+            if index >= MAX_DICT_ITEMS:
+                out[REDACTED] = "[leadpoet-truncated:dict]"
+                break
+            key = str(raw_key)
+            if _SECRET_KEY_RE.search(key) or _CONTENT_KEY_RE.search(key):
+                out[key] = REDACTED
+            else:
+                out[key] = _scrub_object(item, depth + 1)
+        return out
+    if isinstance(value, (list, tuple, set, frozenset)):
+        items = list(value)
+        out_list = [_scrub_object(item, depth + 1) for item in items[:MAX_LIST_ITEMS]]
+        if len(items) > MAX_LIST_ITEMS:
+            out_list.append("[leadpoet-truncated:list]")
+        return out_list
+    # Arbitrary objects: their repr could contain anything. Never serialize.
+    return REDACTED
+
+
+def _scrub_stacktrace(stacktrace: Any) -> None:
+    """Strip source context and residual locals from every frame, in place."""
+    if not isinstance(stacktrace, dict):
+        return
+    frames = stacktrace.get("frames")
+    if not isinstance(frames, list):
+        return
+    for frame in frames:
+        if not isinstance(frame, dict):
+            continue
+        frame.pop("context_line", None)
+        frame.pop("pre_context", None)
+        frame.pop("post_context", None)
+        frame.pop("vars", None)
+
+
+def _stacktrace_is_protected(stacktrace: Any, extra_prefixes: Iterable[str]) -> bool:
+    if not isinstance(stacktrace, dict):
+        return False
+    frames = stacktrace.get("frames")
+    if not isinstance(frames, list):
+        return False
+    for frame in frames:
+        if not isinstance(frame, dict):
+            continue
+        if _is_protected_module(frame.get("module"), extra_prefixes):
+            return True
+        if _is_protected_filename(frame.get("filename")) or _is_protected_filename(
+            frame.get("abs_path")
+        ):
+            return True
+    return False
+
+
+def _iter_exception_values(event: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    exception = event.get("exception")
+    if isinstance(exception, dict):
+        values = exception.get("values")
+        if isinstance(values, list):
+            for value in values:
+                if isinstance(value, dict):
+                    yield value
+
+
+def _iter_thread_values(event: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    threads = event.get("threads")
+    if isinstance(threads, dict):
+        values = threads.get("values")
+        if isinstance(values, list):
+            for value in values:
+                if isinstance(value, dict):
+                    yield value
+
+
+def event_touches_protected_surface(
+    event: Dict[str, Any], extra_prefixes: Iterable[str] = ()
+) -> bool:
+    """True when any part of the event originates on a protected surface.
+
+    Sensitivity is event-level on purpose: a gateway wrapper exception whose
+    message embeds ``str(inner_research_lab_error)`` must be redacted along
+    with the inner value, so one protected link redacts the whole chain.
+    """
+    if _is_protected_module(event.get("logger"), extra_prefixes):
+        return True
+    for value in _iter_exception_values(event):
+        if _is_protected_module(value.get("module"), extra_prefixes):
+            return True
+        if _stacktrace_is_protected(value.get("stacktrace"), extra_prefixes):
+            return True
+    for thread in _iter_thread_values(event):
+        if _stacktrace_is_protected(thread.get("stacktrace"), extra_prefixes):
+            return True
+    return False
+
+
+def scrub_breadcrumb(
+    crumb: Any,
+    extra_prefixes: Iterable[str] = (),
+    redact_all: bool = False,
+) -> Optional[Dict[str, Any]]:
+    """Return a shippable breadcrumb, or None to drop it entirely.
+
+    Breadcrumbs from protected loggers are dropped rather than redacted: a
+    redacted crumb carries no operational signal, and the buffer must never
+    hold protected content. ``redact_all`` drops every breadcrumb.
+    """
+    if not isinstance(crumb, dict):
+        return None
+    if redact_all:
+        return None
+    category = crumb.get("category")
+    if _is_protected_module(category, extra_prefixes):
+        return None
+    if "message" in crumb:
+        crumb["message"] = scrub_text(
+            crumb.get("message"), MAX_BREADCRUMB_MESSAGE_LENGTH
+        )
+    data = crumb.get("data")
+    if isinstance(data, dict):
+        data.pop("http.query", None)
+        data.pop("http.fragment", None)
+        crumb["data"] = _scrub_object(data)
+    return crumb
+
+
+def scrub_event(
+    event: Any,
+    extra_prefixes: Iterable[str] = (),
+    redact_all: bool = False,
+) -> Optional[Dict[str, Any]]:
+    """Scrub one Sentry event in place and return it, or None to drop it."""
+    if not isinstance(event, dict):
+        return None
+    protected = bool(redact_all) or event_touches_protected_surface(
+        event, extra_prefixes
+    )
+
+    # Envelopes that are payload-shaped by construction are dropped outright.
+    event.pop("request", None)
+    event.pop("user", None)
+    extra = event.get("extra")
+    if isinstance(extra, dict):
+        extra.pop("sys.argv", None)
+
+    for value in _iter_exception_values(event):
+        _scrub_stacktrace(value.get("stacktrace"))
+        if protected:
+            if "value" in value:
+                value["value"] = REDACTED_PROTECTED
+        elif "value" in value:
+            value["value"] = scrub_text(value.get("value"), MAX_MESSAGE_LENGTH)
+    for thread in _iter_thread_values(event):
+        _scrub_stacktrace(thread.get("stacktrace"))
+
+    logentry = event.get("logentry")
+    if isinstance(logentry, dict):
+        if protected:
+            for key in ("message", "formatted"):
+                if key in logentry:
+                    logentry[key] = REDACTED_PROTECTED
+            logentry.pop("params", None)
+        else:
+            for key in ("message", "formatted"):
+                if key in logentry:
+                    logentry[key] = scrub_text(logentry[key], MAX_MESSAGE_LENGTH)
+            if "params" in logentry:
+                logentry["params"] = _scrub_object(logentry.get("params"))
+    if "message" in event:
+        event["message"] = (
+            REDACTED_PROTECTED
+            if protected
+            else scrub_text(event.get("message"), MAX_MESSAGE_LENGTH)
+        )
+
+    breadcrumbs = event.get("breadcrumbs")
+    if isinstance(breadcrumbs, dict):
+        values = breadcrumbs.get("values")
+        if isinstance(values, list):
+            kept = []
+            for crumb in values:
+                scrubbed = scrub_breadcrumb(
+                    crumb, extra_prefixes=extra_prefixes, redact_all=redact_all
+                )
+                if scrubbed is not None:
+                    kept.append(scrubbed)
+            breadcrumbs["values"] = kept
+
+    for envelope in ("extra", "contexts", "tags"):
+        if isinstance(event.get(envelope), dict):
+            event[envelope] = _scrub_object(event[envelope])
+
+    if isinstance(event.get("transaction"), str):
+        event["transaction"] = scrub_text(event["transaction"], 200)
+
+    return event

--- a/neurons/auditor_validator.py
+++ b/neurons/auditor_validator.py
@@ -194,6 +194,20 @@ _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.dirname(_SCRIPT_DIR)
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
+
+# Opt-in, fail-closed error monitoring (docs/sentry_error_monitoring.md).
+# Complete no-op unless the LEADPOET_SENTRY_* environment gate is satisfied;
+# public auditors simply leave the gate unset.
+try:
+    from leadpoet_observability import init_sentry as _init_sentry
+
+    _init_sentry(component="auditor-validator")
+except Exception as _sentry_exc:  # must never break the auditor
+    print(
+        "leadpoet_sentry_wiring_skipped error=%s" % type(_sentry_exc).__name__,
+        flush=True,
+    )
+
 import asyncio
 import logging
 import base64

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -4,6 +4,26 @@ import threading
 import argparse
 import traceback
 import getpass
+
+# Opt-in, fail-closed error monitoring (docs/sentry_error_monitoring.md).
+# Complete no-op unless the LEADPOET_SENTRY_* environment gate is satisfied.
+try:
+    try:
+        from leadpoet_observability import init_sentry as _init_sentry
+    except ImportError:
+        import os as _os
+        import sys as _sys
+
+        _sys.path.append(_os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+        from leadpoet_observability import init_sentry as _init_sentry
+
+    _init_sentry(component="miner")
+except Exception as _sentry_exc:  # error monitoring must never break the miner
+    print(
+        "leadpoet_sentry_wiring_skipped error=%s" % type(_sentry_exc).__name__,
+        flush=True,
+    )
+
 import bittensor as bt
 import socket
 from Leadpoet.base.miner import BaseMinerNeuron

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -13,6 +13,19 @@ sys.path.insert(0, str(Path(__file__).parent.parent.resolve()))
 
 os.environ["PYTHONWARNINGS"] = "ignore::UserWarning"
 
+# Opt-in, fail-closed error monitoring (docs/sentry_error_monitoring.md).
+# Wired before the heavy imports below so import-time crashes are captured.
+# Complete no-op unless the LEADPOET_SENTRY_* environment gate is satisfied.
+try:
+    from leadpoet_observability import init_sentry as _init_sentry
+
+    _init_sentry(component="validator")
+except Exception as _sentry_exc:  # must never break the validator
+    print(
+        "leadpoet_sentry_wiring_skipped error=%s" % type(_sentry_exc).__name__,
+        flush=True,
+    )
+
 import re
 import errno
 import time
@@ -12134,6 +12147,13 @@ def main():
     parser.add_argument("--total-containers", type=int, help="Total number of containers running (for dynamic lead distribution)")
     parser.add_argument("--mode", type=str, choices=["coordinator", "worker", "qualification_worker", "fulfillment_worker"], help="Container mode")
     args = parser.parse_args()
+
+    try:  # low-cardinality triage tag; safe no-op when Sentry is inactive
+        from leadpoet_observability import set_sentry_tag as _set_sentry_tag
+
+        _set_sentry_tag("validator.mode", getattr(args, "mode", None) or "coordinator")
+    except Exception:
+        pass
 
     os.environ.setdefault("BITTENSOR_NETWORK", str(args.subtensor_network))
     os.environ.setdefault("BITTENSOR_NETUID", str(args.netuid))

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,11 @@ arweave-python-client>=1.0.19
 # Monitoring and metrics
 prometheus_client>=0.19.0
 structlog>=23.2.0
+# Error monitoring for HOST processes only — never enclave images (the
+# sentry boundary guard test fails CI if it enters an enclave requirements
+# file). Optional at runtime and inert without the LEADPOET_SENTRY_* env
+# gate; see docs/sentry_error_monitoring.md.
+sentry-sdk>=2.0.0,<3.0.0
 # Keep these pinned for Python 3.9 Docker builds. Langfuse 3.x requires
 # OpenTelemetry >=1.33, whose proto exporter requires protobuf >=5; the
 # validator Firestore stack is pinned to protobuf <5.

--- a/scripts/run_research_lab_scoring_worker.py
+++ b/scripts/run_research_lab_scoring_worker.py
@@ -16,6 +16,18 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+# Opt-in, fail-closed error monitoring (docs/sentry_error_monitoring.md).
+# Complete no-op unless the LEADPOET_SENTRY_* environment gate is satisfied.
+try:
+    from leadpoet_observability import init_sentry  # noqa: E402
+
+    init_sentry(component="research-lab-scoring-worker")
+except Exception as _sentry_exc:  # must never break the worker
+    print(
+        "leadpoet_sentry_wiring_skipped error=%s" % type(_sentry_exc).__name__,
+        flush=True,
+    )
+
 from gateway.research_lab.config import ResearchLabGatewayConfig  # noqa: E402
 from gateway.research_lab.scoring_worker import ResearchLabGatewayScoringWorker  # noqa: E402
 from gateway.research_lab.worker_autostart import (  # noqa: E402

--- a/scripts/run_research_lab_scoring_worker_fleet.py
+++ b/scripts/run_research_lab_scoring_worker_fleet.py
@@ -17,6 +17,18 @@ WORKER_SCRIPT = ROOT / "scripts" / "run_research_lab_scoring_worker.py"
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+# Opt-in, fail-closed error monitoring (docs/sentry_error_monitoring.md).
+# Complete no-op unless the LEADPOET_SENTRY_* environment gate is satisfied.
+try:
+    from leadpoet_observability import init_sentry  # noqa: E402
+
+    init_sentry(component="research-lab-scoring-worker-fleet")
+except Exception as _sentry_exc:  # must never break the fleet supervisor
+    print(
+        "leadpoet_sentry_wiring_skipped error=%s" % type(_sentry_exc).__name__,
+        flush=True,
+    )
+
 from gateway.research_lab.worker_autostart import (  # noqa: E402
     build_research_lab_worker_environment,
 )

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,9 @@ requirements = [
     "click>=8.1.0",
     "typing-extensions>=4.7.0",
     "tenacity>=8.2.0",
+
+    # Error monitoring (opt-in; inert without the LEADPOET_SENTRY_* env gate)
+    "sentry-sdk>=2.0.0,<3.0.0",
     
     # Google Cloud (optional)
     "google-cloud-firestore>=2.11.1",
@@ -140,7 +143,7 @@ setup(
     author="Leadpoet",  
     author_email="hello@leadpoet.com",  
     license="MIT",
-    packages=find_packages(include=['Leadpoet', 'Leadpoet.*', 'miner_models', 'miner_models.*', 'neurons', 'neurons.*', 'validator_models', 'validator_models.*', 'leadpoet_audit', 'leadpoet_audit.*', 'gateway', 'gateway.*', 'leadpoet_canonical', 'leadpoet_canonical.*', 'qualification', 'qualification.*', 'leadpoet_verifier', 'leadpoet_verifier.*', 'research_lab', 'research_lab.*']),
+    packages=find_packages(include=['Leadpoet', 'Leadpoet.*', 'miner_models', 'miner_models.*', 'neurons', 'neurons.*', 'validator_models', 'validator_models.*', 'leadpoet_audit', 'leadpoet_audit.*', 'gateway', 'gateway.*', 'leadpoet_canonical', 'leadpoet_canonical.*', 'qualification', 'qualification.*', 'leadpoet_verifier', 'leadpoet_verifier.*', 'research_lab', 'research_lab.*', 'leadpoet_observability', 'leadpoet_observability.*']),
     package_data={
         "leadpoet_verifier": [
             "fixtures/*.json",

--- a/tests/test_sentry_bootstrap.py
+++ b/tests/test_sentry_bootstrap.py
@@ -1,0 +1,194 @@
+"""Contract tests for the opt-in, fail-closed Sentry bootstrap.
+
+A stub ``sentry_sdk`` module is injected into ``sys.modules`` so these
+tests run identically whether or not the real (optional) dependency is
+installed.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from leadpoet_observability import sentry_bootstrap
+from leadpoet_observability.sentry_scrubbing import REDACTED_PROTECTED
+
+
+class _StubSentrySdk(types.ModuleType):
+    def __init__(self):
+        super().__init__("sentry_sdk")
+        self.init_calls = []
+        self.tags = {}
+
+    def init(self, **kwargs):
+        self.init_calls.append(kwargs)
+
+    def set_tag(self, key, value):
+        self.tags[key] = value
+
+
+@pytest.fixture(autouse=True)
+def _reset_bootstrap_state():
+    sentry_bootstrap._reset_for_tests()
+    yield
+    sentry_bootstrap._reset_for_tests()
+
+
+@pytest.fixture
+def stub_sdk(monkeypatch):
+    stub = _StubSentrySdk()
+    monkeypatch.setitem(sys.modules, "sentry_sdk", stub)
+    return stub
+
+
+@pytest.fixture
+def enabled_env(monkeypatch):
+    monkeypatch.setenv(sentry_bootstrap.ENABLED_ENV, "1")
+    monkeypatch.setenv(sentry_bootstrap.DSN_ENV, "https://key@example.ingest.sentry.io/1")
+    monkeypatch.delenv(sentry_bootstrap.ENVIRONMENT_ENV, raising=False)
+    monkeypatch.delenv(sentry_bootstrap.RELEASE_ENV, raising=False)
+    monkeypatch.delenv(sentry_bootstrap.EXTRA_PROTECTED_ENV, raising=False)
+    monkeypatch.delenv(sentry_bootstrap.MESSAGE_MODE_ENV, raising=False)
+
+
+def test_complete_noop_without_env_gate(monkeypatch, stub_sdk):
+    monkeypatch.delenv(sentry_bootstrap.ENABLED_ENV, raising=False)
+    monkeypatch.delenv(sentry_bootstrap.DSN_ENV, raising=False)
+    assert sentry_bootstrap.init_sentry("test") is False
+    assert stub_sdk.init_calls == []
+
+
+def test_enabled_flag_alone_is_not_enough(monkeypatch, stub_sdk):
+    monkeypatch.setenv(sentry_bootstrap.ENABLED_ENV, "true")
+    monkeypatch.delenv(sentry_bootstrap.DSN_ENV, raising=False)
+    assert sentry_bootstrap.init_sentry("test") is False
+    assert stub_sdk.init_calls == []
+
+
+def test_dsn_alone_is_not_enough(monkeypatch, stub_sdk):
+    monkeypatch.delenv(sentry_bootstrap.ENABLED_ENV, raising=False)
+    monkeypatch.setenv(sentry_bootstrap.DSN_ENV, "https://key@example/1")
+    assert sentry_bootstrap.init_sentry("test") is False
+    assert stub_sdk.init_calls == []
+
+
+def test_initializes_with_hard_off_capture_options(enabled_env, stub_sdk):
+    assert sentry_bootstrap.init_sentry("gateway") is True
+    assert len(stub_sdk.init_calls) == 1
+    kwargs = stub_sdk.init_calls[0]
+    assert kwargs["dsn"] == "https://key@example.ingest.sentry.io/1"
+    assert kwargs["environment"] == "production"
+    # Errors only; payload capture hard-off.
+    assert kwargs["traces_sample_rate"] is None
+    assert kwargs["auto_session_tracking"] is False
+    assert kwargs["send_default_pii"] is False
+    assert kwargs["include_local_variables"] is False
+    assert kwargs["max_request_body_size"] == "never"
+    assert kwargs["auto_enabling_integrations"] is False
+    assert kwargs["debug"] is False
+    assert callable(kwargs["before_send"])
+    assert callable(kwargs["before_breadcrumb"])
+    assert stub_sdk.tags["leadpoet.component"] == "gateway"
+
+
+def test_first_call_wins_and_later_calls_do_not_reinit(enabled_env, stub_sdk):
+    assert sentry_bootstrap.init_sentry("gateway") is True
+    assert sentry_bootstrap.init_sentry("validator") is True
+    assert len(stub_sdk.init_calls) == 1
+    assert stub_sdk.tags["leadpoet.component"] == "gateway"
+
+
+def test_missing_sdk_is_swallowed(monkeypatch, enabled_env):
+    # None in sys.modules makes ``import sentry_sdk`` raise ImportError.
+    monkeypatch.setitem(sys.modules, "sentry_sdk", None)
+    assert sentry_bootstrap.init_sentry("gateway") is False
+
+
+def test_sdk_init_failure_is_swallowed(enabled_env, stub_sdk):
+    def _boom(**kwargs):
+        raise RuntimeError("unknown option")
+
+    stub_sdk.init = _boom
+    assert sentry_bootstrap.init_sentry("gateway") is False
+
+
+def test_before_send_scrubs_and_fails_closed(enabled_env, stub_sdk, monkeypatch):
+    sentry_bootstrap.init_sentry("gateway")
+    before_send = stub_sdk.init_calls[0]["before_send"]
+
+    event = {"message": "user a@b.co failed", "request": {"data": "body"}}
+    scrubbed = before_send(event, None)
+    assert "request" not in scrubbed
+    assert "a@b.co" not in scrubbed["message"]
+
+    def _raise(*args, **kwargs):
+        raise ValueError("scrubber broke")
+
+    monkeypatch.setattr(
+        sentry_bootstrap.sentry_scrubbing, "scrub_event", _raise
+    )
+    assert before_send({"message": "x"}, None) is None
+
+
+def test_before_breadcrumb_drops_protected_categories(enabled_env, stub_sdk):
+    sentry_bootstrap.init_sentry("gateway")
+    before_breadcrumb = stub_sdk.init_calls[0]["before_breadcrumb"]
+    assert before_breadcrumb({"category": "research_lab.engine_v1", "message": "m"}, None) is None
+    kept = before_breadcrumb({"category": "gateway.db", "message": "ok"}, None)
+    assert kept["message"] == "ok"
+
+
+def test_extra_protected_modules_env_widens_redaction(monkeypatch, enabled_env, stub_sdk):
+    monkeypatch.setenv(sentry_bootstrap.EXTRA_PROTECTED_ENV, "myco.private, other.pkg")
+    sentry_bootstrap.init_sentry("gateway")
+    before_send = stub_sdk.init_calls[0]["before_send"]
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "ValueError",
+                    "value": "secret sauce",
+                    "stacktrace": {
+                        "frames": [{"module": "myco.private.engine", "filename": "x.py"}]
+                    },
+                }
+            ]
+        }
+    }
+    scrubbed = before_send(event, None)
+    assert scrubbed["exception"]["values"][0]["value"] == REDACTED_PROTECTED
+
+
+def test_redact_all_message_mode(monkeypatch, enabled_env, stub_sdk):
+    monkeypatch.setenv(sentry_bootstrap.MESSAGE_MODE_ENV, "redact-all")
+    sentry_bootstrap.init_sentry("gateway")
+    before_send = stub_sdk.init_calls[0]["before_send"]
+    scrubbed = before_send({"message": "ordinary infra message"}, None)
+    assert scrubbed["message"] == REDACTED_PROTECTED
+
+
+def test_release_env_override_wins(monkeypatch, enabled_env, stub_sdk):
+    monkeypatch.setenv(sentry_bootstrap.RELEASE_ENV, "ab" * 20)
+    sentry_bootstrap.init_sentry("gateway")
+    assert stub_sdk.init_calls[0]["release"] == "ab" * 20
+
+
+def test_set_sentry_tag_is_inert_when_inactive(stub_sdk):
+    sentry_bootstrap.set_sentry_tag("validator.mode", "worker")
+    assert stub_sdk.tags == {}
+
+
+def test_set_sentry_tag_scrubs_values_when_active(enabled_env, stub_sdk):
+    sentry_bootstrap.init_sentry("gateway")
+    sentry_bootstrap.set_sentry_tag("note", "reach me at a@b.co")
+    assert "a@b.co" not in stub_sdk.tags["leadpoet.note"]
+
+
+def test_init_never_raises_even_on_weird_environment(monkeypatch, stub_sdk):
+    monkeypatch.setenv(sentry_bootstrap.ENABLED_ENV, "1")
+    monkeypatch.setenv(sentry_bootstrap.DSN_ENV, "   ")
+    # Whitespace DSN fails the gate: still a clean no-op, never a raise.
+    assert sentry_bootstrap.init_sentry("gateway") is False
+    assert stub_sdk.init_calls == []

--- a/tests/test_sentry_boundary_guard.py
+++ b/tests/test_sentry_boundary_guard.py
@@ -1,0 +1,195 @@
+"""CI guard: the Sentry error-monitoring boundary is code-enforced.
+
+Error monitoring is a single, explicit, opt-in bootstrap in
+``leadpoet_observability/sentry_bootstrap.py`` (namespaced
+``LEADPOET_SENTRY_*`` variables, hard-off payload capture, fail-closed
+scrubbing in ``sentry_scrubbing.py``). This guard fails the build the
+moment any change crosses that boundary:
+
+1. ``sentry_sdk`` is imported or referenced only inside the bootstrap;
+2. enclave requirement files and enclave/TEE surfaces never gain Sentry
+   (enclave images are measured — PCR0 — and have no general egress);
+3. non-namespaced ``SENTRY_*`` variables are referenced nowhere (the SDK
+   must never pick up an ambient destination);
+4. the hard-off capture options and scrubbing hooks stay in the bootstrap;
+5. the scrubber keeps stripping stack locals, source context, the request
+   and user envelopes, and argv;
+6. every wired host entry point keeps its ``init_sentry`` call, so process
+   coverage cannot silently regress.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP = "leadpoet_observability/sentry_bootstrap.py"
+SCRUBBING = "leadpoet_observability/sentry_scrubbing.py"
+THIS_GUARD = "tests/test_sentry_boundary_guard.py"
+
+ENCLAVE_REQUIREMENT_FILES = (
+    "validator_tee/enclave/requirements.txt",
+    "gateway/tee/requirements.txt",
+    "gateway/tee/requirements-scoring-py39.in",
+    "gateway/tee/requirements-scoring-py39.lock",
+)
+
+ENCLAVE_SURFACE_PREFIXES = ("validator_tee/enclave/", "gateway/tee/")
+
+WIRED_ENTRY_POINTS = (
+    "gateway/main.py",
+    "neurons/validator.py",
+    "neurons/miner.py",
+    "neurons/auditor_validator.py",
+    "gateway/research_lab/worker_process.py",
+    "scripts/run_research_lab_scoring_worker.py",
+    "scripts/run_research_lab_scoring_worker_fleet.py",
+)
+
+
+def _tracked_files() -> list:
+    output = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def _read(relative: str) -> str:
+    try:
+        return (REPO_ROOT / relative).read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def test_sentry_sdk_references_only_in_bootstrap() -> None:
+    pattern = re.compile(r"\bsentry_sdk\b")
+    offenders = []
+    for relative in _tracked_files():
+        if not relative.endswith(".py"):
+            continue
+        if relative == BOOTSTRAP or relative.startswith("tests/"):
+            continue
+        if pattern.search(_read(relative)):
+            offenders.append(relative)
+    assert not offenders, (
+        "sentry_sdk may be imported/initialized ONLY inside the bootstrap "
+        "module — a second init point could bypass the fail-closed scrubber. "
+        f"Offending files: {offenders}"
+    )
+
+
+def test_enclave_requirement_files_never_gain_sentry() -> None:
+    offenders = []
+    for relative in ENCLAVE_REQUIREMENT_FILES:
+        if "sentry" in _read(relative).lower():
+            offenders.append(relative)
+    assert not offenders, (
+        "Enclave images are measured (PCR0) and have no general egress; "
+        f"sentry-sdk must never enter them. Offending files: {offenders}"
+    )
+
+
+def test_enclave_and_tee_surfaces_never_reference_error_monitoring() -> None:
+    pattern = re.compile(r"sentry_sdk|leadpoet_observability")
+    offenders = []
+    for relative in _tracked_files():
+        if not relative.startswith(ENCLAVE_SURFACE_PREFIXES):
+            continue
+        if pattern.search(_read(relative)):
+            offenders.append(relative)
+    assert not offenders, (
+        "Enclave/TEE surfaces must never wire error monitoring; the gateway "
+        "host process init already covers host-side TEE modules. "
+        f"Offending files: {offenders}"
+    )
+
+
+def test_no_ambient_sentry_variables_referenced() -> None:
+    # LEADPOET_SENTRY_* is the only permitted namespace. An ambient
+    # SENTRY_DSN / SENTRY_ENVIRONMENT reference would let the SDK acquire a
+    # destination outside the explicit bootstrap options.
+    pattern = re.compile(r"(?<![A-Z_])SENTRY_[A-Z]")
+    offenders = []
+    for relative in _tracked_files():
+        if relative == THIS_GUARD:
+            continue
+        if not relative.endswith(
+            (".py", ".sh", ".bash", ".yml", ".yaml", ".md", ".env", ".example", "Dockerfile")
+        ) and "Dockerfile" not in relative:
+            continue
+        if pattern.search(_read(relative)):
+            offenders.append(relative)
+    assert not offenders, (
+        "Only namespaced LEADPOET_SENTRY_* variables may exist. "
+        f"Offending files: {offenders}"
+    )
+
+
+def test_bootstrap_hard_off_options_present() -> None:
+    source = _read(BOOTSTRAP)
+    for marker in (
+        'include_local_variables=False',
+        'send_default_pii=False',
+        'max_request_body_size="never"',
+        'traces_sample_rate=None',
+        'auto_session_tracking=False',
+        'auto_enabling_integrations=False',
+        'debug=False',
+        'before_send=',
+        'before_breadcrumb=',
+        'LEADPOET_SENTRY_ENABLED',
+        'LEADPOET_SENTRY_DSN',
+    ):
+        assert marker in source, (
+            "the bootstrap's hard-off capture contract drifted: missing "
+            f"{marker!r}"
+        )
+    assert "profiles_sample_rate" not in source, (
+        "profiling must never be enabled — errors only"
+    )
+
+
+def test_bootstrap_fails_closed_and_swallows_wiring_failures() -> None:
+    source = _read(BOOTSTRAP)
+    assert "leadpoet_sentry_scrub_failed" in source and "return None" in source, (
+        "a scrub failure must DROP the event (fail closed), never send it"
+    )
+    assert "except BaseException" in source, (
+        "init and the scrub hooks must swallow every failure — error "
+        "monitoring can never break a runtime"
+    )
+
+
+def test_scrubber_envelope_hygiene_markers_present() -> None:
+    source = _read(SCRUBBING)
+    for marker in (
+        'frame.pop("context_line", None)',
+        'frame.pop("pre_context", None)',
+        'frame.pop("post_context", None)',
+        'frame.pop("vars", None)',
+        'event.pop("request", None)',
+        'event.pop("user", None)',
+        'extra.pop("sys.argv", None)',
+    ):
+        assert marker in source, (
+            "the scrubber's envelope hygiene drifted: missing "
+            f"{marker!r}"
+        )
+
+
+def test_every_wired_entry_point_initializes_sentry() -> None:
+    missing = [
+        relative
+        for relative in WIRED_ENTRY_POINTS
+        if "init_sentry(" not in _read(relative)
+    ]
+    assert not missing, (
+        "a wired host entry point lost its init_sentry call — process "
+        f"coverage silently regressed: {missing}"
+    )

--- a/tests/test_sentry_scrubbing.py
+++ b/tests/test_sentry_scrubbing.py
@@ -1,0 +1,319 @@
+"""Behavioral tests for the fail-closed Sentry event scrubber.
+
+Pure-stdlib tests: they must pass with or without sentry-sdk installed.
+"""
+
+from __future__ import annotations
+
+from leadpoet_observability.sentry_scrubbing import (
+    MAX_MESSAGE_LENGTH,
+    REDACTED,
+    REDACTED_PROTECTED,
+    TRUNCATION_SUFFIX,
+    event_touches_protected_surface,
+    scrub_breadcrumb,
+    scrub_event,
+    scrub_text,
+)
+
+
+def _frame(module, filename="gateway/api/validate.py", **overrides):
+    frame = {
+        "module": module,
+        "filename": filename,
+        "abs_path": "/home/ec2-user/leadpoet_repo/" + filename,
+        "function": "handler",
+        "lineno": 10,
+        "context_line": "secret_source_line()",
+        "pre_context": ["before"],
+        "post_context": ["after"],
+        "vars": {"prompt": "SHOULD NEVER SHIP"},
+    }
+    frame.update(overrides)
+    return frame
+
+
+def _exception_event(module, value="boom", filename="gateway/api/validate.py"):
+    return {
+        "exception": {
+            "values": [
+                {
+                    "type": "ValueError",
+                    "value": value,
+                    "stacktrace": {"frames": [_frame(module, filename)]},
+                }
+            ]
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Frame hygiene: source context and locals never leave the process
+# ---------------------------------------------------------------------------
+
+
+def test_source_context_and_locals_stripped_from_every_frame():
+    event = scrub_event(_exception_event("gateway.api.validate"))
+    frame = event["exception"]["values"][0]["stacktrace"]["frames"][0]
+    assert "context_line" not in frame
+    assert "pre_context" not in frame
+    assert "post_context" not in frame
+    assert "vars" not in frame
+    # Debugging identity survives.
+    assert frame["function"] == "handler"
+    assert frame["lineno"] == 10
+
+
+def test_thread_frames_are_stripped_too():
+    event = {
+        "threads": {
+            "values": [{"stacktrace": {"frames": [_frame("gateway.tasks.anchor")]}}]
+        }
+    }
+    scrubbed = scrub_event(event)
+    frame = scrubbed["threads"]["values"][0]["stacktrace"]["frames"][0]
+    assert "context_line" not in frame and "vars" not in frame
+
+
+# ---------------------------------------------------------------------------
+# Protected surfaces: type + stack survive, messages never do
+# ---------------------------------------------------------------------------
+
+
+def test_protected_module_redacts_message_but_keeps_type_and_stack():
+    event = scrub_event(
+        _exception_event("research_lab.hosted_loop", value="prompt was: SECRET ICP")
+    )
+    entry = event["exception"]["values"][0]
+    assert entry["value"] == REDACTED_PROTECTED
+    assert entry["type"] == "ValueError"
+    assert entry["stacktrace"]["frames"][0]["module"] == "research_lab.hosted_loop"
+
+
+def test_protected_filename_matches_when_module_is_missing():
+    event = _exception_event(
+        None, value="candidate diff contents", filename="gateway/research_lab/code_loop_engine.py"
+    )
+    assert event_touches_protected_surface(event)
+    scrubbed = scrub_event(event)
+    assert scrubbed["exception"]["values"][0]["value"] == REDACTED_PROTECTED
+
+
+def test_one_protected_link_redacts_the_whole_exception_chain():
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "ValueError",
+                    "value": "inner trajectory payload",
+                    "stacktrace": {"frames": [_frame("research_lab.trajectory_corpus")]},
+                },
+                {
+                    "type": "RuntimeError",
+                    "value": "wrapper embedding str(inner): inner trajectory payload",
+                    "stacktrace": {"frames": [_frame("gateway.tasks.epoch_lifecycle")]},
+                },
+            ]
+        }
+    }
+    scrubbed = scrub_event(event)
+    values = scrubbed["exception"]["values"]
+    assert all(entry["value"] == REDACTED_PROTECTED for entry in values)
+
+
+def test_protected_thread_frame_marks_whole_event_protected():
+    event = _exception_event("gateway.api.validate", value="looks harmless")
+    event["threads"] = {
+        "values": [{"stacktrace": {"frames": [_frame("miner_models.intent_model")]}}]
+    }
+    scrubbed = scrub_event(event)
+    assert scrubbed["exception"]["values"][0]["value"] == REDACTED_PROTECTED
+
+
+def test_protected_logger_redacts_log_events_and_drops_params():
+    event = {
+        "logger": "research_lab.observability.tracing",
+        "logentry": {"message": "trace body %s", "params": ["TRAJECTORY DATA"]},
+    }
+    scrubbed = scrub_event(event)
+    assert scrubbed["logentry"]["message"] == REDACTED_PROTECTED
+    assert "params" not in scrubbed["logentry"]
+
+
+def test_langfuse_and_llm_client_modules_are_protected():
+    for module in ("langfuse.client", "openai._base_client", "anthropic.resources"):
+        event = scrub_event(_exception_event(module, value="request echo"))
+        assert event["exception"]["values"][0]["value"] == REDACTED_PROTECTED
+
+
+def test_extra_prefixes_widen_protection():
+    event = _exception_event("myco.private_engine", value="secret sauce")
+    scrubbed = scrub_event(event, extra_prefixes=("myco.private_engine",))
+    assert scrubbed["exception"]["values"][0]["value"] == REDACTED_PROTECTED
+
+
+def test_redact_all_mode_redacts_infra_surfaces_too():
+    event = _exception_event("gateway.api.validate", value="ordinary message")
+    event["breadcrumbs"] = {"values": [{"category": "gateway.db", "message": "x"}]}
+    scrubbed = scrub_event(event, redact_all=True)
+    assert scrubbed["exception"]["values"][0]["value"] == REDACTED_PROTECTED
+    assert scrubbed["breadcrumbs"]["values"] == []
+
+
+# ---------------------------------------------------------------------------
+# Infra surfaces: messages survive scrubbed
+# ---------------------------------------------------------------------------
+
+
+def test_infra_message_scrubs_email_and_phone_but_stays_informative():
+    event = scrub_event(
+        _exception_event(
+            "gateway.api.validate",
+            value="rejected john.doe@acme.com at (415) 555-0100 retrying",
+        )
+    )
+    value = event["exception"]["values"][0]["value"]
+    assert "acme.com" not in value and "555-0100" not in value
+    assert "[leadpoet-redacted:email]" in value
+    assert "[leadpoet-redacted:phone]" in value
+    assert "retrying" in value
+
+
+def test_secret_shaped_values_are_redacted():
+    for text in (
+        "auth failed Bearer abcdef12345678",
+        "key AKIAABCDEFGHIJKLMNOP rejected",
+        "jwt eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N",
+    ):
+        assert scrub_text(text) != text
+
+
+def test_secret_marker_redacts_whole_string():
+    assert scrub_text("request with sk-or-v1-abc123 embedded") == REDACTED
+    assert scrub_text("dump of judge_prompt follows") == REDACTED
+
+
+def test_url_query_strings_are_stripped():
+    scrubbed = scrub_text("GET https://x.supabase.co/rest/v1/leads?email=eq.a@b.co failed")
+    assert "email=eq" not in scrubbed
+    assert "?[leadpoet-redacted:query]" in scrubbed
+
+
+def test_join_keys_survive_verbatim():
+    for ref in (
+        "execution_trace:0f8fad5b-d9cb-469f-a165-70867728950e",
+        "cost_ledger:sha256:" + "ab" * 32,
+        "0f8fad5bd9cb469fa16570867728950e",
+    ):
+        assert scrub_text(ref) == ref
+
+
+def test_numeric_ranges_are_not_phone_false_positives():
+    text = "allocation bytes 6553000-6553360 at block 24151"
+    assert scrub_text(text) == text
+
+
+def test_long_messages_are_truncated():
+    scrubbed = scrub_text("x" * (MAX_MESSAGE_LENGTH * 3), MAX_MESSAGE_LENGTH)
+    assert scrubbed.endswith(TRUNCATION_SUFFIX)
+    assert len(scrubbed) == MAX_MESSAGE_LENGTH + len(TRUNCATION_SUFFIX)
+
+
+# ---------------------------------------------------------------------------
+# Envelope hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_request_user_and_argv_are_dropped():
+    event = {
+        "request": {"url": "https://gw/x?secret=1", "data": "body"},
+        "user": {"ip_address": "1.2.3.4"},
+        "extra": {"sys.argv": ["validator.py", "--wallet_name", "w"], "note": "keep"},
+        "message": "ok",
+    }
+    scrubbed = scrub_event(event)
+    assert "request" not in scrubbed
+    assert "user" not in scrubbed
+    assert "sys.argv" not in scrubbed["extra"]
+    assert scrubbed["extra"]["note"] == "keep"
+
+
+def test_extra_key_based_redaction_and_scalar_preservation():
+    event = {
+        "extra": {
+            "openrouter_api_key": "sk-live",
+            "lead_email": "a@b.co",
+            "page_content": "scraped html",
+            "retry_count": 3,
+            "epoch": 24151,
+            "candidate_sha": "ab" * 20,
+            "status_code": 503,
+        }
+    }
+    scrubbed = scrub_event(event)["extra"]
+    assert scrubbed["openrouter_api_key"] == REDACTED
+    assert scrubbed["lead_email"] == REDACTED
+    assert scrubbed["page_content"] == REDACTED
+    assert scrubbed["retry_count"] == 3
+    assert scrubbed["epoch"] == 24151
+    assert scrubbed["candidate_sha"] == "ab" * 20
+    assert scrubbed["status_code"] == 503
+
+
+def test_leadpoet_tag_keys_are_not_false_positives():
+    event = {"tags": {"leadpoet.component": "gateway", "leadpoet.validator.mode": "coordinator"}}
+    scrubbed = scrub_event(event)["tags"]
+    assert scrubbed["leadpoet.component"] == "gateway"
+    assert scrubbed["leadpoet.validator.mode"] == "coordinator"
+
+
+def test_arbitrary_objects_in_extra_never_serialize_their_repr():
+    class Payload:
+        def __repr__(self):
+            return "FULL LEAD DUMP"
+
+    scrubbed = scrub_event({"extra": {"note": Payload()}})
+    assert scrubbed["extra"]["note"] == REDACTED
+
+
+def test_non_dict_events_are_dropped():
+    assert scrub_event(None) is None
+    assert scrub_event("nonsense") is None
+
+
+# ---------------------------------------------------------------------------
+# Breadcrumbs
+# ---------------------------------------------------------------------------
+
+
+def test_breadcrumbs_from_protected_loggers_are_dropped():
+    event = {
+        "breadcrumbs": {
+            "values": [
+                {"category": "langfuse.client", "message": "trace payload"},
+                {"category": "research_lab.engine_v1", "message": "prompt"},
+                {
+                    "category": "gateway.db.client",
+                    "message": "select ok for a@b.co",
+                    "data": {
+                        "url": "https://x.co/rest/v1/t?apikey=1",
+                        "http.query": "apikey=1",
+                        "status_code": 200,
+                    },
+                },
+            ]
+        }
+    }
+    kept = scrub_event(event)["breadcrumbs"]["values"]
+    assert len(kept) == 1
+    crumb = kept[0]
+    assert crumb["category"] == "gateway.db.client"
+    assert "a@b.co" not in crumb["message"]
+    assert "http.query" not in crumb["data"]
+    assert "apikey=1" not in crumb["data"]["url"]
+    assert crumb["data"]["status_code"] == 200
+
+
+def test_scrub_breadcrumb_rejects_non_dicts():
+    assert scrub_breadcrumb(None) is None
+    assert scrub_breadcrumb("x") is None


### PR DESCRIPTION
## Summary

Cohesive, **opt-in, fail-closed** Sentry error monitoring across every Leadpoet HOST runtime — built to answer "what is breaking and where" (crashes, unhandled thread/task failures, ERROR-level logs) while making it structurally impossible to ship trajectory/training data, prompts, benchmarks, model internals, contact data, or secrets. Follows the same philosophy as the OTel bootstrap in `TELEMETRY.md`: namespaced env gate, explicit options, swallowed wiring failures, CI-enforced boundary.

Full contract + activation runbook: `docs/sentry_error_monitoring.md`.

## What's in it

- **`leadpoet_observability/`** (new, stdlib-only at import):
  - `sentry_bootstrap.py` — no-op unless `LEADPOET_SENTRY_ENABLED` **and** `LEADPOET_SENTRY_DSN` are set; ambient `SENTRY_*` never read; every option explicit; first-call-wins; never raises; release auto-derived from `.git/HEAD`.
  - `sentry_scrubbing.py` — fail-closed scrubber; an event that cannot be fully scrubbed is **dropped**, never sent partially.
- **Wired entry points** (each in `try/except` that can never break startup): `gateway` (`gateway/main.py`), `validator` (`neurons/validator.py`, mode tagged), `miner`, `auditor-validator`, `research-lab-worker` (hosted/scoring, kind tagged), `research-lab-scoring-worker`, and the scoring-worker fleet supervisor. Coverage inside each process is automatic via excepthook + threading hook + stdlib logging at ERROR (`bt.logging`, `uvicorn.error`, and asyncio's unhandled-task handler all route through stdlib logging). **Never wired: the attested enclaves.**

## IP-protection guarantees (CI-enforced)

1. **No stack locals** (`include_local_variables=False`) and **no source context lines** in any frame — an error inside LLM-generated candidate code or a model artifact exports file/function/line only.
2. **Protected surfaces lose messages entirely**: events touching `research_lab`, `gateway.research_lab`, fulfillment, qualification, `leadpoet_verifier`, miner/validator models, lead pool/queue, or the langfuse/openai/anthropic/openrouter/firecrawl clients keep exception type + stack + logger; every message becomes `[leadpoet-redacted:protected-surface]`. One protected link redacts the whole exception chain; protected-logger breadcrumbs are dropped.
3. **Everything else regex-scrubbed**: emails, formatted phones, `sk-*`/AKIA/JWT/bearer values, the `redaction.py` marker vocabulary, URL query strings, 500-char caps — UUID/sha256 join keys (`execution_trace:`, `cost_ledger:`) survive verbatim.
4. **Hard-off**: request/user envelopes, argv, cookies, tracing, profiling, sessions, framework/DB/HTTP auto-instrumentation.
5. **Widen-only knobs**: `LEADPOET_SENTRY_EXTRA_PROTECTED_MODULES`, `LEADPOET_SENTRY_MESSAGE_MODE=redact-all`.

`tests/test_sentry_boundary_guard.py` (modeled on the OTel guard) fails CI if: `sentry_sdk` appears outside the bootstrap, sentry enters an enclave requirements file or enclave/TEE surface, a non-namespaced `SENTRY_*` var is referenced, a hard-off option drifts, scrubber hygiene markers disappear, or a wired entry point loses its `init_sentry` call.

## Verification

- 47 new tests (`test_sentry_scrubbing.py`, `test_sentry_bootstrap.py` via stub SDK — pass with or without sentry-sdk installed, `test_sentry_boundary_guard.py`) + existing OTel guard and redaction suites: **104 passed** on this branch.
- `git diff --check` + `python -m compileall` green on this branch.
- **End-to-end against real sentry-sdk 2.66.1** (isolated venv, capturing transport): init accepts every option; a `research_lab` ERROR log shipped fully redacted; a PII/secret-laden exception shipped as `[leadpoet-redacted]`; no frame carried locals or source; tags + git-derived release correct.
- Docker-dependent stages: none invoked (no Docker touched by this change).
- Unexercised: delivery to a live Sentry project (needs a real DSN) and activation on production hosts.

## Activation / deployment notes

- Code is **inert until the env gate is set**; runtimes without `sentry-sdk` installed no-op with a single log line. Merging changes no runtime behavior.
- `sentry-sdk>=2.0,<3.0` added to `requirements.txt` + `setup.py` (host installs only; the guard blocks enclave requirement files, so no PCR0 impact from the dependency). Per repo rules a dependency change invalidates prior rehearsal evidence — first production activation rides the normal V2 release gate, and merge timing should respect the deployment window rules.
- DSN lives only in operator env files; never committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
