### PR TITLE
Fix gateway-measured weight input authority drift

### DIFF
--- a/gateway/api/weights.py
+++ b/gateway/api/weights.py
@@ -79,6 +79,7 @@ from leadpoet_canonical.compact_auditor_authority_v2 import (
     verify_compact_weight_submission_v2,
 )
 from leadpoet_canonical.hotkey_authority_v2 import (
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
     subnet_epoch_candidate_authorization_message_v1,
     validate_weight_inputs_request_v2,
     weight_inputs_request_message_v2,
@@ -118,11 +119,11 @@ _WEIGHT_AUTHORITY_LOADS_INFLIGHT: Dict[
     asyncio.Task,
 ] = {}
 _WEIGHT_INPUT_LOADS_INFLIGHT: Dict[
-    tuple[int, str],
+    tuple[int, str, str],
     asyncio.Task,
 ] = {}
 _WEIGHT_INPUT_RESULTS: Dict[
-    tuple[int, str],
+    tuple[int, str, str],
     tuple[float, Dict[str, Any]],
 ] = {}
 _WEIGHT_INPUT_RESULT_TTL_SECONDS = 120.0
@@ -214,6 +215,7 @@ async def _build_weight_inputs_v2_singleflight(
     calculation_snapshot: Dict[str, Any],
     leaderboard_window_start: str,
     leaderboard_window_end: str,
+    snapshot_authority_mode: Optional[str],
 ) -> Dict[str, Any]:
     """Share one exact immutable input reconstruction across HTTP retries."""
 
@@ -225,7 +227,7 @@ async def _build_weight_inputs_v2_singleflight(
     )
 
     loop = asyncio.get_running_loop()
-    key = (id(loop), str(request_hash))
+    key = (id(loop), str(request_hash), str(snapshot_authority_mode or "legacy"))
     cached = _WEIGHT_INPUT_RESULTS.get(key)
     if cached is not None:
         expires_at, result = cached
@@ -249,6 +251,7 @@ async def _build_weight_inputs_v2_singleflight(
                 allocation_graph=allocation_graph,
                 leaderboard_window_start=str(leaderboard_window_start),
                 leaderboard_window_end=str(leaderboard_window_end),
+                snapshot_authority_mode=snapshot_authority_mode,
             )
 
         task = asyncio.create_task(_build())
@@ -280,11 +283,13 @@ async def _build_weight_inputs_v2_singleflight(
     return await asyncio.shield(task)
 
 
-def _weight_inputs_v2_has_authorized_work(request_hash: str) -> bool:
+def _weight_inputs_v2_has_authorized_work(
+    request_hash: str, snapshot_authority_mode: Optional[str]
+) -> bool:
     """Return whether this process already authorized the exact request."""
 
     loop = asyncio.get_running_loop()
-    key = (id(loop), str(request_hash))
+    key = (id(loop), str(request_hash), str(snapshot_authority_mode or "legacy"))
     cached = _WEIGHT_INPUT_RESULTS.get(key)
     if cached is not None:
         expires_at, _result = cached
@@ -771,6 +776,10 @@ class WeightInputsV2Response(BaseModel):
     input_receipt_hashes: Dict[str, str]
     gateway_authority_event_hash: str
     upstream_receipt_set: Dict[str, Any]
+    snapshot_authority_mode: Optional[str] = None
+    authoritative_calculation_snapshot: Optional[Dict[str, Any]] = None
+    authoritative_calculation_snapshot_hash: Optional[str] = None
+    normalized_source_categories: Optional[List[str]] = None
 
 
 class WeightInputsCompactV2Response(BaseModel):
@@ -782,6 +791,10 @@ class WeightInputsCompactV2Response(BaseModel):
     gateway_authority_event_hash: str
     upstream_ancestry_proofs: Dict[str, Any]
     upstream_transport_attempts: List[Dict[str, Any]]
+    snapshot_authority_mode: Optional[str] = None
+    authoritative_calculation_snapshot: Optional[Dict[str, Any]] = None
+    authoritative_calculation_snapshot_hash: Optional[str] = None
+    normalized_source_categories: Optional[List[str]] = None
 
 
 class SubnetEpochCandidateSubmissionV1(BaseModel):
@@ -1632,7 +1645,10 @@ async def get_weight_inputs_v2(
     # An exact signed retry may arrive after the original authorized build has
     # outlived MAX_BLOCK_DRIFT. Attach it to that same immutable work/result;
     # all new request hashes must still pass current chain authority.
-    authorized_work = _weight_inputs_v2_has_authorized_work(request["request_hash"])
+    snapshot_authority_mode = request.get("snapshot_authority_mode")
+    authorized_work = _weight_inputs_v2_has_authorized_work(
+        request["request_hash"], snapshot_authority_mode
+    )
     if not authorized_work:
         await _verify_epoch_block_authority(
             netuid=request["netuid"],
@@ -1664,6 +1680,7 @@ async def get_weight_inputs_v2(
                 calculation_snapshot=calculation,
                 leaderboard_window_start=request["leaderboard_window_start"],
                 leaderboard_window_end=request["leaderboard_window_end"],
+                snapshot_authority_mode=snapshot_authority_mode,
             )
     except HTTPException:
         raise
@@ -1704,6 +1721,31 @@ async def get_weight_inputs_v2(
         == "compact-v2"
     )
     compact = result.get("compact_ancestry")
+    normalized_response = (
+        snapshot_authority_mode == GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+    )
+    normalized_kwargs = {}
+    if normalized_response:
+        expected_fields = {
+            "snapshot_authority_mode",
+            "authoritative_calculation_snapshot",
+            "authoritative_calculation_snapshot_hash",
+            "normalized_source_categories",
+        }
+        if not expected_fields.issubset(set(result)):
+            raise HTTPException(
+                status_code=503,
+                detail="Authenticated normalized V2 weight inputs are incomplete",
+            )
+        if result.get("snapshot_authority_mode") != snapshot_authority_mode:
+            raise HTTPException(
+                status_code=503,
+                detail="Authenticated normalized V2 weight input mode differs",
+            )
+        normalized_kwargs = {
+            field: result[field]
+            for field in sorted(expected_fields)
+        }
     if compact_requested:
         if not isinstance(compact, Mapping):
             # A compact-capable validator has explicitly selected the bounded
@@ -1733,6 +1775,7 @@ async def get_weight_inputs_v2(
             upstream_transport_attempts=compact[
                 "upstream_transport_attempts"
             ],
+            **normalized_kwargs,
         )
     else:
         # Old persisted results and N-1 validators retain their exact full
@@ -1744,9 +1787,10 @@ async def get_weight_inputs_v2(
             input_receipt_hashes=result["input_receipt_hashes"],
             gateway_authority_event_hash=result["gateway_authority_event_hash"],
             upstream_receipt_set=result["upstream_receipt_set"],
+            **normalized_kwargs,
         )
     return _weight_authority_http_response(
-        response.model_dump(mode="json"),
+        response.model_dump(mode="json", exclude_none=True),
         accept_encoding=http_request.headers.get("accept-encoding", ""),
     )
 

--- a/gateway/research_lab/attested_scoring_v2.py
+++ b/gateway/research_lab/attested_scoring_v2.py
@@ -92,6 +92,30 @@ _GATEWAY_ANCESTRY_ISSUER_ROLES = (
 )
 
 
+def _validate_artifact_persistence_lineage_output_v2(
+    *,
+    lineage: Mapping[str, Any],
+    lineage_receipt: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return only a canonical persistence output bound to its signed receipt."""
+
+    from gateway.tee.coordinator_executor_v2 import (
+        validate_artifact_persistence_output_v2,
+    )
+
+    try:
+        output = validate_artifact_persistence_output_v2(lineage.get("result"))
+    except ValueError as exc:
+        raise AttestedScoringV2Error(
+            "V2 artifact persistence output is invalid"
+        ) from exc
+    if lineage_receipt.get("output_root") != sha256_json(output):
+        raise AttestedScoringV2Error(
+            "V2 artifact persistence output differs from its receipt"
+        )
+    return output
+
+
 def _env_flag(name: str) -> bool:
     return str(os.getenv(name, "") or "").strip().lower() in {
         "1",
@@ -1822,6 +1846,7 @@ async def execute_scoring_v2(
         require_boot_attestation_verification=True,
     )
     artifact_persistence = []
+    artifact_persistence_output = None
     reuse_persisted_artifacts = False
     if expected_artifact_hashes:
         from gateway.research_lab.attested_artifacts_v2 import (
@@ -2036,6 +2061,12 @@ async def execute_scoring_v2(
             raise AttestedScoringV2Error(
                 "V2 encrypted artifact lineage ancestry is invalid"
             )
+        artifact_persistence_output = (
+            _validate_artifact_persistence_lineage_output_v2(
+                lineage=lineage,
+                lineage_receipt=lineage_receipt,
+            )
+        )
         source_authority = build_certificate_parent_authority_v2(
             ancestry_compact_proof["certificate"],
             expected_lineage_id=ancestry_lineage_id,
@@ -2156,6 +2187,11 @@ async def execute_scoring_v2(
             ),
             "ancestry_checkpoint_persistence": dict(
                 lineage_checkpoint_persistence
+            ),
+            **(
+                {"artifact_persistence_output": artifact_persistence_output}
+                if artifact_persistence_output is not None
+                else {}
             ),
         }
     persistence, ancestry_checkpoint_persistence = (

--- a/gateway/research_lab/attested_weight_inputs_v2.py
+++ b/gateway/research_lab/attested_weight_inputs_v2.py
@@ -16,10 +16,15 @@ from leadpoet_canonical.attested_v2 import (
     sha256_json,
     validate_receipt_graph,
 )
+from leadpoet_canonical.hotkey_authority_v2 import (
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+)
 from leadpoet_canonical.weight_authority_v2 import (
+    GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2,
     GATEWAY_WEIGHT_INPUT_CATEGORIES,
     WEIGHT_INPUT_PURPOSES,
     gateway_weight_input_value_documents_v2,
+    normalize_gateway_measured_weight_inputs_v2,
 )
 
 
@@ -116,7 +121,8 @@ def _compact_weight_ancestry(
             raise AttestedWeightInputsV2Error(
                 "%s measured input execution is absent" % category
             )
-        proof = execution.get("ancestry_compact_proof")
+        execution_proof = execution.get("execution_ancestry_compact_proof")
+        proof = execution_proof or execution.get("ancestry_compact_proof")
         if proof is None:
             return None
         if not isinstance(proof, Mapping):
@@ -134,7 +140,11 @@ def _compact_weight_ancestry(
             if isinstance(claim, Mapping)
             else ""
         )
-        graph = execution.get("receipt_graph")
+        graph = (
+            execution.get("execution_receipt_graph")
+            if execution_proof is not None
+            else execution.get("receipt_graph")
+        )
         if (
             not isinstance(graph, Mapping)
             or root_hash != str(graph.get("root_receipt_hash") or "")
@@ -199,10 +209,18 @@ async def build_gateway_weight_inputs_v2(
     load_sourcing_graphs: Any = load_sourcing_epoch_graphs_v2,
     execution_options: Mapping[str, Any] | None = None,
     coordinator_client_factory: Any = _coordinator_client,
+    snapshot_authority_mode: str | None = None,
 ) -> dict[str, Any]:
     """Produce every coordinator input receipt from measured source reads."""
 
     calculation = dict(calculation_snapshot)
+    normalized_mode = (
+        snapshot_authority_mode == GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+    )
+    if snapshot_authority_mode is not None and not normalized_mode:
+        raise AttestedWeightInputsV2Error(
+            "weight input snapshot authority mode is invalid"
+        )
     epoch_id = calculation.get("epoch_id")
     if not isinstance(epoch_id, int) or isinstance(epoch_id, bool) or epoch_id < 0:
         raise AttestedWeightInputsV2Error("weight input epoch is invalid")
@@ -248,7 +266,16 @@ async def build_gateway_weight_inputs_v2(
         if category in _ALLOCATION_CATEGORIES:
             parents = (allocation_graph,)
         elif category == "sourcing_history":
-            parents = tuple(sourcing_graphs)
+            if normalized_mode:
+                if "bans" not in executions:
+                    raise AttestedWeightInputsV2Error(
+                        "sourcing requires measured bans first"
+                    )
+                parents = tuple(sourcing_graphs) + (
+                    executions["bans"]["receipt_graph"],
+                )
+            else:
+                parents = tuple(sourcing_graphs)
         elif category == "anomaly_adjustments":
             missing = [
                 source
@@ -274,6 +301,27 @@ async def build_gateway_weight_inputs_v2(
             "leaderboard_window_start": str(leaderboard_window_start),
             "leaderboard_window_end": str(leaderboard_window_end),
         }
+        if normalized_mode:
+            payload["snapshot_authority_mode"] = (
+                GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+            )
+            if category == "sourcing_history":
+                bans_document = executions.get("bans", {}).get("result")
+                bans_persistence_output = executions.get("bans", {}).get(
+                    "artifact_persistence_output"
+                )
+                if not isinstance(bans_document, Mapping):
+                    raise AttestedWeightInputsV2Error(
+                        "sourcing measured bans document is absent"
+                    )
+                if not isinstance(bans_persistence_output, Mapping):
+                    raise AttestedWeightInputsV2Error(
+                        "sourcing measured bans persistence output is absent"
+                    )
+                payload["bans_document"] = dict(bans_document)
+                payload["bans_persistence_output"] = dict(
+                    bans_persistence_output
+                )
         if category == "anomaly_adjustments":
             payload["upstream_documents"] = {
                 source: dict(executions[source]["result"])
@@ -323,14 +371,20 @@ async def build_gateway_weight_inputs_v2(
         root_hash = str(graph.get("root_receipt_hash") or "")
         receipt_hash = str(receipt.get("receipt_hash") or "")
         expected_role, _expected_purpose = WEIGHT_INPUT_PURPOSES[category]
+        matches_expected = canonical_json(document) == canonical_json(
+            expected_documents[category]
+        )
         if (
             root_receipt.get("receipt_hash") != root_hash
             or receipts_by_hash.get(receipt_hash) != receipt
             or receipt.get("role") != expected_role
             or receipt.get("purpose") != purpose
             or receipt.get("output_root") != sha256_json(document)
-            or canonical_json(document)
-            != canonical_json(expected_documents[category])
+            or (
+                (not normalized_mode)
+                or category not in GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2
+            )
+            and not matches_expected
         ):
             raise AttestedWeightInputsV2Error(
                 "%s measured input differs from calculation" % category
@@ -347,19 +401,77 @@ async def build_gateway_weight_inputs_v2(
                     "%s persistence lineage differs from measured input"
                     % category
                 )
+        if normalized_mode and category == "bans":
+            if (
+                root_hash == receipt_hash
+                or root_receipt.get("role") != "gateway_coordinator"
+                or root_receipt.get("purpose")
+                != "leadpoet.artifact_persistence.v2"
+                or int(root_receipt.get("epoch_id", -1)) != epoch_id
+            ):
+                raise AttestedWeightInputsV2Error(
+                    "bans requires terminal durable persistence receipt"
+                )
         executions[category] = dict(value)
 
-    # Every category except anomaly_adjustments has independent measured
-    # inputs. Run those jobs together so their mandatory encrypted artifact
-    # persistence does not consume the submission window serially.
-    # The anomaly job remains ordered after all of its receipt parents exist.
-    await asyncio.gather(
-        *(
-            execute_category(category, sequence)
-            for sequence, category in enumerate(independent_categories)
+    # The legacy branch intentionally retains its original concurrent ordering.
+    # In signed normalized mode bans are measured before sourcing replay, so the
+    # latter can verify the bans receipt and reproduce the historic per-epoch
+    # penalty without mutating the signed source records.
+    if normalized_mode:
+        pre_sourcing_categories = [
+            category
+            for category in independent_categories
+            if category != "sourcing_history"
+        ]
+        await asyncio.gather(
+            *(
+                execute_category(category, sequence)
+                for sequence, category in enumerate(pre_sourcing_categories)
+            )
         )
-    )
-    await execute_category("anomaly_adjustments", len(independent_categories))
+        await execute_category("sourcing_history", len(pre_sourcing_categories))
+        measured_documents = {
+            category: dict(executions[category]["result"])
+            for category in sorted(GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2)
+        }
+        try:
+            normalized = normalize_gateway_measured_weight_inputs_v2(
+                calculation_snapshot=calculation,
+                measured_documents=measured_documents,
+                gateway_authority_event_hash=allocation_hash,
+            )
+        except Exception as exc:
+            raise AttestedWeightInputsV2Error(
+                "measured gateway normalization failed"
+            ) from exc
+        calculation = dict(normalized["authoritative_calculation_snapshot"])
+        expected_documents = gateway_weight_input_value_documents_v2(
+            calculation_snapshot=calculation,
+            gateway_authority_event_hash=allocation_hash,
+        )
+        for category, execution in executions.items():
+            if canonical_json(execution["result"]) != canonical_json(
+                expected_documents[category]
+            ):
+                raise AttestedWeightInputsV2Error(
+                    "%s measured input differs from normalized calculation" % category
+                )
+        await execute_category(
+            "anomaly_adjustments", len(pre_sourcing_categories) + 1
+        )
+    else:
+        # Every category except anomaly_adjustments has independent measured
+        # inputs. Run those jobs together so their mandatory encrypted artifact
+        # persistence does not consume the submission window serially.
+        # The anomaly job remains ordered after all of its receipt parents exist.
+        await asyncio.gather(
+            *(
+                execute_category(category, sequence)
+                for sequence, category in enumerate(independent_categories)
+            )
+        )
+        await execute_category("anomaly_adjustments", len(independent_categories))
 
     all_graphs = [
         executions[category]["receipt_graph"]
@@ -384,10 +496,24 @@ async def build_gateway_weight_inputs_v2(
         input_receipt_hashes=input_hashes,
         receipt_set=receipt_set,
     )
-    return {
+    result = {
         "input_receipt_hashes": input_hashes,
         "gateway_authority_event_hash": allocation_hash,
         "upstream_receipt_set": receipt_set,
         "compact_ancestry": compact,
         "executions": executions,
     }
+    if normalized_mode:
+        result.update(
+            {
+                "snapshot_authority_mode": normalized["snapshot_authority_mode"],
+                "authoritative_calculation_snapshot": calculation,
+                "authoritative_calculation_snapshot_hash": normalized[
+                    "authoritative_calculation_snapshot_hash"
+                ],
+                "normalized_source_categories": normalized[
+                    "normalized_source_categories"
+                ],
+            }
+        )
+    return result

--- a/gateway/tee/coordinator_executor_v2.py
+++ b/gateway/tee/coordinator_executor_v2.py
@@ -86,12 +86,78 @@ OP_ANCESTRY_CHECKPOINT_BOOTSTRAP_V2 = (
 _HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _ARTIFACT_PERSISTENCE_PURPOSE = "leadpoet.artifact_persistence.v2"
 _ARTIFACT_PERSISTENCE_PROVIDER = "aws_s3_object_lock"
+_ARTIFACT_PERSISTENCE_OUTPUT_FIELDS = frozenset(
+    {"source_receipt_hash", "artifacts", "artifact_set_root"}
+)
+_ARTIFACT_PERSISTENCE_ARTIFACT_FIELDS = frozenset(
+    {
+        "artifact_id",
+        "plaintext_hash",
+        "ciphertext_hash",
+        "artifact_ref",
+        "storage_document_hash",
+        "encryption_context_hash",
+        "object_lock_mode",
+        "retain_until",
+        "transport_root",
+    }
+)
 
 _COORDINATOR_WEIGHT_INPUT_PURPOSES = {
     category: purpose
     for category, (role, purpose) in WEIGHT_INPUT_PURPOSES.items()
     if role == "gateway_coordinator"
 }
+
+
+def validate_artifact_persistence_output_v2(value: Any) -> dict[str, Any]:
+    """Validate the exact coordinator output committed by a persistence receipt."""
+
+    if not isinstance(value, Mapping) or set(value) != _ARTIFACT_PERSISTENCE_OUTPUT_FIELDS:
+        raise ValueError("artifact persistence output fields are invalid")
+    source_receipt_hash = str(value.get("source_receipt_hash") or "")
+    artifacts = value.get("artifacts")
+    if not _HASH_RE.fullmatch(source_receipt_hash) or not isinstance(artifacts, list):
+        raise ValueError("artifact persistence output is invalid")
+    normalized_artifacts = []
+    artifact_ids = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, Mapping) or set(artifact) != _ARTIFACT_PERSISTENCE_ARTIFACT_FIELDS:
+            raise ValueError("artifact persistence output artifact is invalid")
+        normalized = {key: artifact[key] for key in _ARTIFACT_PERSISTENCE_ARTIFACT_FIELDS}
+        if (
+            not all(
+                _HASH_RE.fullmatch(str(normalized[key] or ""))
+                for key in (
+                    "artifact_id",
+                    "plaintext_hash",
+                    "ciphertext_hash",
+                    "storage_document_hash",
+                    "encryption_context_hash",
+                    "transport_root",
+                )
+            )
+            or not all(
+                isinstance(normalized[key], str) and normalized[key]
+                for key in ("artifact_ref", "object_lock_mode", "retain_until")
+            )
+            or normalized["artifact_id"] in artifact_ids
+        ):
+            raise ValueError("artifact persistence output artifact is invalid")
+        artifact_ids.add(normalized["artifact_id"])
+        normalized_artifacts.append(normalized)
+    if (
+        not normalized_artifacts
+        or normalized_artifacts
+        != sorted(normalized_artifacts, key=lambda artifact: artifact["artifact_id"])
+        or value.get("artifact_set_root") != sha256_json(normalized_artifacts)
+    ):
+        raise ValueError("artifact persistence output artifact set is invalid")
+    return {
+        "source_receipt_hash": source_receipt_hash,
+        "artifacts": normalized_artifacts,
+        "artifact_set_root": str(value["artifact_set_root"]),
+    }
 
 
 def _validated_artifact_persistence_attempts(
@@ -977,7 +1043,7 @@ class CoordinatorExecutorV2:
             "artifact_set_root": sha256_json(output_artifacts),
         }
         return ExecutionResultV2(
-            output=output,
+            output=validate_artifact_persistence_output_v2(output),
             transport_attempts=tuple(transport_attempts),
             artifact_hashes=tuple(artifact_hashes),
         )

--- a/gateway/tee/coordinator_weight_source_v2.py
+++ b/gateway/tee/coordinator_weight_source_v2.py
@@ -5,17 +5,23 @@ from __future__ import annotations
 from collections import OrderedDict
 from typing import Any, Dict, Mapping
 
+from gateway.tee.coordinator_executor_v2 import (
+    validate_artifact_persistence_output_v2,
+)
 from gateway.tee.execution_job_manager_v2 import ExecutionContextV2
 from gateway.tee.supabase_source_v2 import SupabaseSourceReaderV2
 from leadpoet_canonical.attested_v2 import (
     canonical_json,
     sha256_json,
+    validate_receipt_graph,
     validate_signed_execution_receipt,
 )
 from leadpoet_canonical.hotkey_authority_v2 import (
     DISABLED_LEADERBOARD_WINDOW_V1,
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
 )
 from leadpoet_canonical.weight_authority_v2 import (
+    GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2,
     WEIGHT_INPUT_PURPOSES,
     gateway_weight_input_value_documents_v2,
 )
@@ -80,11 +86,20 @@ class CoordinatorWeightSourceV2:
                 "weight source payload fields are invalid"
             )
         category = str(payload.get("category") or "")
-        expected_fields = (
-            required | {"upstream_documents"}
-            if category == "anomaly_adjustments"
-            else required
-        )
+        mode = payload.get("snapshot_authority_mode")
+        normalized_mode = mode == GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+        if mode is not None and not normalized_mode:
+            raise CoordinatorWeightSourceV2Error(
+                "weight source snapshot authority mode is invalid"
+            )
+        expected_fields = set(required)
+        if category == "anomaly_adjustments":
+            expected_fields.add("upstream_documents")
+        if normalized_mode:
+            expected_fields.add("snapshot_authority_mode")
+            if category == "sourcing_history":
+                expected_fields.add("bans_document")
+                expected_fields.add("bans_persistence_output")
         if set(payload) != expected_fields:
             raise CoordinatorWeightSourceV2Error(
                 "weight source payload fields are invalid"
@@ -142,6 +157,15 @@ class CoordinatorWeightSourceV2:
                 proposed=proposed,
                 calculation=calculation,
                 context=context,
+                bans_document=(
+                    payload.get("bans_document") if normalized_mode else None
+                ),
+                bans_persistence_output=(
+                    payload.get("bans_persistence_output")
+                    if normalized_mode
+                    else None
+                ),
+                require_bans_parent=normalized_mode,
             )
         elif category == "anomaly_adjustments":
             reconstructed = self._anomaly_document(
@@ -153,7 +177,10 @@ class CoordinatorWeightSourceV2:
             raise CoordinatorWeightSourceV2Error(
                 "weight source category has no measured producer"
             )
-        if not _same(reconstructed, proposed):
+        if not _same(reconstructed, proposed) and not (
+            normalized_mode
+            and category in GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2
+        ):
             raise CoordinatorWeightSourceV2Error(
                 "%s authenticated source differs from calculation snapshot"
                 % category
@@ -418,7 +445,7 @@ class CoordinatorWeightSourceV2:
                 "fulfillment_share": effective,
                 "fulfillment_rows": [
                     {"hotkey": hotkey, "share": share}
-                    for hotkey, share in effective_rows.items()
+                    for hotkey, share in sorted(effective_rows.items())
                 ],
                 "fulfillment_fetch_ok": True,
             },
@@ -509,6 +536,9 @@ class CoordinatorWeightSourceV2:
         proposed: Mapping[str, Any],
         calculation: Mapping[str, Any],
         context: ExecutionContextV2,
+        bans_document: Any = None,
+        bans_persistence_output: Any = None,
+        require_bans_parent: bool = False,
     ) -> Dict[str, Any]:
         current_epoch = int(context.epoch_id)
         start_epoch = max(0, current_epoch - 30)
@@ -522,6 +552,126 @@ class CoordinatorWeightSourceV2:
             )
         epochs = []
         source_receipt_hashes = []
+        ban_parent_root_hash = None
+        banned_hotkeys = ()
+        if require_bans_parent:
+            if not isinstance(bans_document, Mapping) or set(bans_document) != {
+                "schema_version",
+                "category",
+                "netuid",
+                "epoch_id",
+                "value",
+            }:
+                raise CoordinatorWeightSourceV2Error("sourcing bans document is invalid")
+            ban_value = bans_document.get("value")
+            if (
+                bans_document.get("category") != "bans"
+                or int(bans_document.get("epoch_id", -1)) != current_epoch
+                or bans_document.get("netuid") != proposed.get("netuid")
+                or not isinstance(ban_value, Mapping)
+                or set(ban_value) != {"banned_hotkeys", "banned_lookup_ok"}
+                or ban_value.get("banned_lookup_ok") is not True
+                or not isinstance(ban_value.get("banned_hotkeys"), list)
+            ):
+                raise CoordinatorWeightSourceV2Error("sourcing bans document is invalid")
+            banned_hotkeys = list(ban_value["banned_hotkeys"])
+            if (
+                any(not isinstance(hotkey, str) or not hotkey for hotkey in banned_hotkeys)
+                or banned_hotkeys != sorted(set(banned_hotkeys))
+            ):
+                raise CoordinatorWeightSourceV2Error("sourcing banned hotkeys are invalid")
+            try:
+                persistence_output = validate_artifact_persistence_output_v2(
+                    bans_persistence_output
+                )
+            except ValueError as exc:
+                raise CoordinatorWeightSourceV2Error(
+                    "sourcing bans persistence output is invalid"
+                ) from exc
+            bans_value_hash = sha256_json(bans_document["value"])
+            # The ban input itself is an ephemeral measurement.  Sourcing may
+            # consume it only through the terminal artifact-persistence
+            # receipt, which is the declared direct parent of this operation.
+            # Do not accept a direct ban root here: that would let a host-side
+            # execution result bypass the durable lineage that the coordinator
+            # established before publishing the measured input.
+            matched_bans = []
+            for graph in context.external_receipt_graphs:
+                root_hash = str(graph.get("root_receipt_hash") or "")
+                if root_hash not in context.parent_receipt_hashes:
+                    continue
+                receipts = {
+                    str(item.get("receipt_hash") or ""): item
+                    for item in graph.get("receipts") or ()
+                    if isinstance(item, Mapping)
+                }
+                root = receipts.get(root_hash)
+                if not isinstance(root, Mapping):
+                    continue
+                contains_bans_source = any(
+                    receipt.get("role") == "gateway_coordinator"
+                    and receipt.get("purpose") == "research_lab.ban_input.v2"
+                    for receipt in receipts.values()
+                )
+                is_terminal_persistence = (
+                    root.get("role") == "gateway_coordinator"
+                    and root.get("purpose")
+                    == "leadpoet.artifact_persistence.v2"
+                )
+                if not (contains_bans_source or is_terminal_persistence):
+                    continue
+                try:
+                    validate_receipt_graph(
+                        graph,
+                        required_purposes=(
+                            "research_lab.ban_input.v2",
+                            "leadpoet.artifact_persistence.v2",
+                        ),
+                    )
+                except Exception as exc:
+                    raise CoordinatorWeightSourceV2Error(
+                        "sourcing bans receipt graph is invalid"
+                    ) from exc
+                if (
+                    not is_terminal_persistence
+                    or int(root.get("epoch_id", -1)) != current_epoch
+                ):
+                    continue
+                direct_parent_hashes = tuple(
+                    str(value)
+                    for value in root.get("parent_receipt_hashes") or ()
+                )
+                candidates = [
+                    receipts[parent_hash]
+                    for parent_hash in direct_parent_hashes
+                    if parent_hash in receipts
+                    and receipts[parent_hash].get("role")
+                    == "gateway_coordinator"
+                    and receipts[parent_hash].get("purpose")
+                    == "research_lab.ban_input.v2"
+                ]
+                if len(candidates) != 1:
+                    continue
+                receipt = candidates[0]
+                if (
+                    int(receipt.get("epoch_id", -1)) == current_epoch
+                    and receipt.get("output_root") == sha256_json(bans_document)
+                    and direct_parent_hashes == (receipt.get("receipt_hash"),)
+                    and root.get("output_root") == sha256_json(persistence_output)
+                    and persistence_output["source_receipt_hash"]
+                    == receipt.get("receipt_hash")
+                    and sum(
+                        artifact["plaintext_hash"] == bans_value_hash
+                        for artifact in persistence_output["artifacts"]
+                    )
+                    == 1
+                ):
+                    matched_bans.append((root_hash, receipt))
+            if len(matched_bans) != 1:
+                raise CoordinatorWeightSourceV2Error(
+                    "sourcing requires one declared bans authority receipt"
+                )
+            ban_parent_root_hash = str(matched_bans[0][0])
         for row in rows:
             try:
                 source_doc = validate_sourcing_epoch_v2(row.get("source_doc"))
@@ -567,7 +717,10 @@ class CoordinatorWeightSourceV2:
                 )
             epochs.append(source_doc)
             source_receipt_hashes.append(receipt_hash)
-        if sorted(context.parent_receipt_hashes) != sorted(source_receipt_hashes):
+        expected_parent_hashes = list(source_receipt_hashes)
+        if ban_parent_root_hash is not None:
+            expected_parent_hashes.append(ban_parent_root_hash)
+        if sorted(context.parent_receipt_hashes) != sorted(expected_parent_hashes):
             raise CoordinatorWeightSourceV2Error(
                 "sourcing input parents differ from authenticated epoch receipts"
             )
@@ -575,6 +728,7 @@ class CoordinatorWeightSourceV2:
             scores, lead_count = rolling_sourcing_history_v2(
                 current_epoch=current_epoch,
                 epochs=epochs,
+                banned_hotkeys=banned_hotkeys,
             )
         except SourcingHistoryV2Error as exc:
             raise CoordinatorWeightSourceV2Error(

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -27,7 +27,7 @@
       "symbol": "get_compact_published_weights_v2"
     },
     {
-      "ast_sha256": "sha256:221f2772f3def021f0e33ae9fb892d8d3cb5f899e71663f4b9ab417a45f06a47",
+      "ast_sha256": "sha256:d98887f46be31b044ba2f3188fa871ffdcaa3045b1d9bece1f4f821d81c73173",
       "path": "gateway/api/weights.py",
       "symbol": "get_weight_inputs_v2"
     },
@@ -187,7 +187,7 @@
       "symbol": "_validate_output_ancestry_checkpoint_v2"
     },
     {
-      "ast_sha256": "sha256:24fe0d3d20896f4f49ced6d14189c77c61603d140a735a57a587cf891c931af3",
+      "ast_sha256": "sha256:344102421b92997d3d401ad3f93d3bcc4dfeebf78bec752602a1e9539cc5ac27",
       "path": "gateway/research_lab/attested_scoring_v2.py",
       "symbol": "execute_scoring_v2"
     },
@@ -327,12 +327,12 @@
       "symbol": "persist_receipt_graph_v2"
     },
     {
-      "ast_sha256": "sha256:46b17b5d046a65184e9c2eb5fcb001f3f065fada7086fc4e866f0b10a3b5f1db",
+      "ast_sha256": "sha256:7d466e03e6aa54791742b9b423e2331f25fb75f298f71a9540e0133dd624d551",
       "path": "gateway/research_lab/attested_weight_inputs_v2.py",
       "symbol": "_compact_weight_ancestry"
     },
     {
-      "ast_sha256": "sha256:da63615aa8f1899f4991e51ee8b5889991d58766c7e73ab7c16b47e2ced04c9d",
+      "ast_sha256": "sha256:9ad76264b370e3ca4c09851d9cc8a81750f038ec60bac0942cf342f6d3728e2f",
       "path": "gateway/research_lab/attested_weight_inputs_v2.py",
       "symbol": "build_gateway_weight_inputs_v2"
     },
@@ -1102,7 +1102,7 @@
       "symbol": "attest_subnet_epoch_cutover_v2"
     },
     {
-      "ast_sha256": "sha256:6a8701f85baec4969d70bed93747087b3637a27d9c8c75d837d55f6ff4580f91",
+      "ast_sha256": "sha256:bc2ced6ae7ac1468908161bc21a8b98f52a0ccf2ff0d783a3183ddcc697ebead",
       "path": "gateway/tee/coordinator_executor_v2.py",
       "symbol": "CoordinatorExecutorV2"
     },
@@ -1127,7 +1127,7 @@
       "symbol": "CoordinatorSourceAddProvenanceV2"
     },
     {
-      "ast_sha256": "sha256:e905b2afad9ec079af4bdefe16ce5479e93c58fbe75639c1c5313cf88ae96a2b",
+      "ast_sha256": "sha256:892b9012b4f1b2c6a947f51a7a6f52ff5f5981ace94dd59053c214a1589068d8",
       "path": "gateway/tee/coordinator_weight_source_v2.py",
       "symbol": "CoordinatorWeightSourceV2"
     },
@@ -2042,6 +2042,21 @@
       "symbol": "validate_compact_weight_submission_shape_v2"
     },
     {
+      "ast_sha256": "sha256:909e3844e13605252787c525a626f5125400c2f97502d456f5bd395031ebedc1",
+      "path": "leadpoet_canonical/hotkey_authority_v2.py",
+      "symbol": "GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2"
+    },
+    {
+      "ast_sha256": "sha256:9c3fb03ceca70d1d63d16115296be740c25a41485c8873ab64462305b45478da",
+      "path": "leadpoet_canonical/hotkey_authority_v2.py",
+      "symbol": "build_weight_inputs_request_v2"
+    },
+    {
+      "ast_sha256": "sha256:ca3d6da2d4143cef596bd0cfad85ea69125cc56e13caaa28a2207a96e4319a93",
+      "path": "leadpoet_canonical/hotkey_authority_v2.py",
+      "symbol": "validate_weight_inputs_request_v2"
+    },
+    {
       "ast_sha256": "sha256:ca4917c451f42deb8c1a394125aa3bac38ff1d7bd605603be3eace8b0c5f11c6",
       "path": "leadpoet_canonical/kms_recipient.py",
       "symbol": "decrypt_kms_recipient_ciphertext"
@@ -2082,6 +2097,16 @@
       "symbol": "validate_legacy_weight_bundle_v2"
     },
     {
+      "ast_sha256": "sha256:a7ca9b2cf159d66a64d453895ddd3d316101f169d932c940e7a94e77ba3046d8",
+      "path": "leadpoet_canonical/sourcing_history_v2.py",
+      "symbol": "SOURCING_BANNED_HOTKEY_PENALTY_V2"
+    },
+    {
+      "ast_sha256": "sha256:e9c971d8e6c66fe2048bed5a73c46606be16568758dd6129bca76e56927bbdc6",
+      "path": "leadpoet_canonical/sourcing_history_v2.py",
+      "symbol": "rolling_sourcing_history_v2"
+    },
+    {
       "ast_sha256": "sha256:9da83659412c65a826b0c1e9c6aa9d7b9cce7bf255ae164fc120ea09f0641378",
       "path": "leadpoet_canonical/weight_authority_v2.py",
       "symbol": "build_weight_snapshot_v2"
@@ -2090,6 +2115,11 @@
       "ast_sha256": "sha256:1f522a1f8ac8edbd984c0ef39606574b2a9dd0595b7bdb95ec7de1ebdbc44105",
       "path": "leadpoet_canonical/weight_authority_v2.py",
       "symbol": "gateway_weight_input_value_documents_v2"
+    },
+    {
+      "ast_sha256": "sha256:b1c299b7319f5a9965c2178b2b5106ec3189e575bcd5ab17cd006e83eacbf411",
+      "path": "leadpoet_canonical/weight_authority_v2.py",
+      "symbol": "normalize_gateway_measured_weight_inputs_v2"
     },
     {
       "ast_sha256": "sha256:d20544a7f9e324c4edb69c7168a5df059ac835d64e7737896ad524f215fbffd8",
@@ -2597,7 +2627,7 @@
       "symbol": "verify_source_tree_contract"
     }
   ],
-  "manifest_hash": "sha256:b93d9a16e25075e18040ce4234373fb70e2498a2cc8085f34ae8b99cc8811ac6",
+  "manifest_hash": "sha256:4c2fd31eb8b41b7fb0f25f95bb4a29bbbc21e3e40166e3d68a0c670aadf4d234",
   "protected_source_commit": "a0798fc6336838326bb4708789d24225cd1dcaef",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/protected_workflows.py
+++ b/gateway/tee/protected_workflows.py
@@ -478,11 +478,21 @@ PROTECTED_SYMBOLS = {
     ),
     "leadpoet_canonical/weight_authority_v2.py": (
         "gateway_weight_input_value_documents_v2",
+        "normalize_gateway_measured_weight_inputs_v2",
         "weight_input_value_documents_v2",
         "validate_weight_input_source_evidence_v2",
         "build_weight_snapshot_v2",
         "validate_published_weight_bundle_v2",
         "validate_weight_finalization_submission_v2",
+    ),
+    "leadpoet_canonical/hotkey_authority_v2.py": (
+        "GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2",
+        "build_weight_inputs_request_v2",
+        "validate_weight_inputs_request_v2",
+    ),
+    "leadpoet_canonical/sourcing_history_v2.py": (
+        "SOURCING_BANNED_HOTKEY_PENALTY_V2",
+        "rolling_sourcing_history_v2",
     ),
     "leadpoet_canonical/chain_source_v2.py": (
         "weights_storage_key",

--- a/gateway/tee/rehearsal_behavior_contract_v2.py
+++ b/gateway/tee/rehearsal_behavior_contract_v2.py
@@ -46,6 +46,11 @@ BEHAVIOR_SCENARIOS = (
 
 AUTHORITY_DIAGNOSTICS = (
     "candidate-bundle-generation",
+    "gateway-measured-coordinator",
+    "gateway-measured-client-enclave",
+    "gateway-measured-primary-compact",
+    "gateway-measured-audit-compact",
+    "gateway-measured-immutable-tamper",
     "host-bundle-composition",
     "primary-bundle-verification",
     "auditor-bundle-verification",
@@ -71,6 +76,7 @@ BEHAVIORAL_INVARIANTS = (
     "current_frontier_release_recovery_verified",
     "validator_publication_release_recovery_verified",
     "canonical_vector_primary_auditor_equal",
+    "gateway_measured_authority_exact",
     "receipt_ancestry_verified",
     "sdk_signing_bridge_verified",
     "submission_finalized",

--- a/leadpoet_canonical/hotkey_authority_v2.py
+++ b/leadpoet_canonical/hotkey_authority_v2.py
@@ -33,6 +33,7 @@ SERVE_AXON_EXTRINSIC_AUTHORIZATION_SCHEMA_VERSION = (
 )
 APPLICATION_SIGNATURE_SCHEMA_VERSION = "leadpoet.application_signature.v2"
 WEIGHT_INPUT_REQUEST_SCHEMA_VERSION = "leadpoet.weight_inputs_request.v2"
+GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2 = "gateway-measured-v2"
 WEIGHT_INPUT_REQUEST_PREFIX = "LEADPOET_WEIGHT_INPUTS_V2|"
 DISABLED_LEADERBOARD_WINDOW_V1 = "1970-01-01T00:00:00Z"
 WEIGHT_TRANSPORT_AUTHORIZATION_SCHEMA_VERSION = (
@@ -952,6 +953,7 @@ def build_weight_inputs_request_v2(
     allocation_hash: str,
     leaderboard_window_start: str,
     leaderboard_window_end: str,
+    snapshot_authority_mode: Optional[str] = None,
 ) -> Dict[str, Any]:
     hotkey = str(validator_hotkey or "")
     _require(bool(_HOTKEY_RE.fullmatch(hotkey)), "validator_hotkey is invalid")
@@ -975,12 +977,23 @@ def build_weight_inputs_request_v2(
         "leaderboard_window_start": window_start,
         "leaderboard_window_end": window_end,
     }
+    if snapshot_authority_mode is not None:
+        mode = str(snapshot_authority_mode or "")
+        _require(
+            mode == GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+            "snapshot_authority_mode is invalid",
+        )
+        # The selector is part of the signed request hash.  A legacy request
+        # deliberately omits it so N-1 validators retain their exact wire
+        # representation and cannot share a cache entry with the normalized
+        # measurement path.
+        body["snapshot_authority_mode"] = mode
     return {**body, "request_hash": sha256_json(body)}
 
 
 def validate_weight_inputs_request_v2(value: Mapping[str, Any]) -> Dict[str, Any]:
     _require(isinstance(value, Mapping), "weight input request is invalid")
-    expected_fields = {
+    legacy_fields = {
         "schema_version",
         "validator_hotkey",
         "netuid",
@@ -992,7 +1005,12 @@ def validate_weight_inputs_request_v2(value: Mapping[str, Any]) -> Dict[str, Any
         "leaderboard_window_end",
         "request_hash",
     }
-    _require(set(value) == expected_fields, "weight input request fields are invalid")
+    normalized_fields = legacy_fields | {"snapshot_authority_mode"}
+    actual_fields = set(value)
+    _require(
+        actual_fields in (legacy_fields, normalized_fields),
+        "weight input request fields are invalid",
+    )
     rebuilt = build_weight_inputs_request_v2(
         validator_hotkey=value["validator_hotkey"],
         netuid=value["netuid"],
@@ -1002,6 +1020,11 @@ def validate_weight_inputs_request_v2(value: Mapping[str, Any]) -> Dict[str, Any
         allocation_hash=value["allocation_hash"],
         leaderboard_window_start=value["leaderboard_window_start"],
         leaderboard_window_end=value["leaderboard_window_end"],
+        snapshot_authority_mode=(
+            value["snapshot_authority_mode"]
+            if actual_fields == normalized_fields
+            else None
+        ),
     )
     _require(dict(value) == rebuilt, "weight input request is not canonical")
     return rebuilt

--- a/leadpoet_canonical/sourcing_history_v2.py
+++ b/leadpoet_canonical/sourcing_history_v2.py
@@ -19,6 +19,7 @@ SOURCING_DECISION_SCHEMA_VERSION = "leadpoet.sourcing_decision.v2"
 SOURCING_EPOCH_SCHEMA_VERSION = "leadpoet.sourcing_epoch.v2"
 SOURCING_ROLLING_WINDOW = 30
 LEGACY_ICP_MULTIPLIERS = frozenset({1.0, 1.5, 5.0})
+SOURCING_BANNED_HOTKEY_PENALTY_V2 = -100_000
 
 _HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
@@ -217,7 +218,11 @@ def validate_sourcing_epoch_v2(value: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 def rolling_sourcing_history_v2(
-    *, current_epoch: int, epochs: Sequence[Mapping[str, Any]], window: int = SOURCING_ROLLING_WINDOW
+    *,
+    current_epoch: int,
+    epochs: Sequence[Mapping[str, Any]],
+    window: int = SOURCING_ROLLING_WINDOW,
+    banned_hotkeys: Sequence[str] = (),
 ) -> Tuple[Dict[str, float], int]:
     if not isinstance(current_epoch, int) or current_epoch < 0:
         raise SourcingHistoryV2Error("current_epoch is invalid")
@@ -225,6 +230,14 @@ def rolling_sourcing_history_v2(
         raise SourcingHistoryV2Error("window is invalid")
     start_epoch = current_epoch - window
     end_epoch = current_epoch - 1
+    if not isinstance(banned_hotkeys, (list, tuple, set, frozenset)):
+        raise SourcingHistoryV2Error("banned_hotkeys are invalid")
+    banned = set()
+    for value in banned_hotkeys:
+        hotkey = str(value or "").strip()
+        if not hotkey or any(character.isspace() for character in hotkey):
+            raise SourcingHistoryV2Error("banned_hotkeys are invalid")
+        banned.add(hotkey)
     scores = {}  # type: Dict[str, float]
     lead_count = 0
     seen_epochs = set()
@@ -237,6 +250,16 @@ def rolling_sourcing_history_v2(
         if not start_epoch <= epoch_id <= end_epoch:
             continue
         for row in epoch["miner_scores"]:
-            scores[row["hotkey"]] = scores.get(row["hotkey"], 0) + row["score"]
+            hotkey = row["hotkey"]
+            # This mirrors the existing validator's persisted-history rewrite:
+            # each historic epoch that already contains a now-banned hotkey is
+            # treated as -100,000.  The raw signed epoch document remains
+            # immutable and a ban never invents an absent source row.
+            value = (
+                SOURCING_BANNED_HOTKEY_PENALTY_V2
+                if hotkey in banned
+                else row["score"]
+            )
+            scores[hotkey] = scores.get(hotkey, 0) + value
         lead_count += epoch["approved_lead_count"]
     return scores, lead_count

--- a/leadpoet_canonical/weight_authority_v2.py
+++ b/leadpoet_canonical/weight_authority_v2.py
@@ -18,6 +18,7 @@ from leadpoet_canonical.attested_v2 import (
     EMPTY_TRANSPORT_ROOT,
     WEIGHT_ROLE,
     AttestedV2Error,
+    canonical_json,
     merkle_root,
     sha256_json,
     validate_receipt_graph,
@@ -26,6 +27,7 @@ from leadpoet_canonical.ancestry_checkpoint_v2 import (
     validate_ancestry_parent_authority_v2,
 )
 from leadpoet_canonical.hotkey_authority_v2 import (
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
     HotkeyAuthorityV2Error,
     build_application_signature_request_v2,
     encode_signed_extrinsic_v2,
@@ -97,6 +99,24 @@ VALIDATOR_WEIGHT_INPUT_CATEGORIES = frozenset(
 )
 GATEWAY_WEIGHT_INPUT_CATEGORIES = frozenset(WEIGHT_INPUT_PURPOSES) - (
     VALIDATOR_WEIGHT_INPUT_CATEGORIES
+)
+
+# These are the only gateway-measured values which may replace a signed
+# validator provisional snapshot.  Keeping the map here, next to the value
+# documents, makes it impossible for a caller to opt an unrelated field into
+# normalized authority by naming it in a request or response.
+GATEWAY_MEASURED_NORMALIZATION_FIELDS_V2 = {
+    "bans": ("banned_hotkeys", "banned_lookup_ok"),
+    "fulfillment_rewards": (
+        "fulfillment_share",
+        "fulfillment_rows",
+        "fulfillment_fetch_ok",
+    ),
+    "leaderboard": ("leaderboard_entries", "leaderboard_fetch_ok"),
+    "sourcing_history": ("rolling_lead_count", "rolling_scores"),
+}
+GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2 = frozenset(
+    GATEWAY_MEASURED_NORMALIZATION_FIELDS_V2
 )
 
 _HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -401,6 +421,116 @@ def gateway_weight_input_value_documents_v2(
         "gateway weight input value categories are incomplete",
     )
     return documents
+
+
+def normalize_gateway_measured_weight_inputs_v2(
+    *,
+    calculation_snapshot: Mapping[str, Any],
+    measured_documents: Mapping[str, Mapping[str, Any]],
+    gateway_authority_event_hash: str,
+) -> Dict[str, Any]:
+    """Return the only calculation snapshot allowed by signed measured mode.
+
+    The validator signs a complete *provisional* snapshot before asking the
+    gateway to obtain its mutable inputs.  In ``gateway-measured-v2`` the
+    gateway may replace exactly the values in
+    :data:`GATEWAY_MEASURED_NORMALIZATION_FIELDS_V2`, and only when every
+    replacement is backed by a canonical measured value document for the same
+    netuid and epoch.  All remaining fields stay byte-for-byte anchored to the
+    signed provisional calculation.  The result is recomputed before it leaves
+    this boundary and its regenerated documents must equal the receipts that
+    supplied it.
+    """
+
+    if not isinstance(calculation_snapshot, Mapping):
+        raise WeightAuthorityV2Error("calculation_snapshot must be an object")
+    if not isinstance(measured_documents, Mapping) or set(measured_documents) != set(
+        GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2
+    ):
+        raise WeightAuthorityV2Error(
+            "gateway measured normalization categories are incomplete"
+        )
+
+    provisional = dict(calculation_snapshot)
+    # Validate the complete provisional schema first.  This ensures a malformed
+    # caller value cannot be hidden by a later overlay.
+    compute_final_weights(provisional)
+    expected_provisional = gateway_weight_input_value_documents_v2(
+        calculation_snapshot=provisional,
+        gateway_authority_event_hash=gateway_authority_event_hash,
+    )
+    normalized = dict(provisional)
+    changed_categories = []
+
+    for category in sorted(GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2):
+        document = measured_documents.get(category)
+        if not isinstance(document, Mapping) or set(document) != {
+            "schema_version",
+            "category",
+            "netuid",
+            "epoch_id",
+            "value",
+        }:
+            raise WeightAuthorityV2Error(
+                "%s measured input document is invalid" % category
+            )
+        expected = expected_provisional[category]
+        if (
+            document.get("schema_version") != WEIGHT_INPUT_VALUE_SCHEMA_VERSION
+            or document.get("category") != category
+            or document.get("netuid") != expected["netuid"]
+            or document.get("epoch_id") != expected["epoch_id"]
+            or not isinstance(document.get("value"), Mapping)
+        ):
+            raise WeightAuthorityV2Error(
+                "%s measured input document does not bind the provisional epoch"
+                % category
+            )
+        observed_value = dict(document["value"])
+        expected_value = dict(expected["value"])
+        if set(observed_value) != set(expected_value):
+            raise WeightAuthorityV2Error(
+                "%s measured input value fields are invalid" % category
+            )
+        allowed_fields = GATEWAY_MEASURED_NORMALIZATION_FIELDS_V2[category]
+        for field, expected_value_item in expected_value.items():
+            if field not in allowed_fields and canonical_json(
+                observed_value[field]
+            ) != canonical_json(expected_value_item):
+                raise WeightAuthorityV2Error(
+                    "%s measured input changed an immutable field" % category
+                )
+        for field in allowed_fields:
+            if canonical_json(normalized[field]) != canonical_json(
+                observed_value[field]
+            ):
+                if category not in changed_categories:
+                    changed_categories.append(category)
+            normalized[field] = observed_value[field]
+
+    try:
+        compute_final_weights(normalized)
+    except Exception as exc:
+        raise WeightAuthorityV2Error(
+            "gateway measured normalization does not satisfy canonical computation"
+        ) from exc
+    authoritative_documents = gateway_weight_input_value_documents_v2(
+        calculation_snapshot=normalized,
+        gateway_authority_event_hash=gateway_authority_event_hash,
+    )
+    for category in sorted(GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2):
+        if canonical_json(measured_documents[category]) != canonical_json(
+            authoritative_documents[category]
+        ):
+            raise WeightAuthorityV2Error(
+                "%s measured input differs from normalized calculation" % category
+            )
+    return {
+        "snapshot_authority_mode": GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+        "authoritative_calculation_snapshot": normalized,
+        "authoritative_calculation_snapshot_hash": sha256_json(normalized),
+        "normalized_source_categories": sorted(changed_categories),
+    }
 
 
 def weight_input_value_documents_v2(

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -162,6 +162,7 @@ from leadpoet_canonical.weight_computation import (
 )
 from leadpoet_canonical.hotkey_authority_v2 import (
     DISABLED_LEADERBOARD_WINDOW_V1,
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
 )
 from leadpoet_canonical.constants import (
     ALLOCATION_PREPARATION_BLOCK,
@@ -4460,6 +4461,9 @@ class Validator(BaseValidatorNeuron):
                     expected_chain=expected_chain,
                     client=self._validator_v2_client,
                     before_publish=journal.record_prepared,
+                    snapshot_authority_mode=(
+                        GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+                    ),
                 )
         except Exception as exc:
             code = _sentry_failure_code_for_exception(

--- a/scripts/run_local_restart_rehearsal.py
+++ b/scripts/run_local_restart_rehearsal.py
@@ -201,6 +201,210 @@ def _run(
     )
 
 
+class RehearsalOutputOwnershipError(RuntimeError):
+    """A Docker action and its bounded output-ownership repair both failed."""
+
+    def __init__(
+        self,
+        *,
+        action_error: BaseException,
+        ownership_error: BaseException,
+    ) -> None:
+        self.action_error = action_error
+        self.ownership_error = ownership_error
+        super().__init__(
+            "rehearsal Docker action failed and output ownership could not be "
+            f"restored: action={action_error!r}; ownership={ownership_error!r}"
+        )
+
+
+def _validated_rehearsal_output_roots(
+    output_roots: Sequence[Path],
+) -> tuple[Path, ...]:
+    """Resolve only task-owned temporary directories safe for recursive chown."""
+
+    temporary_root = Path(tempfile.gettempdir()).resolve(strict=True)
+    repository_root = REPO_ROOT.resolve(strict=True)
+    validated: list[Path] = []
+    seen: set[Path] = set()
+    for raw_root in output_roots:
+        root = Path(raw_root)
+        if root.is_symlink():
+            raise ValueError(f"rehearsal output root may not be a symlink: {root}")
+        try:
+            resolved = root.resolve(strict=True)
+        except FileNotFoundError as exc:
+            raise ValueError(
+                f"rehearsal output root does not exist: {root}"
+            ) from exc
+        if not resolved.is_dir():
+            raise ValueError(
+                f"rehearsal output root is not a directory: {resolved}"
+            )
+        if resolved == repository_root or repository_root in resolved.parents:
+            raise ValueError(
+                f"repository paths may not be ownership-normalized: {resolved}"
+            )
+        if resolved == temporary_root or temporary_root not in resolved.parents:
+            raise ValueError(
+                "rehearsal output ownership is restricted to a child of the "
+                f"system temporary directory: {resolved}"
+            )
+        if any(
+            parent.name.startswith("leadpoet-restart-source-")
+            for parent in (resolved, *resolved.parents)
+        ):
+            raise ValueError(
+                f"read-only source snapshots may not be ownership-normalized: {resolved}"
+            )
+        if resolved in seen:
+            raise ValueError(
+                f"duplicate rehearsal output root is not allowed: {resolved}"
+            )
+        seen.add(resolved)
+        validated.append(resolved)
+    if not validated:
+        raise ValueError("at least one rehearsal output root is required")
+    return tuple(validated)
+
+
+def _probe_rehearsal_output_access(output_roots: Sequence[Path]) -> None:
+    """Prove the invoking host user can traverse, read, and clean each tree."""
+
+    marker_suffix = f"{os.getpid()}-{time.time_ns()}"
+    for root in output_roots:
+        for directory, _dirnames, filenames in os.walk(root):
+            current = Path(directory)
+            if not os.access(current, os.R_OK | os.W_OK | os.X_OK):
+                raise PermissionError(
+                    f"rehearsal output directory is not host-accessible: {current}"
+                )
+            for filename in filenames:
+                path = current / filename
+                if path.is_file() and not os.access(path, os.R_OK):
+                    raise PermissionError(
+                        f"rehearsal output file is not host-readable: {path}"
+                    )
+        marker = root / f".leadpoet-host-access-{marker_suffix}"
+        descriptor: int | None = None
+        try:
+            descriptor = os.open(
+                marker,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            marker.unlink(missing_ok=True)
+
+
+def _normalize_rehearsal_output_ownership(
+    tag: str,
+    *,
+    docker_platform: str,
+    output_roots: Sequence[Path],
+) -> None:
+    """Return root-written bind outputs to the invoking POSIX user."""
+
+    roots = _validated_rehearsal_output_roots(output_roots)
+    destinations = [f"/host-output/{index}" for index in range(len(roots))]
+    command = [
+        "docker",
+        "run",
+        "--rm",
+        "--platform",
+        docker_platform,
+        "--network",
+        "none",
+        "--read-only",
+        "--cpus",
+        "0.25",
+        "--memory",
+        "64m",
+        "--pids-limit",
+        "16",
+        "--security-opt",
+        "no-new-privileges",
+        "--cap-drop",
+        "ALL",
+        "--cap-add",
+        "CHOWN",
+        "--cap-add",
+        "FOWNER",
+        "--cap-add",
+        "DAC_OVERRIDE",
+        "--user",
+        "0:0",
+    ]
+    for root, destination in zip(roots, destinations):
+        command.extend(
+            [
+                "--mount",
+                f"type=bind,src={root},dst={destination}",
+            ]
+        )
+    command.extend(
+        [
+            "--entrypoint",
+            "/usr/bin/chown",
+            tag,
+            "-R",
+            "--",
+            f"{os.getuid()}:{os.getgid()}",
+            *destinations,
+        ]
+    )
+    try:
+        _run(command)
+    except subprocess.CalledProcessError:
+        # Docker Desktop-backed mounts may not implement POSIX chown.  Access,
+        # not metadata appearance, is the cleanup contract on those mounts.
+        _probe_rehearsal_output_access(roots)
+        print(
+            "REHEARSAL_OUTPUT_CHOWN_UNAVAILABLE_HOST_ACCESS_VERIFIED "
+            + " ".join(str(root) for root in roots),
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    _probe_rehearsal_output_access(roots)
+
+
+def _run_docker_action_with_output_ownership(
+    action: Callable[[], Any],
+    *,
+    tag: str,
+    docker_platform: str,
+    output_roots: Sequence[Path],
+) -> Any:
+    """Run a root container, normalize declared outputs, then preserve failure."""
+
+    roots = _validated_rehearsal_output_roots(output_roots)
+    action_error: BaseException | None = None
+    result: Any = None
+    try:
+        result = action()
+    except BaseException as exc:
+        action_error = exc
+    try:
+        _normalize_rehearsal_output_ownership(
+            tag,
+            docker_platform=docker_platform,
+            output_roots=roots,
+        )
+    except BaseException as ownership_error:
+        if action_error is not None:
+            raise RehearsalOutputOwnershipError(
+                action_error=action_error,
+                ownership_error=ownership_error,
+            ) from ownership_error
+        raise
+    if action_error is not None:
+        raise action_error.with_traceback(action_error.__traceback__)
+    return result
+
+
 def _git_sha(value: str) -> str:
     result = _run(
         ["git", "rev-parse", "--verify", f"{value}^{{commit}}"],
@@ -613,7 +817,7 @@ def _run_component(
         f"REHEARSAL_GATEWAY_WORKER_FLEET_MODE={gateway_worker_fleet_mode}",
         tag,
     ]
-    try:
+    def run_container() -> None:
         with launcher_log.open("w", encoding="utf-8") as output:
             process = subprocess.Popen(
                 command,
@@ -640,6 +844,14 @@ def _run_component(
                 raise
         if returncode:
             raise subprocess.CalledProcessError(returncode, command)
+
+    try:
+        _run_docker_action_with_output_ownership(
+            run_container,
+            tag=tag,
+            docker_platform=docker_platform,
+            output_roots=(evidence_root, durable_state_root),
+        )
     except BaseException:
         _preserve_failure_evidence(
             evidence_root=evidence_root,
@@ -927,61 +1139,66 @@ def _prepared_fixture_seed(
         generated_state.mkdir()
         generated_config.mkdir()
         seed.mkdir()
-        _run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "--platform",
-                docker_platform,
-                "--network",
-                "none",
-                "--cpus",
-                str(limits["cpus"]),
-                "--memory",
-                str(limits["memory"]),
-                "--pids-limit",
-                "2048",
-                "--security-opt",
-                "no-new-privileges",
-                "--tmpfs",
-                "/tmp:rw,exec,nosuid,size=2g",
-                "--mount",
-                f"type=bind,src={source_root},dst=/source,readonly",
-                "--mount",
-                (
-                    f"type=bind,src={drand_artifact_root},"
-                    "dst=/opt/leadpoet/drand-cabi-v2,readonly"
-                ),
-                "--mount",
-                (
-                    f"type=bind,src={generated_state},"
-                    "dst=/rehearsal-state"
-                ),
-                "--mount",
-                (
-                    f"type=bind,src={generated_config},"
-                    "dst=/fixture-config"
-                ),
-                "--env",
-                "REHEARSAL_COMPONENT=validator",
-                "--env",
-                f"REHEARSAL_CANDIDATE_SHA={candidate_sha}",
-                "--env",
-                "REHEARSAL_SCOPE=exact",
-                "--env",
-                "REHEARSAL_STATE_ROOT=/rehearsal-state",
-                "--env",
-                "PYTHONPATH=/source:/harness",
-                "--entrypoint",
-                "/usr/bin/python3.11",
-                tag,
-                "/harness/prepare_host_fixtures.py",
-                "--output-dir",
-                "/fixture-config",
-                "--candidate-sha",
-                candidate_sha,
-            ]
+        _run_docker_action_with_output_ownership(
+            lambda: _run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--platform",
+                    docker_platform,
+                    "--network",
+                    "none",
+                    "--cpus",
+                    str(limits["cpus"]),
+                    "--memory",
+                    str(limits["memory"]),
+                    "--pids-limit",
+                    "2048",
+                    "--security-opt",
+                    "no-new-privileges",
+                    "--tmpfs",
+                    "/tmp:rw,exec,nosuid,size=2g",
+                    "--mount",
+                    f"type=bind,src={source_root},dst=/source,readonly",
+                    "--mount",
+                    (
+                        f"type=bind,src={drand_artifact_root},"
+                        "dst=/opt/leadpoet/drand-cabi-v2,readonly"
+                    ),
+                    "--mount",
+                    (
+                        f"type=bind,src={generated_state},"
+                        "dst=/rehearsal-state"
+                    ),
+                    "--mount",
+                    (
+                        f"type=bind,src={generated_config},"
+                        "dst=/fixture-config"
+                    ),
+                    "--env",
+                    "REHEARSAL_COMPONENT=validator",
+                    "--env",
+                    f"REHEARSAL_CANDIDATE_SHA={candidate_sha}",
+                    "--env",
+                    "REHEARSAL_SCOPE=exact",
+                    "--env",
+                    "REHEARSAL_STATE_ROOT=/rehearsal-state",
+                    "--env",
+                    "PYTHONPATH=/source:/harness",
+                    "--entrypoint",
+                    "/usr/bin/python3.11",
+                    tag,
+                    "/harness/prepare_host_fixtures.py",
+                    "--output-dir",
+                    "/fixture-config",
+                    "--candidate-sha",
+                    candidate_sha,
+                ]
+            ),
+            tag=tag,
+            docker_platform=docker_platform,
+            output_roots=(generated_state, generated_config),
         )
         release_input = generated_state / "release-build-input.json"
         validator_app = generated_state / "validator-app"
@@ -1086,7 +1303,12 @@ def _run_workflow(
         tag,
     ]
     try:
-        _run(command)
+        _run_docker_action_with_output_ownership(
+            lambda: _run(command),
+            tag=tag,
+            docker_platform=docker_platform,
+            output_roots=(evidence_root,),
+        )
     except BaseException:
         _preserve_failure_evidence(
             evidence_root=evidence_root,
@@ -1144,9 +1366,14 @@ def _join_evidence(
             profile,
             "--output",
             f"/evidence/{output.name}",
-        ]
+    ]
     try:
-        _run(command)
+        _run_docker_action_with_output_ownership(
+            lambda: _run(command),
+            tag=tag,
+            docker_platform=docker_platform,
+            output_roots=(evidence_root,),
+        )
         if not output.is_file():
             raise SystemExit(
                 "joined restart rehearsal evidence was not produced"

--- a/sentry-weight-input-authorityv1.md
+++ b/sentry-weight-input-authorityv1.md
@@ -1,0 +1,368 @@
+# Sentry Weight Input Authority v1 Plan
+
+## Status and scope
+
+This plan addresses the unresolved production Sentry inventory for project
+`4511844334239744` over the 14-day window inspected on 2026-08-03. The Sentry
+UI returned 36 rows representing 35 unique issue IDs; issue `7648940448`
+appeared twice in the captured result set. The implementation base is
+`origin/main` at `02d6e6ff5096ade29714a42d45542208c2e22114`.
+
+The only newly evidenced code defect is the recurring split between the
+validator's provisional weight calculation and the gateway coordinator's
+measured weight inputs. The implementation will preserve strict measurement
+and receipt equality by moving equality after a narrowly bounded,
+receipt-backed normalization step. It will not weaken verification, add a
+fallback weight vector, perform a manual chain submission, restart production,
+or resolve Sentry issues without live exact-release evidence.
+
+## Current behavior and evidence
+
+Sentry issue `7648740574` contains 20 observed events across epochs
+24,322-24,333 and releases `d3c41ee6`, `071f4eeb`, `d19f290f`, `720cb484`,
+`350ecf46`, `b576bf5d`, `987ac1d1`, and `57819588`. The error alternates among:
+
+- `bans measured input differs from calculation`
+- `fulfillment_rewards measured input differs from calculation`
+- `sourcing_history measured input differs from calculation`
+
+The validator currently reads bans and fulfillment through public gateway
+endpoints and reads sourcing history from a mutable local file. Later, the
+gateway coordinator independently reconstructs those values from measured
+Supabase reads and durable signed sourcing-epoch records. Any difference causes
+`build_gateway_weight_inputs_v2()` to fail before it can return the measured
+receipts. An exact retry reuses the stale provisional calculation and cannot
+converge.
+
+Two concrete production-shaped gaps are present in the current implementation:
+
+1. Fulfillment reward rows have no canonical database ordering on either the
+   public endpoint or measured Supabase query, but receipt equality treats the
+   resulting list order as significant.
+2. The validator permanently rewrites each banned hotkey occurrence in local
+   sourcing history to `-100_000`, while measured sourcing replay aggregates
+   the unchanged positive scores from signed epoch documents. Existing tests
+   cover only a single fulfillment miner and unbanned sourcing history.
+
+The public production gateway probes `/health`, `/build-info`, and
+`/health/v2-authority` all returned HTTP 502 during triage. The repository's
+secure Sentry helper could not reach the authorized secret source because the
+configured SSH key was unavailable on this Windows host, so the signed-in
+Sentry UI was used as a read-only fallback. No production writes were made.
+
+## Sentry disposition
+
+### Requires this code fix
+
+- `7648740574`: recurring gateway-measured input drift across 12 consecutive
+  epochs and eight releases.
+
+### Already addressed on current main; requires exact-release rollout proof
+
+- `7650013795`: `runtime.enclave_relay_unavailable` on failed candidate
+  `04288ea0`.
+- `7649919954`: restart-time `authority.dependency_unreadable` on candidate
+  `b1b6fdcc`.
+- `7649624680`: restart stage deadline exceeded.
+- `7649234649`: restart terminal-failure summary.
+
+Current main contains the subsequent Nitro cgroup-v1 root-readiness and runsc
+gofer-root fixes (`602c1442` and `02d6e6ff`). Those changes have not been
+observed live because the gateway is down, so the groups are not confirmed
+resolved.
+
+### Operational/downstream symptoms; keep fail-closed
+
+- `7648934938`: allocation fetch HTTP 502.
+- `7648940429`: weight submission blocked because allocation was unavailable.
+- `7649946194`: gateway weight endpoint unavailable.
+- `7648940448`: allocation authority missing.
+- `7648736163`: no durable publication before the epoch window closed.
+- `7648742222`, `7648742229`, `7648742205`: finalized-chain proof missing and
+  its wrapper/trace groups.
+- `7649149351`, `7649149340`, `7649149328`, `7648946496`: compact publication
+  503/store failure and wrapper groups on superseded releases.
+- `7648740462`, `7648740394`: unsigned/prior-epoch journal quarantine; expected
+  fail-closed recovery behavior.
+- `7648946471`, `7648946455`, `7648929001`, `7648750617`: preparation/allocation
+  failures and wrappers on superseded releases.
+
+These groups do not justify a fallback, warning suppression, or manual weight
+submission. They require exact-SHA deployment, durable publication/finalization
+evidence, and chain readback.
+
+### Superseded Research Lab execution failures; monitor exact new release
+
+- `7649029237`, `7649232899`, `7648893626`, `7648756535`, `7648947705`,
+  `7648959895`, `7648919035`, `7648852473`, `7648756315`.
+
+These protected-surface scoring, artifact-store, and enclave RPC groups span
+older releases. They are not sufficiently specific to justify another patch
+without recurrence on the exact candidate after gateway recovery.
+
+### Diagnostic probe only
+
+- `7648746574`, `7648746529`, `7648746527`: a `<stdin>` probe assumed the
+  legacy `upstream_receipt_set` field even after requesting compact ancestry.
+  Production code already branches correctly between full and compact
+  responses. The probe/runbook should be updated separately; the production
+  protocol should not be changed to satisfy it.
+
+## Goals
+
+1. Allow a new validator to treat authenticated gateway measurements as the
+   authority for exactly nine gateway-owned mutable snapshot fields.
+2. Preserve strict canonical equality between the authoritative calculation
+   and every measured receipt document.
+3. Preserve all scoring, allocation, reward, burn, feature-flag, chain,
+   metagraph, commit, and configuration semantics.
+4. Preserve byte/schema-compatible behavior for N-1 validators that do not
+   select the new signed mode.
+5. Make sourcing history explicitly depend on the measured bans receipt and
+   reproduce the existing per-epoch `-100_000` ban penalty without mutating the
+   persisted signed epoch document.
+6. Prove the authoritative host calculation and validator-enclave result are
+   bit-identical before publication.
+
+## Non-goals
+
+- Deploying, restarting, merging, or mutating production.
+- Resolving Sentry groups before exact-release live verification.
+- Changing Research Lab allocation, fulfillment reward arithmetic, sourcing
+  scores, promotion, settlement, emissions, burn policy, or chain submission.
+- Normalizing validator-owned fields or accepting an arbitrary gateway
+  calculation.
+- Adding a database migration or new production dependency.
+- Repairing the ad hoc `<stdin>` probe in production source.
+
+## Architecture and data flow
+
+### Signed mode selection
+
+Extend the canonical weight-input request with an optional signed field:
+
+```text
+snapshot_authority_mode = "gateway-measured-v2"
+```
+
+The field participates in the canonical request hash and the validator-enclave
+signature. A request without the field follows the exact legacy path. The one
+known value selects normalization. Unknown values and extra fields fail closed.
+Because the mode is signed, legacy and normalized singleflight/cache work can
+never collide.
+
+### Normalization boundary
+
+Add a dependency-free canonical normalizer. It accepts a provisional
+calculation and measured documents and may copy only this map:
+
+| Measured category | Permitted calculation fields |
+| --- | --- |
+| `bans` | `banned_hotkeys`, `banned_lookup_ok` |
+| `fulfillment_rewards` | `fulfillment_share`, `fulfillment_rows`, `fulfillment_fetch_ok` |
+| `leaderboard` | `leaderboard_entries`, `leaderboard_fetch_ok` |
+| `sourcing_history` | `rolling_lead_count`, `rolling_scores` |
+
+The following remain immutable: allocation document and authority, champion,
+reimbursement and source-add data, leaderboard shares, metagraph, burn
+ownership, epoch, block, netuid, commit/config hashes, feature flags, constants,
+parent receipt fields, and every unlisted value.
+
+The normalizer validates each document's schema, category, netuid, epoch, and
+exact value shape; copies only allowed values; runs `compute_final_weights()`;
+and returns the authoritative calculation plus a sorted list of changed source
+categories. After normalization, all gateway input documents are regenerated
+from that calculation and compared canonically with all measured documents.
+The existing equality boundary moves; it is not removed.
+
+### Ban-aware sourcing
+
+Gateway execution ordering becomes:
+
+1. Allocation/config-derived categories, bans, fulfillment, and leaderboard.
+2. Sourcing history, with both signed sourcing-epoch graphs and the signed bans
+   execution graph as parents.
+3. Canonical snapshot normalization.
+4. Anomaly adjustment from the normalized calculation and measured upstream
+   documents.
+5. Final all-category canonical equality.
+
+The sourcing replay validates the bans receipt role, purpose, epoch,
+persistence lineage, declared-parent membership, and output root. For every
+authenticated epoch document, a banned hotkey already present in that epoch is
+treated as exactly `-100_000`; absent hotkeys are not introduced. Raw signed
+sourcing documents are never mutated or rehashed.
+
+### Response and validator flow
+
+Legacy full and compact responses remain unchanged. Normalized full and compact
+responses add:
+
+```text
+snapshot_authority_mode
+authoritative_calculation_snapshot
+authoritative_calculation_snapshot_hash
+normalized_source_categories
+```
+
+`calculation_snapshot_hash` continues to identify the signed provisional
+snapshot. The client validates the exact response field set, authoritative
+hash, allowed diff, and independently derived changed-category list before
+passing the response across vsock.
+
+The validator host first proves the caller's UID/float vector matches canonical
+computation of the provisional snapshot. It then recomputes from the
+authoritative snapshot, sends that exact snapshot and measured receipts to the
+validator enclave, and compares the enclave vector bit-for-bit and u16-for-u16
+with the authoritative host calculation. Only the enclave result proceeds to
+publication and chain submission.
+
+## File-level implementation
+
+- `leadpoet_canonical/hotkey_authority_v2.py`
+  - Add exact legacy/new request schemas and signed mode hashing.
+- `leadpoet_canonical/weight_authority_v2.py`
+  - Add the canonical allowlisted normalizer and changed-category derivation.
+- `leadpoet_canonical/sourcing_history_v2.py`
+  - Add ban-aware rolling replay with existing ordering/numeric semantics.
+- `gateway/tee/coordinator_weight_source_v2.py`
+  - Allow pre-normalization measured values only for the four categories in
+    normalized mode; retain strict early equality elsewhere; validate the bans
+    parent and produce ban-aware sourcing history.
+- `gateway/research_lab/attested_weight_inputs_v2.py`
+  - Sequence bans before sourcing, normalize before anomaly, and enforce final
+    equality for all categories. Preserve strict legacy behavior.
+- `gateway/api/weights.py`
+  - Add exact normalized response models, mode-aware singleflight/cache keys,
+    and hash/category-only observability.
+- `validator_tee/host/gateway_weight_inputs_v2.py`
+  - Sign the mode, validate normalized full/compact responses, and repeat the
+    canonical normalization boundary locally.
+- `validator_tee/host/authoritative_weight_flow_v2.py`
+  - Verify provisional caller vector, then authoritative host/enclave vector,
+    and publish only the enclave result.
+- Protected workflow declarations/manifests
+  - Include the request-mode, normalization, ban-aware sourcing, builder/API,
+    client, and authoritative-flow symbols in both gateway and validator
+    protected closures.
+- Focused unit, integration, protected-closure, and restart-rehearsal fixtures
+  - Add stale provisional bans, fulfillment, leaderboard, and sourcing cases.
+
+No SQL migration or external interface other than the backward-compatible
+signed request/response variant is planned.
+
+## Security and compatibility constraints
+
+- No host-selected value may bypass a measured receipt.
+- The gateway cannot normalize an unlisted field.
+- The validator client independently repeats normalization and rejects any
+  extra response field or category mismatch.
+- The validator enclave continues to verify attestation, receipt signatures,
+  source evidence, output roots, chain state, commit, config, and final vector.
+- Legacy requests and responses remain exact and strict for N-1 compatibility.
+- Unknown modes fail closed.
+- Logs contain only mode, hashes, and category names; never hotkeys, scores,
+  source rows, provider payloads, or credentials.
+- Failures remain 503/fail-closed. No stale cache, manual vector, or burn-only
+  fallback is introduced.
+
+## Failure states and observability
+
+The normalized request must fail closed for invalid signatures, unknown modes,
+forbidden field changes, malformed documents, source/receipt mismatch, missing
+or duplicated bans ancestry, invalid sourcing records, normalization failure,
+host/enclave divergence, or publication/finalization failure.
+
+Record bounded stage telemetry for provisional hash, authoritative hash,
+signed mode, normalized category names, and terminal failure code. Do not emit
+the input values. Existing Sentry wrapper coalescing remains unchanged.
+
+## Acceptance criteria
+
+1. Production-shaped stale provisional bans, fulfillment, leaderboard, and
+   sourcing values succeed only in signed normalized mode.
+2. The same drift still fails in legacy mode.
+3. Every immutable-field or extra-field mutation is rejected.
+4. Measured sourcing includes and validates the direct bans authority and
+   exactly reproduces the existing per-epoch ban penalty.
+5. Final receipt output roots equal documents regenerated from the authoritative
+   snapshot for every gateway category.
+6. The provisional caller vector matches canonical provisional computation.
+7. The authoritative host vector matches the validator-enclave result at UID,
+   IEEE-754 float-bit, sparse UID, and u16 levels.
+8. Compact and full ancestry verification remain intact.
+9. Protected workflow manifests validate from the frozen candidate tree.
+10. Focused tests, syntax checks, diff checks, and the repository `prepush`
+    restart rehearsal pass with every critical stage passed.
+11. No database migration, dependency, production mutation, or unrelated file
+    enters the diff.
+
+## Test matrix
+
+### Canonical and component tests
+
+- Every allowed overlay independently and in combination.
+- Immutable, nested, schema, category, epoch, netuid, hash, and extra-field
+  attacks.
+- Multi-miner fulfillment data in reverse source order.
+- Ban-aware sourcing with present/absent hotkeys and multiple epochs.
+- Missing, forged, duplicated, wrong-purpose, wrong-epoch, unpersisted, and
+  output-root-mismatched bans parents.
+- Legacy drift rejection and normalized drift convergence.
+
+### API and compatibility tests
+
+- Exact legacy and normalized signed request hashes.
+- Exact legacy/new compact and full response field sets.
+- Unknown mode rejection and legacy/new singleflight isolation.
+- Provisional versus authoritative hash/category validation.
+- Compact proof and full receipt-set verification unchanged.
+
+### Workflow and adversarial tests
+
+- Provisional caller-vector mismatch rejected before gateway publication.
+- Authoritative host/enclave mismatch rejected before publication.
+- Enclave receives only the authoritative snapshot.
+- Anomaly executes after normalization and binds all measured final documents.
+- Protected gateway and validator closures/manifests validate.
+- Restart rehearsal injects stale provisional dynamic values and reaches the
+  same compact bundle at gateway, primary validator, and audit validator.
+
+### Required release gate
+
+Run focused pytest files for canonical weight authority, coordinator source,
+attested input builder, gateway API/client, authoritative host/enclave flow,
+protected workflows, canonical computation, validator epoch flow, model
+sandbox, and restart evidence identity. Then run:
+
+```text
+git diff --check
+python -m py_compile <all touched Python files>
+python -m gateway.tee.protected_workflows --root . --manifest gateway/tee/protected_workflows.json
+python -m validator_tee.host.protected_workflows_v2 --root . --manifest validator_tee/enclave/protected_workflows_v2.json
+```
+
+Because this changes gateway, validator, receipt ancestry, and weight
+publication, freeze the candidate and run the repository `prepush` profile from
+the verified deployed N-1 SHA. The user did not request `unaccelerated`, so the
+long profile is out of scope.
+
+## Rollout and rollback
+
+This task may open a reviewed pull request. It does not authorize merge,
+deployment, restart, Sentry resolution, production database mutation, or chain
+submission.
+
+Before any runtime-changing push, recheck the official live epoch block and
+GitHub release/attestation state. A separately authorized deployment must prove
+the exact candidate through `/health`, `/build-info`, `/health/v2-authority`,
+PCR0, manifests, coordination marker, identical gateway/primary/audit bundle
+hash, durable publication/finalization rows, finalized extrinsic, `LastUpdate`,
+and chain readback. Observe three consecutive complete epochs with no new
+measured-input drift or 502/downstream alarms before resolving historical
+Sentry groups.
+
+Rollback uses all components on the previous full 40-character attested SHA.
+Release `57819588` may restore availability but contains the recurring
+measured-input defect, so it is only an emergency fail-closed rollback and not
+a durable resolution.

--- a/sentry-weight-input-authorityv2.md
+++ b/sentry-weight-input-authorityv2.md
@@ -1,0 +1,379 @@
+# Sentry Weight Input Authority v2 Remediation Plan
+
+## Decision
+
+V2 is a no-code remediation and verification phase.
+
+The complete v1 implementation has no confirmed unresolved product, security,
+compatibility, test, or rehearsal defect. Do not change production source,
+tests, protected manifests, or the restart runner merely to create phase-5
+churn. Add only this v2 plan, then proceed to frozen-candidate verification.
+
+Binary recommendation: accept v1 for completed-work verification, withhold push
+if the official `prepush` gate or its live deployed-N-1 prerequisites cannot be
+completed.
+
+## Scope and Sentry disposition
+
+The task remains scoped to the 35 unique Sentry issues inspected for project
+`4511844334239744` over 14 days.
+
+Only issue `7648740574` required new code. Its 20 events across epochs
+24,322-24,333 and eight releases showed a recurring disagreement between
+provisional validator inputs and independently measured gateway bans,
+fulfillment rewards, and sourcing history.
+
+The v1 implementation addresses that defect with a signed optional
+`snapshot_authority_mode="gateway-measured-v2"` path, exact legacy-wire
+preservation, a nine-field normalization allowlist, deterministic fulfillment
+ordering, durable-ban-aware sourcing replay, strict receipt equality after
+normalization, independent gateway/client/enclave verification, provisional
+caller-vector verification, authoritative host/enclave equality, and
+enclave-only publication.
+
+The remaining Sentry groups stay in their v1 dispositions:
+
+- Current-main restart/runtime fixes require exact-release rollout evidence.
+- Allocation, publication, finalization, and chain-readback failures are
+  downstream or operational fail-closed symptoms.
+- Superseded Research Lab execution failures require recurrence on the exact
+  new release before another patch is justified.
+- The `<stdin>` compact-ancestry probe is a bad diagnostic, not a production
+  protocol defect.
+
+No fallback vector, warning suppression, manual chain submission, production
+restart, Sentry resolution, or deployment is authorized.
+
+## V1 findings and remediation status
+
+### Protected workflow digest drift
+
+Confirmed finding: five gateway protected AST digests were stale after the v1
+source changes.
+
+Root cause: protected symbols changed but the canonical generated manifest had
+not yet been refreshed.
+
+Remediation completed in v1: regenerate through the repository's canonical
+generator while preserving the existing protected source commitments. Both
+gateway and validator protected manifests now validate.
+
+Regression evidence: both protected-manifest validation commands passed from
+the LF candidate mirror.
+
+V2 action: none.
+
+### Compact ancestry selected the persistence wrapper
+
+Confirmed finding: compact input ancestry could select the terminal
+artifact-persistence proof and graph rather than the direct measured execution
+proof. The persistence proof does not disclose the direct measured input
+receipt required by compact verification.
+
+Root cause: `_compact_weight_ancestry()` preferred the generic terminal fields
+even when execution-specific compact evidence was present.
+
+Remediation completed in v1: prefer `execution_ancestry_compact_proof` with
+`execution_receipt_graph`, retaining the terminal fields as the legacy
+fallback.
+
+Regression evidence: the focused builder test verifies every compact category
+resolves to the execution receipt rather than the persistence wrapper.
+
+V2 action: none.
+
+### Artifact-persistence output was not available as a strict receipt-bound value
+
+Confirmed finding: ban-aware sourcing needed to consume a canonical
+artifact-persistence output and prove that the terminal receipt committed
+exactly that value.
+
+Root cause: the executor output existed, but the scoring bridge did not expose
+it through an exact schema-and-output-root validation boundary.
+
+Remediation completed in v1:
+
+- Validate exact persistence output and artifact descriptor fields.
+- Require unique, sorted artifact IDs and a canonical `artifact_set_root`.
+- Bind the returned output to the terminal receipt's `output_root`.
+- Pass the validated output into measured sourcing.
+- Require exactly one persisted artifact whose plaintext hash binds the bans
+  value.
+
+Regression evidence covers missing and extra fields, malformed descriptors,
+duplicate and unsorted IDs, wrong set roots, receipt mismatch,
+missing/direct/duplicated/forged/wrong-purpose/wrong-epoch bans ancestry,
+output mismatch, and extra terminal parents.
+
+V2 action: none.
+
+### Rehearsal adapter defects discovered during real execution
+
+Confirmed findings in the v1 rehearsal implementation included a keyword-only
+source invocation mismatch, incorrect persistence logical-operation IDs,
+premature local graph validation before parent merge, a sourcing receipt
+stamped with the current rather than source epoch, fabricated-lineage risk, and
+a missing real hotkey authorization ID.
+
+Root cause: the first rehearsal draft did not yet reproduce all production
+coordinator and validator authority contracts.
+
+Remediation completed in v1:
+
+- Invoke the real source resolver with its keyword-only contract.
+- Use production-shaped logical operation IDs.
+- Merge declared external parents before graph validation.
+- Stamp signed sourcing evidence with the source epoch.
+- Derive one shared lineage with `derive_ancestry_lineage_id_v2`.
+- Use the real `ValidatorHotkeyAuthorityV2` seed provisioning, result
+  registration, application signing, and validator publication ancestry proof.
+- Exercise real coordinator manager/source/executor, gateway client, validator
+  enclave authority, compact primary verifier, publication operation, public
+  authority builder, compact audit verifier, and typed immutable-field
+  rejection.
+
+All five gateway-measured diagnostic stages and the joined invariant passed.
+
+V2 action: none.
+
+## Missing or limited acceptance evidence
+
+### Official frozen-candidate prepush gate
+
+Status: missing and required.
+
+Reason: the candidate has not yet been frozen into an exact commit. The public
+gateway later recovered and a read-only `GET /health/v2-authority` returned
+HTTP 200 with status `ready` and deployed commit
+`56f6aa425fb08f468e2701b2001f13303419236f`; this is authoritative point-in-time
+N-1 evidence, but it must be rechecked immediately before the rehearsal. At
+the same checkpoint, the official Subnet 71 snapshot was epoch block 193 and
+current `origin/main` was `99fb514e013f751214bb8419ff607cb104514f88` with its
+unit/workflow job passed while Docker smoke and independent attested builds
+were still running.
+
+Disposition: this is a phase-6/7 verification and release-readiness gate, not a
+V2 source defect.
+
+Required action:
+
+1. Freeze the complete reviewed candidate, including both plan files.
+2. Recheck the official live epoch block and current GitHub
+   release/attestation state.
+3. Verify the exact deployed N-1 SHA through an approved read-only authority.
+4. Run:
+
+   ```bash
+   python3 scripts/run_local_restart_rehearsal.py \
+     --from-sha <verified-deployed-n-minus-one-sha> \
+     --candidate-sha <frozen-candidate-sha> \
+     --transition forward \
+     --profile prepush
+   ```
+
+5. Require every critical stage to be `passed`; no critical stage may be
+   `failed` or `unexercised`.
+6. Report per-stage and total duration.
+
+The user did not request `unaccelerated`; do not run that profile.
+
+If the deployed N-1 identity, epoch block, or attestation state remains
+unavailable, stop before push. Do not substitute the Sentry release tag, a
+guessed SHA, or a working-tree snapshot.
+
+### Windows-mounted real-vsock timeout
+
+Status: resolved for completed-work verification; not a candidate defect.
+
+Evidence: `test_local_vsock_runs_real_framing_and_rejects_unknown_rpc` timed out
+only from the Windows-mounted LF mirror; the identical unmodified LF base
+passed the exact test. The exact current-main candidate then passed the full
+native-Linux integrity file, 108/108, including the real-vsock test. Native
+Windows collection still has pre-existing Linux-only `fcntl` and CRLF raw
+signed-contract limitations.
+
+Disposition:
+
+- Do not increase production or rehearsal timeouts to hide a mount-specific
+  slowdown.
+- Do not skip the test.
+- Keep candidate and prepush verification on a native LF Linux/WSL filesystem
+  with the declared-requirements environment.
+- Treat any future same-environment candidate-only recurrence as a real defect;
+  do not widen timeouts or skip the test.
+
+### Post-deploy production proof
+
+Status: unavailable and out of scope because deployment was not requested.
+
+Required later evidence, under separate deployment authorization, remains
+exact candidate identity, PCR0, protected manifests, coordination marker,
+identical gateway/primary/audit bundle hash, durable publication and
+finalization, finalized extrinsic, `LastUpdate`, chain readback, and three
+consecutive complete epochs without measured-input drift or downstream 502
+alarms.
+
+Historical Sentry issues must not be resolved before that proof exists.
+
+## V2 change set
+
+Create:
+
+- `sentry-weight-input-authorityv2.md`
+
+Do not modify:
+
+- Production gateway, canonical, validator, enclave, or neuron modules.
+- Unit or integration tests.
+- Restart rehearsal implementation or behavior contract.
+- Protected workflow source declarations or generated manifests.
+- Dependencies, database schema, migrations, configuration, or deployment
+  files.
+
+If phase-6 verification finds a candidate-only failure, return the exact
+failure to a scoped V2 implementation pass and add the smallest regression
+before repeating verification. Do not preemptively change code.
+
+## Rehearsal-size decision
+
+Retain the 1,407-line addition to
+`tests/restart_rehearsal/production_workflow_runner.py`.
+
+The size is substantial, but the added code is not duplicated production
+policy or a synthetic success fixture. It supplies strict sanitized adapters
+for privileged Supabase, object-lock, chain, attestation, and hotkey boundaries
+while driving the existing production coordinator, persistence, client,
+enclave, compact verification, publication, and audit paths.
+
+Splitting it into another helper module now would move rather than remove
+complexity, enlarge the diff, and add import and maintenance surface without
+improving incident acceptance. A later refactor is justified only if another
+scenario reuses these adapters and can preserve identical stage-ledger and
+integrity coverage.
+
+## Vector-evidence decision
+
+Do not add duplicate primary/audit vector fields solely for display.
+
+The measured path already provides:
+
+- Direct host/enclave equality at UID order, IEEE-754 float bits, sparse UID
+  order, and u16 weights through `_verify_host_vector` and its focused
+  regressions.
+- A compact primary verifier that validates the signed immutable bundle.
+- A compact public audit verifier that binds the same bundle hash through the
+  publication authority.
+- A rehearsal invariant requiring the primary and audit bundle hashes to
+  match.
+- Existing independent direct primary/auditor `uids` and `weights_u16`
+  equality coverage in the broader rehearsal.
+
+Re-serializing the same measured vector into another evidence field would not
+be an independent check. Add it only if a future verifier consumes vector
+evidence without verifying the signed bundle.
+
+## Completed v1 and current-main integration evidence
+
+The exact task diff was three-way integrated onto fetched current main
+`99fb514e013f751214bb8419ff607cb104514f88`. All production, test, and runner
+hunks applied cleanly; only the two generated protected manifests conflicted,
+and both were canonically regenerated from the combined source while
+preserving the current upstream commitments. The publishing worktree and
+native LF candidate had the same tracked binary diff SHA-256,
+`81648e3c8ea1cb5600a6baf20cb82638de4c689aa72dad501844b1021a5e2b11`.
+
+The fresh clean LF declared-requirements verification produced:
+
+- 247 focused tests passed.
+- 59 compact/canonical/epoch/protected tests passed.
+- 89 related Sentry, recovery, coordinator, bundle, submission, and external-
+  boundary tests passed.
+- All 11 independent workflow stages passed, including all five
+  gateway-measured stages, and `gateway_measured_authority_exact` was true.
+- Both protected manifests validated.
+- All touched Python files compiled.
+- `git diff --check` passed.
+- `tests/restart_rehearsal/test_rehearsal_integrity.py` passed 108/108 from
+  native LF storage, including the real-vsock framing regression.
+
+This evidence supports a no-code V2 decision but does not replace
+frozen-candidate verification.
+
+## Required completed-work verification
+
+Run from a clean native LF Linux/WSL candidate environment with only declared
+test requirements:
+
+```bash
+python3 -m pytest -q \
+  tests/test_hotkey_authority_v2.py \
+  tests/test_weight_authority_v2.py \
+  tests/test_sourcing_history_v2.py \
+  tests/test_coordinator_executor_v2.py \
+  tests/test_attested_scoring_v2_bridge.py \
+  tests/test_coordinator_weight_source_v2.py \
+  tests/test_attested_weight_inputs_v2.py \
+  tests/test_gateway_weights_v2.py \
+  tests/test_gateway_weight_inputs_client_v2.py \
+  tests/test_validator_weight_authority_v2.py \
+  tests/test_authoritative_weight_flow_v2.py
+```
+
+Repeat the previously green compact/canonical/epoch/protected and
+Sentry/ban/release/coordinator/bundle/submission slices, then run:
+
+```bash
+python3 -m pytest -q tests/restart_rehearsal/test_rehearsal_integrity.py
+git diff --check
+python3 -m py_compile <all touched Python files>
+python3 -m gateway.tee.protected_workflows \
+  --root . \
+  --manifest gateway/tee/protected_workflows.json
+python3 -m validator_tee.host.protected_workflows_v2 \
+  --root . \
+  --manifest validator_tee/enclave/protected_workflows_v2.json
+```
+
+Finally run the frozen-candidate `prepush` command above. Re-test every v1
+finding and require the gateway-measured stage ledger to include:
+
+- `diagnostic:gateway-measured-coordinator`
+- `diagnostic:gateway-measured-client-enclave`
+- `diagnostic:gateway-measured-primary-compact`
+- `diagnostic:gateway-measured-audit-compact`
+- `diagnostic:gateway-measured-immutable-tamper`
+
+Require `gateway_measured_authority_exact` to be true.
+
+## Acceptance criteria
+
+1. No V2 production, test, rehearsal, manifest, dependency, migration,
+   configuration, or deployment change is introduced without new failure
+   evidence.
+2. All completed-work focused and integrity checks pass from a native LF
+   candidate environment.
+3. Both generated protected manifests validate from the frozen candidate.
+4. Every critical `prepush` stage passes from the verified deployed N-1 SHA to
+   the exact candidate SHA.
+5. The five gateway-measured diagnostics pass and
+   `gateway_measured_authority_exact` is true.
+6. The candidate remains backward-compatible for exact legacy requests and
+   fail-closed for unknown modes, immutable mutations, invalid ancestry, vector
+   divergence, publication failure, and finalization failure.
+7. No production write, restart, deployment, Sentry resolution, or chain
+   submission occurs under `$ship`.
+8. If live N-1, epoch, or attestation authority is unavailable, the branch is
+   not pushed and the exact blocker is reported.
+
+## Rollout limitations and rollback
+
+This plan authorizes neither merge nor deployment.
+
+Before push, the repository's epoch and attestation gate must be satisfied. A
+later deployment must activate gateway and validators on one exact attested SHA
+and prove the full durable and chain path before any Sentry issue is resolved.
+
+Rollback, if separately authorized after deployment, must use all components
+on the previous full 40-character attested SHA. The observed `57819588...`
+release retains the original measured-input defect and is therefore only an
+emergency fail-closed availability rollback, not a durable resolution.

--- a/sentry-weight-input-authorityv2.md
+++ b/sentry-weight-input-authorityv2.md
@@ -377,3 +377,26 @@ Rollback, if separately authorized after deployment, must use all components
 on the previous full 40-character attested SHA. The observed `57819588...`
 release retains the original measured-input defect and is therefore only an
 emergency fail-closed availability rollback, not a durable resolution.
+
+## Post-freeze rehearsal harness remediation
+
+The first exact frozen-candidate `prepush` run supplied new failure evidence
+and therefore activated the scoped remediation path described above. The
+candidate behavior tests passed, but the release gate failed before exercising
+gateway and validator restart stages for two harness-only reasons:
+
+- The workflow component executed before Git trusted the read-only `/source`
+  mount, so every exact `git show` identity check failed with Git's dubious
+  ownership protection. The harness now trusts only `/source` before the early
+  workflow execution and no longer installs wildcard safe-directory trust.
+- Root-required rehearsal containers left declared temporary fixture, durable
+  state, and evidence bind mounts owned by root. The driver now runs a bounded,
+  offline sidecar after each such Docker action to return only those validated
+  task-temporary output roots to the invoking UID/GID, then proves host
+  traversal, readability, writability, and marker cleanup. Source, artifact,
+  and fixture-seed read-only mounts remain untouched.
+
+The original production change, exact-commit comparisons, fail-closed policy,
+container root execution, time budget, and protected manifests are unchanged.
+This addendum does not clear the release gate: a newly frozen candidate must
+pass the complete official `prepush` rehearsal before publication.

--- a/tests/restart_rehearsal/production_workflow_runner.py
+++ b/tests/restart_rehearsal/production_workflow_runner.py
@@ -25,7 +25,10 @@ import time
 import traceback
 from types import SimpleNamespace
 from typing import Any, Callable, Mapping
+from urllib.parse import parse_qs, urlparse
 
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 
@@ -35,25 +38,71 @@ if str(SOURCE_ROOT) not in sys.path:
 
 from leadpoet_canonical.attested_v2 import (  # noqa: E402
     EMPTY_HOST_OPERATION_ROOT,
+    build_checkpointed_receipt_graph,
     build_execution_receipt_body,
     build_receipt_graph,
+    build_transport_attempt,
+    canonical_json,
     create_signed_execution_receipt,
     merkle_root,
+    sha256_bytes,
     sha256_json,
+    transport_root,
+)
+from leadpoet_canonical.ancestry_checkpoint_v2 import (  # noqa: E402
+    derive_ancestry_lineage_id_v2,
+)
+from leadpoet_canonical.binding import create_binding_message  # noqa: E402
+from leadpoet_canonical.chain_source_v2 import ss58_encode_account_id  # noqa: E402
+from leadpoet_canonical.compact_auditor_authority_v2 import (  # noqa: E402
+    build_compact_published_weight_authority_v2,
+    verify_compact_published_weight_authority_v2,
+    verify_compact_weight_submission_v2,
+)
+from leadpoet_canonical.compact_weight_authority_v2 import (  # noqa: E402
+    build_checkpointed_weight_graph_from_compact_v2,
 )
 from leadpoet_canonical.auditor_v2 import (  # noqa: E402
     verify_attested_weight_authority_v2,
     verify_attested_weight_bundle_v2,
 )
 from leadpoet_canonical.hotkey_authority_v2 import (  # noqa: E402
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
     build_weight_extrinsic_authorization_v2,
     chain_signing_profiles,
     encode_signed_extrinsic_v2,
     signed_extrinsic_hash_v2,
+    weight_inputs_request_message_v2,
 )
 from leadpoet_canonical.weight_authority_v2 import (  # noqa: E402
+    GATEWAY_MEASURED_NORMALIZATION_FIELDS_V2,
+    GATEWAY_WEIGHT_INPUT_CATEGORIES,
     validate_published_weight_bundle_v2,
     validate_weight_finalization_submission_v2,
+)
+from gateway.research_lab.attested_weight_inputs_v2 import (  # noqa: E402
+    build_gateway_weight_inputs_v2,
+)
+from gateway.tee.coordinator_executor_v2 import (  # noqa: E402
+    COORDINATOR_OPERATIONS_V2,
+    OP_ATTEST_ARTIFACT_PERSISTENCE,
+    OP_ATTEST_WEIGHT_INPUT,
+    OP_ATTEST_WEIGHT_PUBLICATION,
+    CoordinatorExecutorV2,
+    coordinator_failed_parent_graph_policy_v2,
+)
+from gateway.tee.coordinator_weight_source_v2 import (  # noqa: E402
+    CoordinatorWeightSourceV2,
+)
+from gateway.tee.execution_job_manager_v2 import (  # noqa: E402
+    JOB_SCHEMA_VERSION,
+    PARENT_RECEIPT_GRAPH_SET_FIELD,
+    ExecutionJobManagerV2,
+    pack_parent_receipt_graph_set_v2,
+)
+from gateway.tee.supabase_source_v2 import (  # noqa: E402
+    QUERY_POLICIES,
+    SupabaseSourceReaderV2,
 )
 from local_services import (  # noqa: E402
     LocalBoundaryServices,
@@ -69,9 +118,18 @@ from sanitized_weight_fixture import (  # noqa: E402
 )
 from validator_tee.enclave.hotkey_authority_v2 import (  # noqa: E402
     _Sr25519Backend,
+    ValidatorHotkeyAuthorityV2,
+)
+from validator_tee.enclave.weight_authority_v2 import (  # noqa: E402
+    ValidatorWeightAuthorityV2,
+)
+from validator_tee.host.gateway_weight_inputs_v2 import (  # noqa: E402
+    GatewayWeightInputsV2Error,
+    fetch_gateway_weight_inputs_v2,
 )
 from validator_tee.host.weight_authority_v2 import (  # noqa: E402
     build_authoritative_weight_bundle_v2,
+    build_compact_weight_submission_v2,
 )
 from gateway.tee.rehearsal_behavior_contract_v2 import (  # noqa: E402
     build_rehearsal_behavior_contract_v2,
@@ -1288,11 +1346,784 @@ def _recompose_candidate_bundle(
     )
 
 
+def _verify_gateway_measured_boot_v2(
+    identity: Mapping[str, Any],
+    *,
+    expected_pcr0: str | None = None,
+    **_kwargs: Any,
+) -> dict[str, str]:
+    """Validate the sanitized attestation boundary without accepting a flag."""
+
+    boot = dict(identity)
+    if expected_pcr0 is not None and boot.get("pcr0") != expected_pcr0:
+        raise RuntimeError("gateway measured boot PCR0 differs")
+    try:
+        attestation = base64.b64decode(
+            str(boot["attestation_document_b64"]), validate=True
+        )
+    except Exception as exc:
+        raise RuntimeError("gateway measured boot attestation is invalid") from exc
+    if not attestation:
+        raise RuntimeError("gateway measured boot attestation is empty")
+    return {
+        "boot_identity_hash": str(boot["boot_identity_hash"]),
+        "pcr0": str(boot["pcr0"]),
+        "attestation_document_hash": sha256_bytes(attestation),
+    }
+
+
+def _gateway_measured_epoch_authority_v2(
+    *,
+    fixture: SanitizedWeightFixture,
+    calculation_snapshot: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], str]:
+    """Build one stateful cutover identity used by every local authority."""
+
+    calculation = dict(calculation_snapshot)
+    netuid = int(calculation["netuid"])
+    epoch_id = int(calculation["epoch_id"])
+    current_block = int(calculation["block"])
+    tempo = 360
+    last_epoch_block = current_block - (current_block % tempo)
+    epoch_block = current_block - last_epoch_block
+    cutover = {
+        "schema_version": "leadpoet.subnet_epoch_cutover.v1",
+        "epoch_scheme": "bittensor.subnet_epoch_index.v1",
+        "network_genesis_hash": GENESIS_HASH,
+        "netuid": netuid,
+        "cutover_block": last_epoch_block,
+        "cutover_block_hash": "0x" + sha256_json(
+            {"kind": "gateway-measured-cutover", "block": last_epoch_block}
+        )[7:],
+        "first_subnet_epoch_index": epoch_id,
+        "first_settlement_epoch_id": epoch_id,
+        "last_legacy_epoch_id": max(0, epoch_id - 1),
+    }
+    cutover_mapping_hash = sha256_json(cutover)
+    epoch_ref = sha256_json(
+        {
+            "candidate_sha": fixture.candidate_sha,
+            "netuid": netuid,
+            "epoch_id": epoch_id,
+            "kind": "gateway-measured-stateful-epoch",
+        }
+    )
+    boundary = {
+        "schema_version": "leadpoet.subnet_epoch_snapshot.v1",
+        "epoch_scheme": "bittensor.subnet_epoch_index.v1",
+        "network_genesis_hash": GENESIS_HASH,
+        "netuid": netuid,
+        "head_kind": "finalized",
+        "block_hash": "0x" + sha256_json(
+            {"kind": "gateway-measured-boundary", "block": last_epoch_block}
+        )[7:],
+        "current_block": last_epoch_block,
+        "last_epoch_block": last_epoch_block,
+        "pending_epoch_at": last_epoch_block + tempo,
+        "subnet_epoch_index": epoch_id,
+        "tempo": tempo,
+        "blocks_since_last_step": 0,
+        "observed_at": "2026-07-24T23:40:00Z",
+        "epoch_id": epoch_id,
+        "epoch_ref": epoch_ref,
+        "epoch_block": 0,
+        "next_epoch_block": last_epoch_block + tempo,
+        "blocks_remaining": tempo,
+        "settlement_epoch_id": epoch_id,
+        "cutover_mapping_hash": cutover_mapping_hash,
+    }
+    authority = {
+        **boundary,
+        "block_hash": "0x" + sha256_json(
+            {"kind": "gateway-measured-current", "block": current_block}
+        )[7:],
+        "current_block": current_block,
+        "blocks_since_last_step": epoch_block,
+        "observed_at": NOW,
+        "epoch_block": epoch_block,
+        "blocks_remaining": tempo - epoch_block,
+    }
+    lineage_id = derive_ancestry_lineage_id_v2(
+        cutover_mapping_hash=cutover_mapping_hash,
+        network_genesis_hash=GENESIS_HASH,
+        netuid=netuid,
+    )
+    return authority, boundary, lineage_id
+
+
+class _GatewayMeasuredChainSourceV2:
+    """Strict byte-derived local boundary for the finalized chain read."""
+
+    def __init__(
+        self,
+        *,
+        fixture: SanitizedWeightFixture,
+        calculation_snapshot: Mapping[str, Any],
+        epoch_authority: Mapping[str, Any],
+        epoch_boundary: Mapping[str, Any],
+    ) -> None:
+        self._fixture = fixture
+        self._calculation = dict(calculation_snapshot)
+        self._epoch_authority = dict(epoch_authority)
+        self._epoch_boundary = dict(epoch_boundary)
+
+    def _attempt(
+        self,
+        *,
+        job_id: str,
+        purpose: str,
+        operation: str,
+        response: Mapping[str, Any],
+    ) -> tuple[dict[str, Any], list[dict[str, str]]]:
+        request_body = canonical_json(
+            {
+                "operation": operation,
+                "netuid": self._calculation["netuid"],
+                "epoch_id": self._calculation["epoch_id"],
+            }
+        ).encode("utf-8")
+        response_body = canonical_json(response).encode("utf-8")
+        request_hash = sha256_bytes(request_body)
+        response_hash = sha256_bytes(response_body)
+        attempt = build_transport_attempt(
+            request_id=sha256_json(
+                {"job_id": job_id, "operation": operation}
+            )[7:39],
+            logical_operation_id="gateway-measured-chain:%s:%s"
+            % (job_id, operation),
+            job_id=job_id,
+            purpose=purpose,
+            provider_id="bittensor_chain",
+            attempt_number=0,
+            method="POST",
+            destination_host="entrypoint-finney.opentensor.ai",
+            destination_port=443,
+            path_hash=sha256_json({"path": "/"}),
+            nonsecret_headers_hash=sha256_json({"accept": "application/json"}),
+            body_hash=request_hash,
+            credential_ref_hash=sha256_json({"credential": "none"}),
+            retry_policy_hash=sha256_json({"retry": "gateway-measured-chain"}),
+            timeout_ms=30000,
+            started_at=NOW,
+            terminal_status="authenticated_response",
+            http_status=200,
+            response_hash=response_hash,
+            request_artifact_hash=request_hash,
+            response_artifact_hash=response_hash,
+            tls_peer_chain_hash=sha256_json({"tls": "bittensor-chain"}),
+            tls_protocol="TLSv1.3",
+            failure_code=None,
+            completed_at=NOW,
+        )
+        return attempt, [
+            {
+                "artifact_hash": request_hash,
+                "kind": "chain_rpc_request",
+                "body_b64": base64.b64encode(request_body).decode("ascii"),
+            },
+            {
+                "artifact_hash": response_hash,
+                "kind": "chain_rpc_response",
+                "body_b64": base64.b64encode(response_body).decode("ascii"),
+            },
+        ]
+
+    def read_finalized_snapshot(
+        self, *, netuid: int, epoch_id: int
+    ) -> dict[str, Any]:
+        if (
+            netuid != int(self._calculation["netuid"])
+            or epoch_id != int(self._calculation["epoch_id"])
+        ):
+            raise RuntimeError("gateway measured chain request scope differs")
+        block = int(self._calculation["block"])
+        header = {
+            "block": block,
+            "state_root": sha256_json({"kind": "state-root", "block": block})[
+                7:
+            ],
+            "state_root_commitment": sha256_json(
+                {"kind": "state-root-commitment", "block": block}
+            ),
+            "parent_hash": sha256_json({"kind": "parent", "block": block})[7:],
+            "extrinsics_root": sha256_json(
+                {"kind": "extrinsics", "block": block}
+            )[7:],
+        }
+        metagraph = {
+            "netuid": netuid,
+            "block": block,
+            "owner_hotkey": self._calculation["expected_burn_target_hotkey"],
+            "hotkeys": list(self._calculation["metagraph_hotkeys"]),
+        }
+        jobs = {
+            "chain_state": "gateway-measured-chain-state:%d" % epoch_id,
+            "metagraph_state": "gateway-measured-metagraph-state:%d" % epoch_id,
+            "subnet_epoch_snapshot": "gateway-measured-epoch-current:%d"
+            % epoch_id,
+            "subnet_epoch_boundary": "gateway-measured-epoch-boundary:%d"
+            % epoch_id,
+        }
+        specifications = (
+            (
+                jobs["chain_state"],
+                "validator.chain_state.v2",
+                "chain-state",
+                header,
+            ),
+            (
+                jobs["metagraph_state"],
+                "validator.metagraph_state.v2",
+                "metagraph-state",
+                metagraph,
+            ),
+            (
+                jobs["subnet_epoch_boundary"],
+                "validator.subnet_epoch_snapshot.v2",
+                "epoch-boundary",
+                self._epoch_boundary,
+            ),
+            (
+                jobs["subnet_epoch_snapshot"],
+                "validator.subnet_epoch_snapshot.v2",
+                "epoch-current",
+                self._epoch_authority,
+            ),
+        )
+        attempts: list[dict[str, Any]] = []
+        artifacts: list[dict[str, str]] = []
+        for job_id, purpose, operation, response in specifications:
+            attempt, scoped_artifacts = self._attempt(
+                job_id=job_id,
+                purpose=purpose,
+                operation=operation,
+                response=response,
+            )
+            attempts.append(attempt)
+            artifacts.extend(scoped_artifacts)
+        return {
+            "finalized_block_hash": sha256_json(
+                {"kind": "finalized", "block": block}
+            )[7:],
+            "header": header,
+            "metagraph": metagraph,
+            "attempts": attempts,
+            "artifacts": artifacts,
+            "jobs": jobs,
+            "epoch_authority": dict(self._epoch_authority),
+            "epoch_boundary": dict(self._epoch_boundary),
+        }
+
+
+class _GatewayMeasuredDrandV2:
+    """Sanitized drand boundary retained for the production hotkey facade."""
+
+    def generate_commit(self, **kwargs: Any) -> tuple[bytes, int]:
+        return canonical_json(
+            {"kind": "gateway-measured-drand", "request": kwargs}
+        ).encode("utf-8"), 998877
+
+
+class _GatewayMeasuredHotkeyClientV2:
+    """Expose only the real application-signature API consumed by the host."""
+
+    def __init__(self, authority: ValidatorHotkeyAuthorityV2) -> None:
+        self._authority = authority
+
+    def sign_application_message_v2(self, message: bytes) -> dict[str, Any]:
+        return self._authority.sign_application_message(message_hex=message.hex())
+
+
+def _gateway_measured_release_lineage_v2(
+    *boots: Mapping[str, Any],
+) -> dict[str, Any]:
+    roles: dict[str, dict[str, str]] = {}
+    commit_sha = None
+    for boot_value in boots:
+        boot = dict(boot_value)
+        candidate = str(boot["commit_sha"])
+        if commit_sha is None:
+            commit_sha = candidate
+        elif commit_sha != candidate:
+            raise RuntimeError("gateway measured release lineage commit differs")
+        role = str(boot["physical_role"])
+        expectation = {
+            "commit_sha": candidate,
+            "build_manifest_hash": str(boot["build_manifest_hash"]),
+            "dependency_lock_hash": str(boot["dependency_lock_hash"]),
+            "pcr0": str(boot["pcr0"]),
+        }
+        previous = roles.get(role)
+        if previous is not None and previous != expectation:
+            raise RuntimeError("gateway measured release role differs")
+        roles[role] = expectation
+    if commit_sha is None:
+        raise RuntimeError("gateway measured release lineage is empty")
+    return {commit_sha: {"roles": roles}}
+
+
+def _gateway_measured_hotkey_authority_v2(
+    *,
+    fixture: SanitizedWeightFixture,
+    calculation_snapshot: Mapping[str, Any],
+    chain_source: _GatewayMeasuredChainSourceV2,
+) -> tuple[ValidatorHotkeyAuthorityV2, str, dict[str, Any], _Sr25519Backend]:
+    validator_boot = fixture._boot(
+        role="validator_weights",
+        key=fixture.weight_key,
+        config_hash=sha256_json(
+            {
+                "kind": "gateway-measured-validator",
+                "calculation_snapshot_hash": sha256_json(calculation_snapshot),
+            }
+        ),
+        boot_nonce_context="gateway-measured-validator",
+    )
+    sr25519 = _Sr25519Backend()
+    seed = hashlib.sha256(
+        b"gateway-measured-hotkey:" + fixture.candidate_sha.encode("ascii")
+    ).digest()
+    hotkey_public_key, _secret = sr25519.pair_from_seed(seed)
+    validator_hotkey = ss58_encode_account_id(hotkey_public_key)
+
+    def attest(*, user_data: bytes, public_key: bytes) -> bytes:
+        if not user_data or not public_key:
+            raise RuntimeError("gateway measured hotkey attestation input is empty")
+        return canonical_json(
+            {
+                "kind": "gateway-measured-hotkey-attestation",
+                "user_data_hash": sha256_bytes(user_data),
+                "recipient_public_key_hash": sha256_bytes(public_key),
+            }
+        ).encode("utf-8")
+
+    authority = ValidatorHotkeyAuthorityV2(
+        boot_identity_supplier=lambda: validator_boot,
+        validator_hotkey=validator_hotkey,
+        hotkey_public_key_hex=hotkey_public_key.hex(),
+        chain_profile=fixture.chain_profile(),
+        sign_receipt_digest=fixture.weight_key.sign,
+        attestation_supplier=attest,
+        drand_backend=_GatewayMeasuredDrandV2(),
+        chain_source=chain_source,
+        sr25519_backend=sr25519,
+        clock=lambda: datetime.fromisoformat(NOW.replace("Z", "+00:00")),
+    )
+    request = authority.recipient_request()
+    recipient_public_key = serialization.load_der_public_key(
+        base64.b64decode(request["recipient_public_key_der_b64"])
+    )
+    ciphertext = recipient_public_key.encrypt(
+        seed,
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    authority.provision_seed(
+        ciphertext_for_recipient_b64=base64.b64encode(ciphertext).decode("ascii")
+    )
+    return authority, validator_hotkey, validator_boot, sr25519
+
+
+class _GatewayMeasuredCoordinatorAdapterV2:
+    """Strict local boundary around the production coordinator execution path."""
+
+    def __init__(
+        self,
+        *,
+        fixture: SanitizedWeightFixture,
+        source_fixture: Mapping[str, Any],
+        ancestry_lineage_id: str,
+    ) -> None:
+        self._fixture = fixture
+        self._rows = dict(source_fixture["rows"])
+        self._job_number = 0
+        self.lineage_id = str(ancestry_lineage_id)
+        self._boot = fixture._boot(
+            role="gateway_coordinator",
+            key=fixture.coordinator_key,
+            config_hash=sha256_json({"kind": "gateway-measured"}),
+            boot_nonce_context="gateway-measured",
+        )
+        reader = SupabaseSourceReaderV2(
+            execute_provider=self._read_supabase,
+            retry_policy_hash=sha256_json({"retry": "gateway-measured"}),
+            sleep=lambda _seconds: None,
+        )
+        source = CoordinatorWeightSourceV2(reader)
+
+        def resolve_weight_source(payload: Any, context: Any) -> dict[str, Any]:
+            try:
+                return source.resolve(payload=payload, context=context)
+            except Exception as exc:
+                self._source_failure = "%s: %s" % (
+                    type(exc).__name__,
+                    str(exc),
+                )
+                raise
+
+        self._source_failure: str | None = None
+        executor = CoordinatorExecutorV2(
+            weight_source_resolver=resolve_weight_source,
+            artifact_evidence_supplier=self._artifact_evidence,
+        )
+        self._manager = ExecutionJobManagerV2(
+            boot_identity_supplier=lambda: self._boot,
+            sign_digest=fixture.coordinator_key.sign,
+            operations=COORDINATOR_OPERATIONS_V2,
+            executor=executor,
+            worker_count=1,
+            configured_worker_count=0,
+            failed_parent_graph_policy=coordinator_failed_parent_graph_policy_v2,
+            ancestry_lineage_id=self.lineage_id,
+            ancestry_boot_attestation_verifier=_verify_gateway_measured_boot_v2,
+            ancestry_allowed_issuer_roles=(
+                "gateway_coordinator",
+                "validator_weights",
+            ),
+        )
+
+    @property
+    def boot_identity(self) -> dict[str, Any]:
+        return dict(self._boot)
+
+    def _read_supabase(self, request: Mapping[str, Any]) -> dict[str, Any]:
+        parsed = urlparse(str(request["url"]))
+        logical_operation_id = str(request["logical_operation_id"])
+        parts = logical_operation_id.split(":")
+        if (
+            len(parts) != 5
+            or parts[0] != str(request["job_id"])
+            or parts[2] != "sha256"
+            or len(parts[3]) != 64
+            or not parts[4].startswith("page-")
+            or not parts[4][5:].isdigit()
+        ):
+            raise RuntimeError("sanitized Supabase logical operation is invalid")
+        policy_id = parts[1]
+        policy = QUERY_POLICIES.get(policy_id)
+        if (
+            policy is None
+            or policy.table != parsed.path.rsplit("/", 1)[-1]
+            or int(parts[4][5:]) >= policy.max_pages
+        ):
+            raise RuntimeError("sanitized Supabase policy is not declared")
+        rows = list(self._rows.get(policy_id, ()))
+        if policy_id == "attested_receipt_by_hash":
+            expected = parse_qs(parsed.query).get("receipt_hash", [""])[0]
+            rows = [
+                row for row in rows
+                if row["receipt_doc"]["receipt_hash"] == expected.removeprefix("eq.")
+            ]
+        body = canonical_json(rows).encode("utf-8")
+        request_id = sha256_json(
+            {"operation": request["logical_operation_id"], "attempt": request["attempt_number"]}
+        )[7:39]
+        attempt = build_transport_attempt(
+            request_id=request_id,
+            logical_operation_id=str(request["logical_operation_id"]),
+            job_id=str(request["job_id"]),
+            purpose=str(request["purpose"]),
+            provider_id="supabase",
+            attempt_number=int(request["attempt_number"]),
+            method="GET",
+            destination_host="qplwoislplkcegvdmbim.supabase.co",
+            destination_port=443,
+            path_hash=sha256_json({"path": parsed.path}),
+            nonsecret_headers_hash=sha256_json({"accept": "application/json"}),
+            body_hash=sha256_bytes(base64.b64decode(str(request["body_b64"]))),
+            credential_ref_hash=sha256_json({"credential": "supabase"}),
+            retry_policy_hash=str(request["retry_policy_hash"]),
+            timeout_ms=int(request["timeout_ms"]),
+            started_at=NOW,
+            terminal_status="authenticated_response",
+            http_status=200,
+            response_hash=sha256_bytes(body),
+            request_artifact_hash=sha256_json({"request": request_id}),
+            response_artifact_hash=sha256_bytes(body),
+            tls_peer_chain_hash=sha256_json({"tls": "supabase"}),
+            tls_protocol="TLSv1.3",
+            failure_code=None,
+            completed_at=NOW,
+        )
+        return {
+            "terminal_status": "authenticated_response",
+            "http_status": 200,
+            "body_b64": base64.b64encode(body).decode("ascii"),
+            "transport_attempt": attempt,
+        }
+
+    def _artifact_evidence(self, artifact_ids: Any, context: Any) -> list[dict[str, Any]]:
+        evidence = []
+        for ordinal, artifact_id in enumerate(sorted(set(artifact_ids))):
+            attempts = [
+                build_transport_attempt(
+                    request_id="%032x" % (self._job_number * 100 + ordinal * 2 + offset),
+                    logical_operation_id=f"{artifact_id}:{method.lower()}",
+                    job_id=context.job_id,
+                    purpose="leadpoet.artifact_persistence.v2",
+                    provider_id="aws_s3_object_lock",
+                    attempt_number=offset,
+                    method=method,
+                    destination_host="immutable.example.s3.us-east-1.amazonaws.com",
+                    destination_port=443,
+                    path_hash=sha256_json({"artifact_id": artifact_id}),
+                    nonsecret_headers_hash=sha256_json({"accept": "application/json"}),
+                    body_hash=sha256_bytes(b""),
+                    credential_ref_hash=sha256_json({"credential": "object-lock"}),
+                    retry_policy_hash=sha256_json({"retry": "object-lock"}),
+                    timeout_ms=30000,
+                    started_at=NOW,
+                    terminal_status="authenticated_response",
+                    http_status=200,
+                    response_hash=sha256_json({"artifact_id": artifact_id, "method": method}),
+                    request_artifact_hash=sha256_json({"artifact_id": artifact_id, "request": method}),
+                    response_artifact_hash=sha256_json({"artifact_id": artifact_id, "response": method}),
+                    tls_peer_chain_hash=sha256_json({"tls": "object-lock"}),
+                    tls_protocol="TLSv1.3",
+                    failure_code=None,
+                    completed_at=NOW,
+                )
+                for offset, method in enumerate(("GET", "HEAD"))
+            ]
+            evidence.append(
+                {
+                    "artifact_id": artifact_id,
+                    "plaintext_hash": artifact_id,
+                    "ciphertext_hash": sha256_json({"ciphertext": artifact_id}),
+                    "artifact_ref": f"s3://immutable/{artifact_id[7:]}.json",
+                    "storage_document_hash": sha256_json({"storage": artifact_id}),
+                    "encryption_context_hash": sha256_json({"context": artifact_id}),
+                    "object_lock_mode": "COMPLIANCE",
+                    "retain_until": "2027-07-25T00:00:00Z",
+                    "transport_root": transport_root(attempts),
+                    "transport_attempts": attempts,
+                    "persisted": True,
+                }
+            )
+        return evidence
+
+    @staticmethod
+    def _merge_graphs(root: Mapping[str, Any], graphs: tuple[Mapping[str, Any], ...]) -> dict[str, Any]:
+        fields = {
+            "boot_identities": "boot_identity_hash",
+            "receipts": "receipt_hash",
+            "transport_attempts": "attempt_hash",
+            "host_operations": None,
+        }
+        merged = {field: {} for field in fields}
+        for graph in graphs:
+            for field, key in fields.items():
+                for item in graph.get(field, ()):
+                    identity = sha256_json(item) if key is None else str(item[key])
+                    if identity in merged[field] and merged[field][identity] != item:
+                        raise RuntimeError("gateway measured graph identity conflicts")
+                    merged[field][identity] = dict(item)
+        return build_receipt_graph(
+            root_receipt_hash=str(root["receipt_hash"]),
+            boot_identities=list(merged["boot_identities"].values()),
+            receipts=list(merged["receipts"].values()),
+            transport_attempts=list(merged["transport_attempts"].values()),
+            host_operations=list(merged["host_operations"].values()),
+        )
+
+    def _run(self, *, operation: str, purpose: str, epoch_id: int, sequence: int, payload: Mapping[str, Any], parent_graphs: tuple[Mapping[str, Any], ...] = ()) -> dict[str, Any]:
+        self._job_number += 1
+        self._source_failure = None
+        wire_payload = dict(payload)
+        if parent_graphs:
+            wire_payload[PARENT_RECEIPT_GRAPH_SET_FIELD] = pack_parent_receipt_graph_set_v2(parent_graphs)
+        encoded = canonical_json(wire_payload).encode("utf-8")
+        job_id = f"gateway-measured-{self._fixture.epoch_id}-{self._job_number}"
+        self._manager.submit(
+            {
+                "schema_version": JOB_SCHEMA_VERSION,
+                "job_id": job_id,
+                "operation": operation,
+                "purpose": purpose,
+                "epoch_id": epoch_id,
+                "sequence": sequence,
+                "payload_sha256": sha256_bytes(encoded),
+                "payload_size_bytes": len(encoded),
+                "parent_receipt_hashes": [graph["root_receipt_hash"] for graph in parent_graphs],
+                "input_artifact_hashes": [],
+                "provider_credential_profile": "default",
+                "provider_credential_ref_hashes": {},
+            }
+        )
+        self._manager.put_chunk(
+            job_id=job_id,
+            offset=0,
+            data_b64=base64.b64encode(encoded).decode("ascii"),
+            chunk_sha256=sha256_bytes(encoded),
+        )
+        self._manager.seal(job_id)
+        deadline = time.monotonic() + 5.0
+        status = self._manager.status(job_id)
+        while status["state"] not in {"succeeded", "failed", "cancelled"}:
+            if time.monotonic() >= deadline:
+                raise RuntimeError("gateway measured coordinator deadline elapsed")
+            time.sleep(0.001)
+            status = self._manager.status(job_id)
+        if status["state"] != "succeeded":
+            raise RuntimeError(
+                "gateway measured coordinator failed: %s%s"
+                % (
+                    canonical_json(status),
+                    (
+                        "; sanitized source failure: %s"
+                        % self._source_failure
+                        if self._source_failure
+                        else ""
+                    ),
+                )
+            )
+        part = self._manager.result_chunk(job_id=job_id)
+        result_bytes = base64.b64decode(part["data_b64"])
+        if not part["eof"] or sha256_bytes(result_bytes) != part["result_sha256"]:
+            raise RuntimeError("gateway measured result transport differs")
+        receipt = self._manager.receipt(job_id)
+        local_graph = {
+            "boot_identities": [self._boot],
+            "receipts": self._manager.receipts(job_id),
+            "transport_attempts": self._manager.transport_attempts(job_id),
+            "host_operations": self._manager.host_operations(job_id),
+        }
+        proof = self._manager.ancestry_compact_proof(job_id)
+        if any("ancestry_proof" in graph for graph in parent_graphs):
+            graph = build_checkpointed_receipt_graph(
+                root_receipt_hash=str(receipt["receipt_hash"]),
+                boot_identities=local_graph["boot_identities"],
+                receipts=local_graph["receipts"],
+                transport_attempts=local_graph["transport_attempts"],
+                host_operations=local_graph["host_operations"],
+                ancestry_lineage_id=self.lineage_id,
+                ancestry_proof=proof,
+                boot_attestation_verifier=_verify_gateway_measured_boot_v2,
+                require_boot_attestation_verification=True,
+            )
+        else:
+            graph = self._merge_graphs(receipt, parent_graphs + (local_graph,))
+        return {
+            "result": json.loads(result_bytes.decode("utf-8")),
+            "receipt": receipt,
+            "receipt_graph": graph,
+            "ancestry_compact_proof": proof,
+            "artifact_hashes": list(self._manager.artifact_hashes(job_id)),
+        }
+
+    async def execute(self, **kwargs: Any) -> dict[str, Any]:
+        direct = self._run(
+            operation=str(kwargs["operation"]),
+            purpose=str(kwargs["purpose"]),
+            epoch_id=int(kwargs["epoch_id"]),
+            sequence=int(kwargs["sequence"]),
+            payload=kwargs["payload"],
+            parent_graphs=tuple(kwargs.get("parent_graphs") or ()),
+        )
+        if kwargs["operation"] != OP_ATTEST_WEIGHT_INPUT:
+            return {"status": "succeeded", **direct, "execution_receipt": direct["receipt"]}
+        persisted = self._run(
+            operation=OP_ATTEST_ARTIFACT_PERSISTENCE,
+            purpose="leadpoet.artifact_persistence.v2",
+            epoch_id=int(kwargs["epoch_id"]),
+            sequence=10000 + int(kwargs["sequence"]),
+            payload={
+                "source_receipt_hash": direct["receipt"]["receipt_hash"],
+                "artifact_ids": direct["artifact_hashes"],
+                "artifact_plaintext_hashes": direct["artifact_hashes"],
+            },
+            parent_graphs=(direct["receipt_graph"],),
+        )
+        return {
+            "status": "succeeded",
+            "result": direct["result"],
+            "receipt": persisted["receipt"],
+            "execution_receipt": direct["receipt"],
+            "receipt_graph": self._merge_graphs(
+                persisted["receipt"], (direct["receipt_graph"], persisted["receipt_graph"])
+            ),
+            "execution_receipt_graph": direct["receipt_graph"],
+            "execution_ancestry_compact_proof": direct[
+                "ancestry_compact_proof"
+            ],
+            "ancestry_compact_proof": persisted["ancestry_compact_proof"],
+            "artifact_persistence_output": persisted["result"],
+        }
+
+    def assert_clean(self) -> None:
+        if self._manager.health()["active_job_ids"]:
+            raise RuntimeError("gateway measured coordinator retained active jobs")
+
+
+def _gateway_measured_coordinator_runtime_v2(
+    *, epoch_fixture: SanitizedWeightFixture
+) -> dict[str, Any]:
+    """Run measured inputs and retain only the real local authorities."""
+
+    source_fixture = epoch_fixture.gateway_measured_source_fixture_v2()
+    epoch_authority, epoch_boundary, lineage_id = _gateway_measured_epoch_authority_v2(
+        fixture=epoch_fixture,
+        calculation_snapshot=source_fixture["provisional"],
+    )
+    adapter = _GatewayMeasuredCoordinatorAdapterV2(
+        fixture=epoch_fixture,
+        source_fixture=source_fixture,
+        ancestry_lineage_id=lineage_id,
+    )
+
+    async def load_sourcing_graphs(*, current_epoch: int) -> list[dict[str, Any]]:
+        if current_epoch != epoch_fixture.epoch_id:
+            raise RuntimeError("gateway measured sourcing epoch scope differs")
+        return list(source_fixture["sourcing_graphs"])
+
+    async def build() -> dict[str, Any]:
+        return await build_gateway_weight_inputs_v2(
+            calculation_snapshot=source_fixture["provisional"],
+            allocation_graph=source_fixture["allocation_graph"],
+            leaderboard_window_start="2026-07-24T00:00:00Z",
+            leaderboard_window_end=NOW,
+            execute=adapter.execute,
+            load_sourcing_graphs=load_sourcing_graphs,
+            coordinator_client_factory=lambda: object(),
+            snapshot_authority_mode=GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+        )
+
+    try:
+        result = asyncio.run(build())
+    except Exception:
+        adapter.assert_clean()
+        raise
+    authoritative = result["authoritative_calculation_snapshot"]
+    expected_categories = sorted(
+        category
+        for category, fields in GATEWAY_MEASURED_NORMALIZATION_FIELDS_V2.items()
+        if any(
+            canonical_json(source_fixture["provisional"][field])
+            != canonical_json(authoritative[field])
+            for field in fields
+        )
+    )
+    if result["normalized_source_categories"] != expected_categories:
+        raise RuntimeError("gateway measured normalization categories differ")
+    return {
+        "adapter": adapter,
+        "source_fixture": source_fixture,
+        "result": result,
+        "epoch_authority": epoch_authority,
+        "epoch_boundary": epoch_boundary,
+        "lineage_id": lineage_id,
+    }
+
+
 def _run_independent_epoch_diagnostics(
     *,
     candidate_sha: str,
     epoch_id: int,
     stages: list[dict[str, Any]],
+    authority_diagnostic_evidence: dict[str, Any],
 ) -> None:
     """Exercise independent downstream contracts before the joined epoch."""
 
@@ -1306,6 +2137,11 @@ def _run_independent_epoch_diagnostics(
         stages=stages,
     )
     dependent_stages = (
+        "diagnostic:gateway-measured-coordinator",
+        "diagnostic:gateway-measured-client-enclave",
+        "diagnostic:gateway-measured-primary-compact",
+        "diagnostic:gateway-measured-audit-compact",
+        "diagnostic:gateway-measured-immutable-tamper",
         "diagnostic:host-bundle-composition",
         "diagnostic:primary-bundle-verification",
         "diagnostic:auditor-bundle-verification",
@@ -1320,6 +2156,517 @@ def _run_independent_epoch_diagnostics(
                 stages=stages,
             )
         return
+
+    runtime: dict[str, Any] | None = None
+    pipeline: dict[str, Any] = {}
+
+    def run_gateway_measured_coordinator() -> dict[str, Any]:
+        nonlocal runtime
+        runtime = _gateway_measured_coordinator_runtime_v2(
+            epoch_fixture=epoch_fixture
+        )
+        measured = runtime["result"]
+        bans_execution = measured["executions"]["bans"]
+        bans_persistence = bans_execution["receipt"]
+        return {
+            "lineage_id": runtime["lineage_id"],
+            "provisional_calculation_snapshot_hash": sha256_json(
+                runtime["source_fixture"]["provisional"]
+            ),
+            "authoritative_calculation_snapshot_hash": measured[
+                "authoritative_calculation_snapshot_hash"
+            ],
+            "input_receipt_hashes": dict(measured["input_receipt_hashes"]),
+            "normalized_source_categories": list(
+                measured["normalized_source_categories"]
+            ),
+            "expected_normalized_source_categories": sorted(
+                category
+                for category, fields in GATEWAY_MEASURED_NORMALIZATION_FIELDS_V2.items()
+                if any(
+                    canonical_json(runtime["source_fixture"]["provisional"][field])
+                    != canonical_json(
+                        measured["authoritative_calculation_snapshot"][field]
+                    )
+                    for field in fields
+                )
+            ),
+            "bans_execution_receipt_hash": bans_execution["execution_receipt"][
+                "receipt_hash"
+            ],
+            "bans_persistence_receipt_hash": bans_persistence["receipt_hash"],
+            "bans_persistence_purpose": bans_persistence["purpose"],
+            "bans_persistence_output_root": bans_persistence["output_root"],
+            "bans_persistence_output_hash": sha256_json(
+                bans_execution["artifact_persistence_output"]
+            ),
+        }
+
+    measured_passed, measured = _run_workflow_stage(
+        stage="diagnostic:gateway-measured-coordinator",
+        action=run_gateway_measured_coordinator,
+        stages=stages,
+    )
+    if measured_passed:
+        authority_diagnostic_evidence["gateway-measured-coordinator"] = measured
+    if not measured_passed or runtime is None:
+        for stage in (
+            "diagnostic:gateway-measured-client-enclave",
+            "diagnostic:gateway-measured-primary-compact",
+            "diagnostic:gateway-measured-audit-compact",
+            "diagnostic:gateway-measured-immutable-tamper",
+        ):
+            _mark_workflow_stage_unexercised(
+                stage=stage,
+                blocked_by=["diagnostic:gateway-measured-coordinator"],
+                stages=stages,
+            )
+    else:
+        source_fixture = runtime["source_fixture"]
+        gateway_result = runtime["result"]
+
+        def gateway_response(
+            payload: Mapping[str, Any], *, immutable_tamper: bool = False
+        ) -> dict[str, Any]:
+            request = dict(payload["request"])
+            calculation = dict(payload["calculation_snapshot"])
+            if (
+                sha256_json(calculation) != request["calculation_snapshot_hash"]
+                or calculation != source_fixture["provisional"]
+            ):
+                raise RuntimeError("gateway measured request calculation differs")
+            try:
+                signature = bytes.fromhex(str(payload["validator_hotkey_signature"]))
+            except ValueError as exc:
+                raise RuntimeError("gateway measured request signature is invalid") from exc
+            if not pipeline["sr25519"].verify(
+                signature,
+                weight_inputs_request_message_v2(request).encode("utf-8"),
+                pipeline["hotkey_authority"].hotkey_public_key,
+            ):
+                raise RuntimeError("gateway measured request signature differs")
+            reply = {
+                "request_hash": request["request_hash"],
+                "calculation_snapshot_hash": request["calculation_snapshot_hash"],
+                "input_receipt_hashes": dict(
+                    gateway_result["input_receipt_hashes"]
+                ),
+                "gateway_authority_event_hash": gateway_result[
+                    "gateway_authority_event_hash"
+                ],
+                "upstream_ancestry_proofs": dict(
+                    gateway_result["compact_ancestry"]["upstream_ancestry_proofs"]
+                ),
+                "upstream_transport_attempts": list(
+                    gateway_result["compact_ancestry"]["upstream_transport_attempts"]
+                ),
+                "snapshot_authority_mode": gateway_result[
+                    "snapshot_authority_mode"
+                ],
+                "authoritative_calculation_snapshot": dict(
+                    gateway_result["authoritative_calculation_snapshot"]
+                ),
+                "authoritative_calculation_snapshot_hash": gateway_result[
+                    "authoritative_calculation_snapshot_hash"
+                ],
+                "normalized_source_categories": list(
+                    gateway_result["normalized_source_categories"]
+                ),
+            }
+            if immutable_tamper:
+                authoritative = dict(reply["authoritative_calculation_snapshot"])
+                authoritative["burn_target_uid"] = (
+                    int(authoritative["burn_target_uid"]) + 1
+                )
+                reply["authoritative_calculation_snapshot"] = authoritative
+                reply["authoritative_calculation_snapshot_hash"] = sha256_json(
+                    authoritative
+                )
+            return reply
+
+        def run_gateway_measured_client_enclave() -> dict[str, Any]:
+            calculation = gateway_result["authoritative_calculation_snapshot"]
+            chain_source = _GatewayMeasuredChainSourceV2(
+                fixture=epoch_fixture,
+                calculation_snapshot=calculation,
+                epoch_authority=runtime["epoch_authority"],
+                epoch_boundary=runtime["epoch_boundary"],
+            )
+            hotkey_authority, validator_hotkey, validator_boot, sr25519 = (
+                _gateway_measured_hotkey_authority_v2(
+                    fixture=epoch_fixture,
+                    calculation_snapshot=calculation,
+                    chain_source=chain_source,
+                )
+            )
+            release_lineage = _gateway_measured_release_lineage_v2(
+                *gateway_result["upstream_receipt_set"]["boot_identities"],
+                runtime["adapter"].boot_identity,
+                validator_boot,
+            )
+            validator_authority = ValidatorWeightAuthorityV2(
+                boot_identity_supplier=lambda: validator_boot,
+                gateway_release_lineage_supplier=lambda: release_lineage,
+                sign_digest=epoch_fixture.weight_key.sign,
+                chain_source=chain_source,
+                boot_verifier=_verify_gateway_measured_boot_v2,
+                clock=lambda: datetime.fromisoformat(NOW.replace("Z", "+00:00")),
+            )
+            # The local gateway verifies this real request signature before
+            # ``fetch_gateway_weight_inputs_v2`` returns.
+            pipeline.update(
+                {
+                    "hotkey_authority": hotkey_authority,
+                    "sr25519": sr25519,
+                }
+            )
+
+            async def post_json(
+                endpoint: str, payload: Mapping[str, Any], timeout_seconds: float
+            ) -> dict[str, Any]:
+                if not endpoint.endswith("/weights/inputs/v2?ancestry=compact-v2"):
+                    raise RuntimeError("gateway measured endpoint differs")
+                if timeout_seconds <= 0:
+                    raise RuntimeError("gateway measured timeout is invalid")
+                return gateway_response(payload)
+
+            fetched = asyncio.run(
+                fetch_gateway_weight_inputs_v2(
+                    gateway_url="https://gateway.sanitized",
+                    calculation_snapshot=source_fixture["provisional"],
+                    validator_hotkey=validator_hotkey,
+                    allocation_hash=source_fixture["allocation_graph"][
+                        "root_receipt_hash"
+                    ],
+                    leaderboard_window_start="2026-07-24T00:00:00Z",
+                    leaderboard_window_end=NOW,
+                    client=_GatewayMeasuredHotkeyClientV2(hotkey_authority),
+                    post_json=post_json,
+                    max_attempts=1,
+                    snapshot_authority_mode=(
+                        GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+                    ),
+                )
+            )
+            request_fields = (
+                "input_receipt_hashes",
+                "gateway_authority_event_hash",
+                "upstream_ancestry_proofs",
+                "upstream_transport_attempts",
+                "snapshot_authority_mode",
+                "authoritative_calculation_snapshot",
+                "authoritative_calculation_snapshot_hash",
+                "normalized_source_categories",
+            )
+            enclave_response = validator_authority.compute(
+                {
+                    "validator_hotkey": validator_hotkey,
+                    "calculation_snapshot": source_fixture["provisional"],
+                    **{field: fetched[field] for field in request_fields},
+                }
+            )
+            observed_lineage = derive_ancestry_lineage_id_v2(
+                cutover_mapping_hash=enclave_response["epoch_authority"]["cutover_mapping_hash"],
+                network_genesis_hash=enclave_response["epoch_authority"]["network_genesis_hash"],
+                netuid=int(enclave_response["epoch_authority"]["netuid"]),
+            )
+            if observed_lineage != runtime["lineage_id"]:
+                raise RuntimeError("gateway measured validator lineage differs")
+            enclave_response["weight_authorization_id"] = (
+                hotkey_authority.register_weight_result(
+                    {
+                        field: enclave_response[field]
+                        for field in (
+                            "weight_snapshot",
+                            "weight_result",
+                            "weights_signature",
+                            "receipt_graph_delta",
+                            "ancestry_commitment",
+                            "boot_identity",
+                        )
+                    }
+                )
+            )
+            pipeline.update(
+                {
+                    "chain_source": chain_source,
+                    "enclave_response": enclave_response,
+                    "fetched": fetched,
+                    "hotkey_authority": hotkey_authority,
+                    "sr25519": sr25519,
+                    "validator_authority": validator_authority,
+                    "validator_boot": validator_boot,
+                    "validator_hotkey": validator_hotkey,
+                }
+            )
+            return {
+                "lineage_id": observed_lineage,
+                "request_hash": fetched["request_authorization"]["request_hash"],
+                "request_receipt_hash": fetched["request_authorization"]["receipt"][
+                    "receipt_hash"
+                ],
+                "weight_authorization_id": enclave_response[
+                    "weight_authorization_id"
+                ],
+                "weight_receipt_hash": enclave_response["receipt_graph_delta"][
+                    "root_receipt_hash"
+                ],
+            }
+
+        def run_gateway_measured_primary_compact() -> dict[str, Any]:
+            enclave_response = pipeline["enclave_response"]
+            boot = enclave_response["boot_identity"]
+            binding_message = create_binding_message(
+                netuid=int(enclave_response["weight_result"]["netuid"]),
+                chain=epoch_fixture.chain_profile()["chain_endpoint"],
+                enclave_pubkey=boot["signing_pubkey"],
+                validator_code_hash=boot["build_manifest_hash"],
+                version=boot["commit_sha"],
+            )
+            binding_signature = pipeline["hotkey_authority"].sign_application_message(
+                message_hex=binding_message.encode("utf-8").hex(),
+                parent_receipt_hash=enclave_response["receipt_graph_delta"][
+                    "root_receipt_hash"
+                ],
+            )
+            validator_proof = pipeline[
+                "validator_authority"
+            ].issue_validator_publication_ancestry_proof(
+                validator_receipt_delta=enclave_response["receipt_graph_delta"],
+                upstream_ancestry_proofs=enclave_response[
+                    "upstream_ancestry_proofs"
+                ],
+                binding_receipt=binding_signature["receipt"],
+                epoch_authority=enclave_response["epoch_authority"],
+            )
+            compact = build_compact_weight_submission_v2(
+                enclave_response=enclave_response,
+                validator_hotkey=pipeline["validator_hotkey"],
+                binding_message=binding_message,
+                binding_signature_result={
+                    **binding_signature,
+                    "validator_ancestry_proof": validator_proof,
+                },
+            )
+            primary = verify_compact_weight_submission_v2(
+                compact,
+                expected_lineage_id=runtime["lineage_id"],
+                expected_chain=epoch_fixture.chain_profile()["chain_endpoint"],
+                identity_cache=epoch_fixture.identity_cache(bundle),
+                boot_verifier=_verify_gateway_measured_boot_v2,
+            )
+            pipeline.update(
+                {
+                    "binding_signature": binding_signature,
+                    "compact": compact,
+                    "primary": primary,
+                    "validator_proof": validator_proof,
+                }
+            )
+            return {
+                "binding_receipt_hash": binding_signature["receipt"]["receipt_hash"],
+                "compact_submission_hash": primary["compact_submission_hash"],
+                "bundle_hash": primary["bundle_hash"],
+                "validator_ancestry_proof_hash": validator_proof["proof_hash"],
+                "weight_receipt_hash": primary["weight_receipt_hash"],
+            }
+
+        def run_gateway_measured_audit_compact() -> dict[str, Any]:
+            compact = pipeline["compact"]
+            primary = pipeline["primary"]
+            validator_parent_graph = build_checkpointed_weight_graph_from_compact_v2(
+                compact,
+                expected_lineage_id=runtime["lineage_id"],
+                boot_attestation_verifier=_verify_gateway_measured_boot_v2,
+            )
+            durable_readback_hash = sha256_json(
+                {
+                    "bundle_hash": primary["bundle_hash"],
+                    "compact_submission_hash": primary["compact_submission_hash"],
+                    "kind": "gateway-measured-durable-readback",
+                }
+            )
+            transparency_event_hash = sha256_json(
+                {
+                    "bundle_hash": primary["bundle_hash"],
+                    "root_receipt_hash": primary["root_receipt_hash"],
+                    "kind": "gateway-measured-transparency-event",
+                }
+            )
+            publication = asyncio.run(
+                runtime["adapter"].execute(
+                    operation=OP_ATTEST_WEIGHT_PUBLICATION,
+                    purpose="gateway.weights.publication.v2",
+                    epoch_id=epoch_id,
+                    sequence=50_000,
+                    payload={
+                        "bundle_hash": primary["bundle_hash"],
+                        "root_receipt_hash": primary["root_receipt_hash"],
+                        "durable_readback_hash": durable_readback_hash,
+                        "transparency_event_hash": transparency_event_hash,
+                    },
+                    parent_graphs=(validator_parent_graph,),
+                )
+            )
+            publication_doc = dict(publication["result"])
+            publication_receipt = publication["receipt"]
+            weight_submission_event_hash = sha256_json(
+                {
+                    "bundle_hash": primary["bundle_hash"],
+                    "publication_receipt_hash": publication_receipt["receipt_hash"],
+                    "transparency_event_hash": transparency_event_hash,
+                    "durable_readback_hash": durable_readback_hash,
+                }
+            )
+            public_authority = build_compact_published_weight_authority_v2(
+                authority_stage="published",
+                lineage_id=runtime["lineage_id"],
+                bundle_hash=primary["bundle_hash"],
+                compact_submission=compact,
+                publication={
+                    "weight_submission_event_hash": weight_submission_event_hash,
+                    "publication_receipt_hash": publication_receipt["receipt_hash"],
+                    "publication_doc": publication_doc,
+                    "ancestry_proof": publication["ancestry_compact_proof"],
+                },
+                finalization=None,
+            )
+            audit = verify_compact_published_weight_authority_v2(
+                public_authority,
+                identity_cache=epoch_fixture.identity_cache(bundle),
+                chain_signing_profile=None,
+                expected_lineage_id=runtime["lineage_id"],
+                expected_chain=epoch_fixture.chain_profile()["chain_endpoint"],
+                boot_verifier=_verify_gateway_measured_boot_v2,
+            )
+            pipeline.update(
+                {
+                    "publication": publication,
+                    "public_authority": public_authority,
+                    "audit": audit,
+                }
+            )
+            return {
+                "authority_hash": audit["authority_hash"],
+                "publication_receipt_hash": publication_receipt["receipt_hash"],
+                "weight_submission_event_hash": audit[
+                    "weight_submission_event_hash"
+                ],
+                "bundle_hash": audit["bundle_hash"],
+            }
+
+        def run_gateway_measured_immutable_tamper() -> dict[str, Any]:
+            async def tampered_post_json(
+                _endpoint: str, payload: Mapping[str, Any], _timeout: float
+            ) -> dict[str, Any]:
+                return gateway_response(payload, immutable_tamper=True)
+
+            try:
+                asyncio.run(
+                    fetch_gateway_weight_inputs_v2(
+                        gateway_url="https://gateway.sanitized",
+                        calculation_snapshot=source_fixture["provisional"],
+                        validator_hotkey=pipeline["validator_hotkey"],
+                        allocation_hash=source_fixture["allocation_graph"][
+                            "root_receipt_hash"
+                        ],
+                        leaderboard_window_start="2026-07-24T00:00:00Z",
+                        leaderboard_window_end=NOW,
+                        client=_GatewayMeasuredHotkeyClientV2(
+                            pipeline["hotkey_authority"]
+                        ),
+                        post_json=tampered_post_json,
+                        max_attempts=1,
+                        snapshot_authority_mode=(
+                            GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+                        ),
+                    )
+                )
+            except GatewayWeightInputsV2Error as exc:
+                return {
+                    "exception_type": type(exc).__name__,
+                    "exception_message_hash": sha256_bytes(
+                        str(exc).encode("utf-8")
+                    ),
+                }
+            raise RuntimeError("gateway measured immutable tamper was accepted")
+
+        try:
+            client_passed, client_evidence = _run_workflow_stage(
+                stage="diagnostic:gateway-measured-client-enclave",
+                action=run_gateway_measured_client_enclave,
+                stages=stages,
+            )
+            if client_passed:
+                authority_diagnostic_evidence[
+                    "gateway-measured-client-enclave"
+                ] = client_evidence
+                primary_compact_passed, primary_compact_evidence = (
+                    _run_workflow_stage(
+                        stage="diagnostic:gateway-measured-primary-compact",
+                        action=run_gateway_measured_primary_compact,
+                        stages=stages,
+                    )
+                )
+                if primary_compact_passed:
+                    authority_diagnostic_evidence[
+                        "gateway-measured-primary-compact"
+                    ] = primary_compact_evidence
+                    audit_compact_passed, audit_compact_evidence = (
+                        _run_workflow_stage(
+                            stage="diagnostic:gateway-measured-audit-compact",
+                            action=run_gateway_measured_audit_compact,
+                            stages=stages,
+                        )
+                    )
+                    if audit_compact_passed:
+                        authority_diagnostic_evidence[
+                            "gateway-measured-audit-compact"
+                        ] = audit_compact_evidence
+                        tamper_passed, tamper_evidence = _run_workflow_stage(
+                            stage="diagnostic:gateway-measured-immutable-tamper",
+                            action=run_gateway_measured_immutable_tamper,
+                            stages=stages,
+                        )
+                        if tamper_passed:
+                            authority_diagnostic_evidence[
+                                "gateway-measured-immutable-tamper"
+                            ] = tamper_evidence
+                    else:
+                        _mark_workflow_stage_unexercised(
+                            stage="diagnostic:gateway-measured-immutable-tamper",
+                            blocked_by=[
+                                "diagnostic:gateway-measured-audit-compact"
+                            ],
+                            stages=stages,
+                        )
+                else:
+                    for stage in (
+                        "diagnostic:gateway-measured-audit-compact",
+                        "diagnostic:gateway-measured-immutable-tamper",
+                    ):
+                        _mark_workflow_stage_unexercised(
+                            stage=stage,
+                            blocked_by=[
+                                "diagnostic:gateway-measured-primary-compact"
+                            ],
+                            stages=stages,
+                        )
+            else:
+                for stage in (
+                    "diagnostic:gateway-measured-primary-compact",
+                    "diagnostic:gateway-measured-audit-compact",
+                    "diagnostic:gateway-measured-immutable-tamper",
+                ):
+                    _mark_workflow_stage_unexercised(
+                        stage=stage,
+                        blocked_by=[
+                            "diagnostic:gateway-measured-client-enclave"
+                        ],
+                        stages=stages,
+                    )
+        finally:
+            runtime["adapter"].assert_clean()
 
     _run_workflow_stage(
         stage="diagnostic:host-bundle-composition",
@@ -4710,10 +6057,12 @@ def main() -> int:
         if passed:
             behavior_evidence[scenario] = result
 
+    authority_diagnostic_evidence: dict[str, Any] = {}
     _run_independent_epoch_diagnostics(
         candidate_sha=args.candidate_sha,
         epoch_id=30_000,
         stages=stages,
+        authority_diagnostic_evidence=authority_diagnostic_evidence,
     )
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
@@ -5232,6 +6581,63 @@ def main() -> int:
                 for epoch in epochs
             )
         ),
+        "gateway_measured_authority_exact": (
+            set(
+                authority_diagnostic_evidence.get(
+                    "gateway-measured-coordinator", {}
+                ).get("input_receipt_hashes", {})
+            )
+            == set(GATEWAY_WEIGHT_INPUT_CATEGORIES)
+            and authority_diagnostic_evidence.get(
+                "gateway-measured-coordinator", {}
+            ).get("provisional_calculation_snapshot_hash")
+            != authority_diagnostic_evidence.get(
+                "gateway-measured-coordinator", {}
+            ).get("authoritative_calculation_snapshot_hash")
+            and authority_diagnostic_evidence.get(
+                "gateway-measured-coordinator", {}
+            ).get("normalized_source_categories")
+            == authority_diagnostic_evidence.get(
+                "gateway-measured-coordinator", {}
+            ).get("expected_normalized_source_categories")
+            and authority_diagnostic_evidence.get(
+                "gateway-measured-coordinator", {}
+            ).get("bans_persistence_purpose")
+            == "leadpoet.artifact_persistence.v2"
+            and authority_diagnostic_evidence.get(
+                "gateway-measured-coordinator", {}
+            ).get("bans_persistence_output_root")
+            == authority_diagnostic_evidence.get(
+                "gateway-measured-coordinator", {}
+            ).get("bans_persistence_output_hash")
+            and authority_diagnostic_evidence.get(
+                "gateway-measured-client-enclave", {}
+            ).get("lineage_id")
+            == authority_diagnostic_evidence.get(
+                "gateway-measured-coordinator", {}
+            ).get("lineage_id")
+            and authority_diagnostic_evidence.get(
+                "gateway-measured-client-enclave", {}
+            ).get("weight_receipt_hash")
+            == authority_diagnostic_evidence.get(
+                "gateway-measured-primary-compact", {}
+            ).get("weight_receipt_hash")
+            and authority_diagnostic_evidence.get(
+                "gateway-measured-primary-compact", {}
+            ).get("bundle_hash")
+            == authority_diagnostic_evidence.get(
+                "gateway-measured-audit-compact", {}
+            ).get("bundle_hash")
+            and bool(
+                authority_diagnostic_evidence.get(
+                    "gateway-measured-audit-compact", {}
+                ).get("authority_hash")
+            )
+            and authority_diagnostic_evidence.get(
+                "gateway-measured-immutable-tamper", {}
+            ).get("exception_type")
+            == GatewayWeightInputsV2Error.__name__
+        ),
         "receipt_ancestry_verified": (
             epoch_authority_complete
             and all(
@@ -5338,6 +6744,7 @@ def main() -> int:
             else None
         ),
         "behavior_evidence": behavior_evidence,
+        "authority_diagnostic_evidence": authority_diagnostic_evidence,
         "behavioral_invariants": behavioral_invariants,
         "production_source_identities": identities,
         "epoch_count": len(epochs),

--- a/tests/restart_rehearsal/run_inside.sh
+++ b/tests/restart_rehearsal/run_inside.sh
@@ -41,6 +41,8 @@ if { [ "$COMPONENT" = "gateway" ] || [ "$COMPONENT" = "validator" ]; } \
   echo "ERROR: REHEARSAL_DURABLE_SCHEMA_SHA is required" >&2
   exit 2
 fi
+mkdir -p "${HOME:?HOME is required}"
+git config --global --add safe.directory /source
 if [ "$COMPONENT" = "workflow" ]; then
   case "$REHEARSAL_PROFILE" in
     prepush|release) ;;
@@ -151,7 +153,6 @@ ln -sf /harness/bin/python3 /home/ec2-user/venv311/bin/python3
 
 git config --global user.email "restart-rehearsal@leadpoet.invalid"
 git config --global user.name "Leadpoet Restart Rehearsal"
-git config --global --add safe.directory '*'
 
 git -C /source cat-file -e "$FROM_SHA^{commit}"
 git -C /source cat-file -e "$CANDIDATE_SHA^{commit}"

--- a/tests/restart_rehearsal/sanitized_weight_fixture.py
+++ b/tests/restart_rehearsal/sanitized_weight_fixture.py
@@ -74,6 +74,11 @@ class SanitizedWeightFixture:
                 b"validator:" + candidate_sha.encode("ascii")
             ).digest()
         )
+        self.scoring_key = Ed25519PrivateKey.from_private_bytes(
+            hashlib.sha256(
+                b"scoring:" + candidate_sha.encode("ascii")
+            ).digest()
+        )
 
     @staticmethod
     def _public_key(key: Ed25519PrivateKey) -> str:
@@ -88,11 +93,13 @@ class SanitizedWeightFixture:
         release_identity: Mapping[str, Any] | None = None,
         boot_nonce_context: str | None = None,
     ) -> dict[str, Any]:
-        physical_role = (
-            "gateway_coordinator"
-            if role == COORDINATOR_ROLE
-            else "validator_weights"
-        )
+        physical_role = {
+            COORDINATOR_ROLE: "gateway_coordinator",
+            WEIGHT_ROLE: "validator_weights",
+            "gateway_scoring": "gateway_scoring",
+        }.get(role)
+        if physical_role is None:
+            raise ValueError("sanitized fixture role is unsupported")
         pcr0 = self.pcr0
         build_manifest_hash = HASH
         dependency_lock_hash = HASH_B
@@ -196,6 +203,7 @@ class SanitizedWeightFixture:
         output_root: str = HASH_B,
         parents: tuple[str, ...] | list[str] = (),
         sequence: int = 1,
+        epoch_id: int | None = None,
         transport_root: str = EMPTY_TRANSPORT_ROOT,
         artifact_root: str = EMPTY_ARTIFACT_ROOT,
     ) -> dict[str, Any]:
@@ -205,7 +213,7 @@ class SanitizedWeightFixture:
             role=role,
             purpose=purpose,
             job_id=job_id,
-            epoch_id=self.epoch_id,
+            epoch_id=self.epoch_id if epoch_id is None else epoch_id,
             sequence=sequence,
             commit_sha=str(boot["commit_sha"]),
             pcr0=str(boot["pcr0"]),
@@ -594,6 +602,126 @@ class SanitizedWeightFixture:
                 bytes.fromhex(result["weights_hash"])
             ).hex(),
             "receipt_graph": graph,
+        }
+
+    def signed_sourcing_epoch_graph_v2(
+        self,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Build one signed source epoch used by the measured-source adapter."""
+
+        from leadpoet_canonical.sourcing_history_v2 import (
+            build_sourcing_decision_v2,
+            build_sourcing_epoch_v2,
+        )
+
+        source_epoch = self.epoch_id - 1
+        decision = build_sourcing_decision_v2(
+            epoch_id=source_epoch,
+            sequence=0,
+            lead_id_hash=sha256_json({"source_epoch": source_epoch}),
+            miner_hotkey="source-hotkey",
+            decision="approve",
+            rep_score=7,
+            is_icp_multiplier=0,
+        )
+        source_doc = build_sourcing_epoch_v2(
+            epoch_id=source_epoch,
+            decisions=[decision],
+        )
+        boot = self._boot(
+            role="gateway_scoring",
+            key=self.scoring_key,
+            config_hash=HASH,
+            boot_nonce_context="gateway-measured-source",
+        )
+        receipt = self.receipt(
+            role="gateway_scoring",
+            purpose="qualification.sourcing_epoch.v2",
+            job_id=f"gateway-measured-source-{source_epoch}",
+            key=self.scoring_key,
+            boot=boot,
+            config_hash=HASH,
+            input_root=source_doc["decision_root"],
+            output_root=sha256_json(source_doc),
+            sequence=400,
+            epoch_id=source_epoch,
+        )
+        graph = build_receipt_graph(
+            root_receipt_hash=receipt["receipt_hash"],
+            boot_identities=[boot],
+            receipts=[receipt],
+            transport_attempts=[],
+        )
+        return graph, {
+            "epoch_id": source_epoch,
+            "epoch_hash": source_doc["epoch_hash"],
+            "receipt_hash": receipt["receipt_hash"],
+            "source_doc": source_doc,
+            "receipt_doc": receipt,
+        }
+
+    def gateway_measured_source_fixture_v2(self) -> dict[str, Any]:
+        """Return provisional state and production-policy-keyed measured rows."""
+
+        bundle = self.bundle()
+        allocation_receipt = next(
+            receipt
+            for receipt in bundle["receipt_graph"]["receipts"]
+            if receipt["purpose"] == "research_lab.allocation.v2"
+        )
+        coordinator_boot = next(
+            boot
+            for boot in bundle["receipt_graph"]["boot_identities"]
+            if boot["role"] == COORDINATOR_ROLE
+        )
+        allocation_graph = build_receipt_graph(
+            root_receipt_hash=allocation_receipt["receipt_hash"],
+            boot_identities=[coordinator_boot],
+            receipts=[allocation_receipt],
+            transport_attempts=[],
+        )
+        provisional = self.calculation_snapshot(
+            [allocation_receipt["receipt_hash"]],
+            allocation_receipt["receipt_hash"],
+        )
+        provisional["parent_receipt_hashes"] = [allocation_receipt["receipt_hash"]]
+        provisional["research_lab_allocation_receipt_hash"] = allocation_receipt[
+            "receipt_hash"
+        ]
+        provisional["config_hash"] = weight_config_hash(provisional)
+        source_graph, source_row = self.signed_sourcing_epoch_graph_v2()
+        return {
+            "provisional": provisional,
+            "allocation_graph": allocation_graph,
+            "sourcing_graphs": [source_graph],
+            "rows": {
+                "attested_receipt_by_hash": [
+                    {"receipt_doc": allocation_receipt},
+                    {"receipt_doc": source_row["receipt_doc"]},
+                ],
+                "research_lab_allocation_current": [
+                    {"allocation_doc": provisional["research_lab_allocation_doc"]}
+                ],
+                "banned_hotkeys": [{"hotkey": "source-hotkey"}],
+                "fulfillment_active_rewards": [
+                    {"miner_hotkey": "fulfillment-hotkey", "reward_pct": 0.6}
+                ],
+                "fulfillment_leaderboard_winners": [
+                    {"miner_hotkey": "fulfillment-hotkey", "reward_pct": 0.6}
+                    for _ in range(9)
+                ],
+                "sourcing_epoch_inputs": [source_row],
+            },
+            "expected_stale_facts": {
+                "bans": ["source-hotkey"],
+                "fulfillment_share": 0.6,
+                "sourcing": {
+                    "rolling_lead_count": 1,
+                    "rolling_scores": [
+                        {"hotkey": "source-hotkey", "score": -100000}
+                    ],
+                },
+            },
         }
 
     @staticmethod

--- a/tests/restart_rehearsal/test_rehearsal_integrity.py
+++ b/tests/restart_rehearsal/test_rehearsal_integrity.py
@@ -4,6 +4,7 @@ import base64
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 import hashlib
+import inspect
 import importlib.util
 import json
 import os
@@ -3805,14 +3806,222 @@ def test_evidence_verifier_keeps_stdout_json_channel_clean() -> None:
     assert result.stdout == "VERIFIER_IMPORT_OK\n"
 
 
-def test_workflow_runs_before_command_adapters_are_installed() -> None:
+def test_workflow_configures_exact_source_before_early_exec() -> None:
     script = (
         Path(__file__).resolve().parent / "run_inside.sh"
     ).read_text(encoding="utf-8")
+    home = script.index('mkdir -p "${HOME:?HOME is required}"')
+    safe_source = script.index(
+        "git config --global --add safe.directory /source"
+    )
     workflow = script.index('if [ "$COMPONENT" = "workflow" ]; then')
     adapters = script.index("make_adapter()")
-    assert workflow < adapters
+    assert home < safe_source < workflow < adapters
     assert "/harness/production_workflow_runner.py" in script[workflow:adapters]
+    assert "safe.directory '*'" not in script
+
+
+def test_output_ownership_normalizer_is_bounded(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        rehearsal,
+        "_run",
+        lambda command: commands.append(list(command)),
+    )
+
+    rehearsal._normalize_rehearsal_output_ownership(
+        "rehearsal-image",
+        docker_platform="linux/amd64",
+        output_roots=(first, second),
+    )
+
+    assert len(commands) == 1
+    command = commands[0]
+    assert command[:5] == [
+        "docker",
+        "run",
+        "--rm",
+        "--platform",
+        "linux/amd64",
+    ]
+    for expected in (
+        ("--network", "none"),
+        ("--cpus", "0.25"),
+        ("--memory", "64m"),
+        ("--pids-limit", "16"),
+        ("--security-opt", "no-new-privileges"),
+        ("--cap-drop", "ALL"),
+        ("--user", "0:0"),
+        ("--entrypoint", "/usr/bin/chown"),
+    ):
+        index = command.index(expected[0])
+        assert command[index + 1] == expected[1]
+    assert "--read-only" in command
+    assert [
+        command[index + 1]
+        for index, value in enumerate(command[:-1])
+        if value == "--cap-add"
+    ] == ["CHOWN", "FOWNER", "DAC_OVERRIDE"]
+    assert f"type=bind,src={first.resolve()},dst=/host-output/0" in command
+    assert f"type=bind,src={second.resolve()},dst=/host-output/1" in command
+    assert command[-5:] == [
+        "-R",
+        "--",
+        f"{os.getuid()}:{os.getgid()}",
+        "/host-output/0",
+        "/host-output/1",
+    ]
+
+    with pytest.raises(ValueError, match="at least one"):
+        rehearsal._validated_rehearsal_output_roots(())
+    with pytest.raises(ValueError, match="system temporary"):
+        rehearsal._validated_rehearsal_output_roots(
+            (Path(rehearsal.tempfile.gettempdir()),)
+        )
+    with pytest.raises(ValueError, match="system temporary"):
+        rehearsal._validated_rehearsal_output_roots(
+            (Path(rehearsal.tempfile.gettempdir()).resolve().anchor,)
+        )
+    with pytest.raises(ValueError, match="repository paths"):
+        rehearsal._validated_rehearsal_output_roots((rehearsal.REPO_ROOT,))
+    with pytest.raises(ValueError, match="duplicate"):
+        rehearsal._validated_rehearsal_output_roots((first, first))
+    with pytest.raises(ValueError, match="does not exist"):
+        rehearsal._validated_rehearsal_output_roots((tmp_path / "absent",))
+    regular_file = tmp_path / "not-a-directory"
+    regular_file.write_text("not a root\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="not a directory"):
+        rehearsal._validated_rehearsal_output_roots((regular_file,))
+    source_snapshot = tmp_path / "leadpoet-restart-source-test" / "source"
+    source_snapshot.mkdir(parents=True)
+    with pytest.raises(ValueError, match="source snapshots"):
+        rehearsal._validated_rehearsal_output_roots((source_snapshot,))
+
+
+def test_output_ownership_normalizes_after_success_and_failure(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    output = tmp_path / "output"
+    output.mkdir()
+    normalized: list[tuple[Path, ...]] = []
+    monkeypatch.setattr(
+        rehearsal,
+        "_normalize_rehearsal_output_ownership",
+        lambda _tag, *, docker_platform, output_roots: normalized.append(
+            tuple(output_roots)
+        ),
+    )
+
+    assert rehearsal._run_docker_action_with_output_ownership(
+        lambda: "ok",
+        tag="image",
+        docker_platform="linux/amd64",
+        output_roots=(output,),
+    ) == "ok"
+    assert normalized == [(output.resolve(),)]
+
+    action_error = subprocess.CalledProcessError(17, ["docker", "run"])
+
+    def fail_action() -> None:
+        raise action_error
+
+    with pytest.raises(subprocess.CalledProcessError) as caught:
+        rehearsal._run_docker_action_with_output_ownership(
+            fail_action,
+            tag="image",
+            docker_platform="linux/amd64",
+            output_roots=(output,),
+        )
+    assert caught.value is action_error
+    assert normalized == [(output.resolve(),), (output.resolve(),)]
+
+    ownership_error = PermissionError("root-owned output")
+
+    def fail_ownership(*_args, **_kwargs) -> None:
+        raise ownership_error
+
+    monkeypatch.setattr(
+        rehearsal,
+        "_normalize_rehearsal_output_ownership",
+        fail_ownership,
+    )
+    with pytest.raises(rehearsal.RehearsalOutputOwnershipError) as dual:
+        rehearsal._run_docker_action_with_output_ownership(
+            fail_action,
+            tag="image",
+            docker_platform="linux/amd64",
+            output_roots=(output,),
+        )
+    assert dual.value.action_error is action_error
+    assert dual.value.ownership_error is ownership_error
+    assert "action=" in str(dual.value) and "ownership=" in str(dual.value)
+
+
+def test_every_writable_rehearsal_mount_is_registered_for_normalization() -> None:
+    fixture = inspect.getsource(rehearsal._prepared_fixture_seed)
+    component = inspect.getsource(rehearsal._run_component)
+    workflow = inspect.getsource(rehearsal._run_workflow)
+    join = inspect.getsource(rehearsal._join_evidence)
+
+    assert "output_roots=(generated_state, generated_config)" in fixture
+    assert "output_roots=(evidence_root, durable_state_root)" in component
+    assert "output_roots=(evidence_root,)" in workflow
+    assert "output_roots=(evidence_root,)" in join
+    combined = "\n".join((fixture, component, workflow, join))
+    for read_only_root in (
+        "source_root",
+        "drand_artifact_root",
+        "fixture_seed_root",
+        "from_fixture_seed_root",
+        "durable_fixture_seed_root",
+    ):
+        assert f"output_roots=({read_only_root}" not in combined
+
+
+def test_host_output_access_probe_checks_nested_state(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    output = tmp_path / "evidence"
+    nested = output / "local-services" / "epochs"
+    builder = output / "release-builder"
+    nested.mkdir(parents=True)
+    builder.mkdir()
+    (nested / "production-shaped.sqlite3").write_bytes(b"sqlite")
+    (builder / "release.json").write_text("{}\n", encoding="utf-8")
+
+    rehearsal._probe_rehearsal_output_access((output,))
+    assert not list(output.glob(".leadpoet-host-access-*"))
+
+    original_access = rehearsal.os.access
+    monkeypatch.setattr(
+        rehearsal.os,
+        "access",
+        lambda path, mode: (
+            False if Path(path) == nested else original_access(path, mode)
+        ),
+    )
+    with pytest.raises(PermissionError, match="not host-accessible"):
+        rehearsal._probe_rehearsal_output_access((output,))
+
+    unreadable = builder / "release.json"
+    monkeypatch.setattr(
+        rehearsal.os,
+        "access",
+        lambda path, mode: (
+            False if Path(path) == unreadable else original_access(path, mode)
+        ),
+    )
+    with pytest.raises(PermissionError, match="not host-readable"):
+        rehearsal._probe_rehearsal_output_access((output,))
 
 
 def test_workflow_uses_the_strict_exact_external_boundaries(

--- a/tests/restart_rehearsal/test_rehearsal_integrity.py
+++ b/tests/restart_rehearsal/test_rehearsal_integrity.py
@@ -4036,6 +4036,11 @@ def test_workflow_uses_the_strict_exact_external_boundaries(
         captured["command"] = list(command)
 
     monkeypatch.setattr(rehearsal, "_run", run)
+    monkeypatch.setattr(
+        rehearsal,
+        "_run_docker_action_with_output_ownership",
+        lambda action, **_kwargs: action(),
+    )
     rehearsal._run_workflow(
         "rehearsal-image",
         source_root=tmp_path / "source",

--- a/tests/test_attested_scoring_v2_bridge.py
+++ b/tests/test_attested_scoring_v2_bridge.py
@@ -67,6 +67,54 @@ def _hash(character):
     return "sha256:" + character * 64
 
 
+def _artifact_persistence_lineage_output():
+    artifacts = [
+        {
+            "artifact_id": _hash("8"),
+            "plaintext_hash": _hash("1"),
+            "ciphertext_hash": _hash("2"),
+            "artifact_ref": "s3://immutable/8.json",
+            "storage_document_hash": _hash("3"),
+            "encryption_context_hash": _hash("4"),
+            "object_lock_mode": "COMPLIANCE",
+            "retain_until": "2027-07-10T12:00:00Z",
+            "transport_root": _hash("5"),
+        }
+    ]
+    return {
+        "source_receipt_hash": _hash("6"),
+        "artifacts": artifacts,
+        "artifact_set_root": sha256_json(artifacts),
+    }
+
+
+def test_artifact_persistence_lineage_output_is_schema_and_receipt_bound():
+    output = _artifact_persistence_lineage_output()
+    assert attested_scoring_v2._validate_artifact_persistence_lineage_output_v2(
+        lineage={"result": output},
+        lineage_receipt={"output_root": sha256_json(output)},
+    ) == output
+
+
+def test_artifact_persistence_lineage_output_rejects_invalid_schema():
+    output = _artifact_persistence_lineage_output()
+    output["unexpected"] = True
+    with pytest.raises(AttestedScoringV2Error, match="output is invalid"):
+        attested_scoring_v2._validate_artifact_persistence_lineage_output_v2(
+            lineage={"result": output},
+            lineage_receipt={"output_root": sha256_json(output)},
+        )
+
+
+def test_artifact_persistence_lineage_output_rejects_receipt_mismatch():
+    output = _artifact_persistence_lineage_output()
+    with pytest.raises(AttestedScoringV2Error, match="differs from its receipt"):
+        attested_scoring_v2._validate_artifact_persistence_lineage_output_v2(
+            lineage={"result": output},
+            lineage_receipt={"output_root": _hash("f")},
+        )
+
+
 @pytest.fixture(autouse=True)
 def _checkpoint_runtime(monkeypatch):
     monkeypatch.setenv(
@@ -2277,6 +2325,10 @@ async def test_v2_bridge_persists_every_authenticated_provider_artifact_first(
         == result["receipt"]["job_id"]
     )
     assert result["artifact_persistence"][0]["status"] == "persisted"
+    assert result["artifact_persistence_output"]["artifacts"]
+    assert result["receipt"]["output_root"] == sha256_json(
+        result["artifact_persistence_output"]
+    )
     assert result["receipt"]["purpose"] == "leadpoet.artifact_persistence.v2"
     assert result["execution_receipt"]["purpose"] == "research_lab.benchmark.v2"
     assert (

--- a/tests/test_attested_weight_inputs_v2.py
+++ b/tests/test_attested_weight_inputs_v2.py
@@ -9,6 +9,9 @@ from gateway.research_lab.attested_weight_inputs_v2 import (
     build_gateway_weight_inputs_v2,
 )
 from leadpoet_canonical.attested_v2 import sha256_json
+from leadpoet_canonical.hotkey_authority_v2 import (
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+)
 from leadpoet_canonical.weight_authority_v2 import (
     GATEWAY_WEIGHT_INPUT_CATEGORIES,
     WEIGHT_INPUT_PURPOSES,
@@ -267,7 +270,7 @@ async def test_gateway_weight_input_builder_gives_each_live_job_one_client(
 
 
 @pytest.mark.asyncio
-async def test_gateway_weight_input_builder_uses_artifact_backed_execution_receipt(
+async def test_gateway_weight_input_builder_prefers_execution_proof_over_persistence_wrapper(
     monkeypatch,
 ):
     monkeypatch.setattr(
@@ -294,6 +297,7 @@ async def test_gateway_weight_input_builder_uses_artifact_backed_execution_recei
         persistence_hash = sha256_json({"persistence": category})
         execution_receipt = {
             "receipt_hash": execution_hash,
+            "job_id": "execution-%s" % category,
             "role": WEIGHT_INPUT_PURPOSES[category][0],
             "purpose": WEIGHT_INPUT_PURPOSES[category][1],
             "output_root": sha256_json(expected[category]),
@@ -313,12 +317,26 @@ async def test_gateway_weight_input_builder_uses_artifact_backed_execution_recei
             "host_operations": [],
         }
         execution_graphs[category] = execution_graph
+        execution_proof = {
+            "certificate": {
+                "claim": {"output_root_receipt_hash": execution_hash}
+            },
+            "disclosed_receipts": [execution_receipt],
+        }
+        persistence_proof = {
+            "certificate": {
+                "claim": {"output_root_receipt_hash": persistence_hash}
+            },
+            "disclosed_receipts": [persistence_receipt],
+        }
         return {
             "status": "succeeded",
             "result": expected[category],
             "receipt": persistence_receipt,
             "execution_receipt": execution_receipt,
             "execution_receipt_graph": execution_graph,
+            "execution_ancestry_compact_proof": execution_proof,
+            "ancestry_compact_proof": persistence_proof,
             "receipt_graph": {
                 "root_receipt_hash": persistence_hash,
                 "boot_identities": [],
@@ -353,6 +371,170 @@ async def test_gateway_weight_input_builder_uses_artifact_backed_execution_recei
         execution_graphs[category]
         for category in attested_weight_inputs_v2._ANOMALY_SOURCE_CATEGORIES
     )
+    assert {
+        category: proof["certificate"]["claim"]["output_root_receipt_hash"]
+        for category, proof in result["compact_ancestry"][
+            "upstream_ancestry_proofs"
+        ].items()
+    } == {
+        category: sha256_json({"execution": category})
+        for category in GATEWAY_WEIGHT_INPUT_CATEGORIES
+    }
+
+
+@pytest.mark.asyncio
+async def test_gateway_weight_input_builder_normalizes_only_signed_measured_fields(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        attested_weight_inputs_v2,
+        "validate_receipt_graph",
+        lambda *_args, **_kwargs: (),
+    )
+    provisional = _snapshot()
+    authoritative = _snapshot()
+    authoritative.update(
+        {
+            "banned_hotkeys": ["banned"],
+            "fulfillment_share": 0.6,
+            "fulfillment_rows": [{"hotkey": "miner", "share": 0.6}],
+            "leaderboard_entries": [{"miner_hotkey": "miner", "wins": 1}],
+            "rolling_lead_count": 1,
+            "rolling_scores": [{"hotkey": "banned", "score": -100000}],
+        }
+    )
+    authoritative["config_hash"] = weight_config_hash(authoritative)
+    allocation = _allocation_graph()
+    authority_hash = allocation["root_receipt_hash"]
+    provisional_documents = gateway_weight_input_value_documents_v2(
+        calculation_snapshot=provisional,
+        gateway_authority_event_hash=authority_hash,
+    )
+    authoritative_documents = gateway_weight_input_value_documents_v2(
+        calculation_snapshot=authoritative,
+        gateway_authority_event_hash=authority_hash,
+    )
+    calls = []
+
+    async def execute(**kwargs):
+        calls.append(kwargs)
+        category = kwargs["payload"]["category"]
+        document = (
+            authoritative_documents[category]
+            if category
+            in {
+                "bans",
+                "fulfillment_rewards",
+                "leaderboard",
+                "sourcing_history",
+                "anomaly_adjustments",
+            }
+            else provisional_documents[category]
+        )
+        receipt_hash = sha256_json({"normalized-category": category})
+        receipt = {
+            "receipt_hash": receipt_hash,
+            "role": WEIGHT_INPUT_PURPOSES[category][0],
+            "purpose": WEIGHT_INPUT_PURPOSES[category][1],
+            "epoch_id": provisional["epoch_id"],
+            "output_root": sha256_json(document),
+        }
+        if category == "bans":
+            persistence_hash = sha256_json({"normalized-persistence": category})
+            artifacts = [
+                {
+                    "artifact_id": "sha256:" + "a" * 64,
+                    "plaintext_hash": sha256_json(document["value"]),
+                    "ciphertext_hash": "sha256:" + "b" * 64,
+                    "artifact_ref": "s3://immutable/bans.json",
+                    "storage_document_hash": "sha256:" + "c" * 64,
+                    "encryption_context_hash": "sha256:" + "d" * 64,
+                    "object_lock_mode": "COMPLIANCE",
+                    "retain_until": "2027-07-10T20:00:00Z",
+                    "transport_root": "sha256:" + "e" * 64,
+                }
+            ]
+            persistence_output = {
+                "source_receipt_hash": receipt_hash,
+                "artifacts": artifacts,
+                "artifact_set_root": sha256_json(artifacts),
+            }
+            persistence_receipt = {
+                "receipt_hash": persistence_hash,
+                "role": "gateway_coordinator",
+                "purpose": "leadpoet.artifact_persistence.v2",
+                "epoch_id": provisional["epoch_id"],
+                "parent_receipt_hashes": [receipt_hash],
+                "output_root": sha256_json(persistence_output),
+            }
+            return {
+                "status": "succeeded",
+                "result": document,
+                "receipt": persistence_receipt,
+                "execution_receipt": receipt,
+                "artifact_persistence_output": persistence_output,
+                "execution_receipt_graph": {
+                    "root_receipt_hash": receipt_hash,
+                    "boot_identities": [],
+                    "receipts": [receipt],
+                    "transport_attempts": [],
+                    "host_operations": [],
+                },
+                "receipt_graph": {
+                    "root_receipt_hash": persistence_hash,
+                    "boot_identities": [],
+                    "receipts": [receipt, persistence_receipt],
+                    "transport_attempts": [],
+                    "host_operations": [],
+                },
+            }
+        return {
+            "status": "succeeded",
+            "result": document,
+            "receipt": receipt,
+            "receipt_graph": {
+                "root_receipt_hash": receipt_hash,
+                "boot_identities": [],
+                "receipts": [receipt],
+                "transport_attempts": [],
+                "host_operations": [],
+            },
+        }
+
+    result = await build_gateway_weight_inputs_v2(
+        calculation_snapshot=provisional,
+        allocation_graph=allocation,
+        leaderboard_window_start="2026-07-03T00:00:00Z",
+        leaderboard_window_end="2026-07-10T00:00:00Z",
+        execute=execute,
+        load_sourcing_graphs=lambda **_kwargs: _async_value([]),
+        snapshot_authority_mode=GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+    )
+
+    sourcing_call = next(
+        call for call in calls if call["payload"]["category"] == "sourcing_history"
+    )
+    assert sourcing_call["payload"]["bans_document"] == authoritative_documents["bans"]
+    assert sourcing_call["payload"]["bans_persistence_output"] == (
+        result["executions"]["bans"]["artifact_persistence_output"]
+    )
+    assert sourcing_call["parent_graphs"][0]["root_receipt_hash"] == sha256_json(
+        {"normalized-persistence": "bans"}
+    )
+    assert result["snapshot_authority_mode"] == (
+        GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+    )
+    assert result["authoritative_calculation_snapshot"] == authoritative
+    assert result["normalized_source_categories"] == [
+        "bans",
+        "fulfillment_rewards",
+        "leaderboard",
+        "sourcing_history",
+    ]
+    assert result["executions"]["anomaly_adjustments"]["result"] == (
+        authoritative_documents["anomaly_adjustments"]
+    )
+    assert provisional["banned_hotkeys"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_authoritative_weight_flow_v2.py
+++ b/tests/test_authoritative_weight_flow_v2.py
@@ -9,8 +9,14 @@ import pytest
 
 from leadpoet_canonical.attested_v2 import sha256_bytes, sha256_json
 from leadpoet_canonical.hotkey_authority_v2 import (
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
     validate_weight_transport_authorization_v2,
     weight_transport_authorization_message_v2,
+)
+from leadpoet_canonical.weight_computation import (
+    WEIGHT_SNAPSHOT_SCHEMA_VERSION,
+    compute_final_weights,
+    weight_config_hash,
 )
 from validator_tee.host import authoritative_weight_flow_v2 as flow_module
 from validator_tee.host.authoritative_weight_flow_v2 import (
@@ -325,6 +331,90 @@ class Client:
         }
 
 
+def _measured_calculation(**overrides):
+    value = {
+        "schema_version": WEIGHT_SNAPSHOT_SCHEMA_VERSION,
+        "netuid": 71,
+        "epoch_id": 100,
+        "block": 36099,
+        "commit_sha": "a" * 40,
+        "config_hash": "",
+        "parent_receipt_hashes": [],
+        "research_lab_allocation_receipt_hash": "",
+        "burn_target_uid": 0,
+        "expected_burn_target_hotkey": "burn",
+        "metagraph_hotkeys": ["burn", "miner"],
+        "banned_hotkeys": [],
+        "banned_lookup_ok": True,
+        "ff_enabled": True,
+        "base_burn_share": 0.0,
+        "champion_share": 0.0,
+        "champion_uid": None,
+        "effective_champion_share": 0.0,
+        "research_lab_fallback_share": 0.2,
+        "research_lab_allocation_doc": {
+            "lab_cap_percent": 20.0,
+            "unallocated_percent": 20.0,
+            "champion_allocations": [],
+            "queued_champion_allocations": [],
+            "reimbursement_allocations": [],
+            "source_add_allocations": [],
+        },
+        "leaderboard_bonus_share": 0.095,
+        "leaderboard_rank_shares": [0.05, 0.03, 0.015],
+        "leaderboard_entries": [],
+        "leaderboard_fetch_ok": True,
+        "fulfillment_share": 0.705,
+        "fulfillment_rows": [{"hotkey": "miner", "share": 0.705}],
+        "fulfillment_fetch_ok": True,
+        "rolling_lead_count": 0,
+        "rolling_scores": [],
+        "sourcing_floor_threshold": 125000,
+        "min_total_rep_for_distribution": 100,
+    }
+    value.update(overrides)
+    value["config_hash"] = weight_config_hash(value)
+    return value
+
+
+def _measured_gateway_inputs(authoritative):
+    return {
+        "input_receipt_hashes": {"research_lab_allocation": "sha256:" + "b" * 64},
+        "gateway_authority_event_hash": "sha256:" + "c" * 64,
+        "upstream_receipt_set": {"receipts": []},
+        "snapshot_authority_mode": GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+        "authoritative_calculation_snapshot": authoritative,
+        "authoritative_calculation_snapshot_hash": sha256_json(authoritative),
+        "normalized_source_categories": [
+            "bans",
+            "fulfillment_rewards",
+            "leaderboard",
+            "sourcing_history",
+        ],
+    }
+
+
+def _computed_response(client, request, calculation):
+    client.compute_requests.append(dict(request))
+    result = dict(compute_final_weights(calculation))
+    # The test publication acknowledgement is intentionally fixture-bound;
+    # vector verification uses the float/sparse values, not this transport id.
+    result["weights_hash"] = "4" * 64
+    return {
+        "weight_snapshot": {"snapshot": True},
+        "weight_result": result,
+        "weights_signature": "5" * 128,
+        "receipt_graph": {"root_receipt_hash": ROOT, "receipts": []},
+        "boot_identity": {
+            "signing_pubkey": "6" * 64,
+            "build_manifest_hash": "sha256:" + "7" * 64,
+            "commit_sha": "8" * 40,
+        },
+        "weight_authorization_id": "sha256:" + "9" * 64,
+        "source_artifacts": [],
+    }
+
+
 async def _inputs(**kwargs):
     assert kwargs["validator_hotkey"] == HOTKEY
     return {
@@ -458,6 +548,113 @@ async def test_flow_orders_inputs_compute_parent_binding_and_durable_publication
     assert result["uids"] == [0, 1]
     assert result["weight_submission_event_hash"] == EVENT
     assert order == ["journal", "post"]
+
+
+@pytest.mark.asyncio
+async def test_signed_measured_flow_checks_provisional_then_authoritative_vector(
+    monkeypatch,
+):
+    monkeypatch.setattr(flow_module, "build_authoritative_weight_bundle_v2", _bundle)
+    monkeypatch.setattr(
+        flow_module,
+        "validate_published_weight_bundle_v2",
+        _verified_bundle,
+    )
+    provisional = _measured_calculation()
+    authoritative = _measured_calculation(
+        banned_hotkeys=["banned"],
+        fulfillment_share=0.6,
+        fulfillment_rows=[{"hotkey": "miner", "share": 0.6}],
+        leaderboard_entries=[{"miner_hotkey": "miner", "wins": 1}],
+        rolling_lead_count=1,
+        rolling_scores=[{"hotkey": "banned", "score": -100000}],
+    )
+    provisional_result = compute_final_weights(provisional)
+    authoritative_result = compute_final_weights(authoritative)
+    client = Client()
+
+    def compute(request):
+        assert request["calculation_snapshot"] == provisional
+        assert request["authoritative_calculation_snapshot"] == authoritative
+        return _computed_response(client, request, authoritative)
+
+    client.compute_authoritative_weights_v2 = compute
+
+    async def inputs(**kwargs):
+        assert kwargs["snapshot_authority_mode"] == (
+            GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+        )
+        return _measured_gateway_inputs(authoritative)
+
+    async def post(*_args):
+        return _ack()
+
+    result = await prepare_authoritative_weight_publication_v2(
+        calculation_snapshot=provisional,
+        host_uids=provisional_result["uids"],
+        host_weights=provisional_result["weights"],
+        validator_hotkey=HOTKEY,
+        allocation_hash="sha256:" + "d" * 64,
+        leaderboard_window_start="2026-07-03T20:00:00Z",
+        leaderboard_window_end="2026-07-10T20:00:00Z",
+        gateway_url="https://gateway.example",
+        expected_chain="wss://entrypoint-finney.opentensor.ai:443",
+        client=client,
+        fetch_inputs=inputs,
+        post_json=post,
+        snapshot_authority_mode=GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+    )
+
+    assert client.compute_requests[0]["snapshot_authority_mode"] == (
+        GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+    )
+    assert result["uids"] == authoritative_result["uids"]
+    assert result["weights"] == authoritative_result["weights"]
+
+
+@pytest.mark.asyncio
+async def test_signed_measured_flow_rejects_enclave_provisional_vector(monkeypatch):
+    monkeypatch.setattr(flow_module, "build_authoritative_weight_bundle_v2", _bundle)
+    provisional = _measured_calculation()
+    authoritative = _measured_calculation(
+        banned_hotkeys=["banned"],
+        fulfillment_share=0.6,
+        fulfillment_rows=[{"hotkey": "miner", "share": 0.6}],
+        leaderboard_entries=[{"miner_hotkey": "miner", "wins": 1}],
+        rolling_lead_count=1,
+        rolling_scores=[{"hotkey": "banned", "score": -100000}],
+    )
+    provisional_result = compute_final_weights(provisional)
+    client = Client()
+    client.compute_authoritative_weights_v2 = (
+        lambda request: _computed_response(client, request, provisional)
+    )
+
+    async def inputs(**_kwargs):
+        return _measured_gateway_inputs(authoritative)
+
+    async def post(*_args):
+        raise AssertionError("mismatched authoritative vector must not publish")
+
+    with pytest.raises(
+        AuthoritativeWeightFlowV2Error,
+        match="authoritative host and enclave vectors differ",
+    ):
+        await prepare_authoritative_weight_publication_v2(
+            calculation_snapshot=provisional,
+            host_uids=provisional_result["uids"],
+            host_weights=provisional_result["weights"],
+            validator_hotkey=HOTKEY,
+            allocation_hash="sha256:" + "d" * 64,
+            leaderboard_window_start="2026-07-03T20:00:00Z",
+            leaderboard_window_end="2026-07-10T20:00:00Z",
+            gateway_url="https://gateway.example",
+            expected_chain="wss://entrypoint-finney.opentensor.ai:443",
+            client=client,
+            fetch_inputs=inputs,
+            post_json=post,
+            snapshot_authority_mode=GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator_executor_v2.py
+++ b/tests/test_coordinator_executor_v2.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 
 from gateway.tee.artifact_vault_v2 import (
@@ -15,6 +17,7 @@ from gateway.tee.coordinator_executor_v2 import (
     OP_RESEARCH_LAB_ALLOCATION,
     CoordinatorExecutorV2,
     coordinator_receipt_output_v2,
+    validate_artifact_persistence_output_v2,
 )
 from gateway.tee.execution_job_manager_v2 import ExecutionContextV2
 from gateway.tee.provider_outcome_v2 import ProviderOutcomeLedgerV2
@@ -109,6 +112,83 @@ def _artifact_evidence(artifact_id, plaintext_hash, attempts):
         "transport_attempts": attempts,
         "persisted": True,
     }
+
+
+def _artifact_persistence_output():
+    artifacts = []
+    for character in ("a", "b"):
+        artifacts.append(
+            {
+                "artifact_id": "sha256:" + character * 64,
+                "plaintext_hash": "sha256:" + "1" * 64,
+                "ciphertext_hash": "sha256:" + "2" * 64,
+                "artifact_ref": f"s3://immutable/{character}.json",
+                "storage_document_hash": "sha256:" + "3" * 64,
+                "encryption_context_hash": "sha256:" + "4" * 64,
+                "object_lock_mode": "COMPLIANCE",
+                "retain_until": "2027-07-10T12:00:00Z",
+                "transport_root": "sha256:" + "5" * 64,
+            }
+        )
+    return {
+        "source_receipt_hash": "sha256:" + "6" * 64,
+        "artifacts": artifacts,
+        "artifact_set_root": sha256_json(artifacts),
+    }
+
+
+def test_artifact_persistence_output_validator_accepts_exact_executor_shape():
+    output = _artifact_persistence_output()
+    assert validate_artifact_persistence_output_v2(output) == output
+
+
+@pytest.mark.parametrize(
+    "field", ("source_receipt_hash", "artifacts", "artifact_set_root")
+)
+def test_artifact_persistence_output_validator_rejects_missing_or_extra_fields(
+    field,
+):
+    output = _artifact_persistence_output()
+    output.pop(field)
+    with pytest.raises(ValueError, match="fields are invalid"):
+        validate_artifact_persistence_output_v2(output)
+
+    output = _artifact_persistence_output()
+    output["unexpected"] = True
+    with pytest.raises(ValueError, match="fields are invalid"):
+        validate_artifact_persistence_output_v2(output)
+
+
+def test_artifact_persistence_output_validator_rejects_malformed_descriptor():
+    output = _artifact_persistence_output()
+    output["artifacts"][0].pop("transport_root")
+    output["artifact_set_root"] = sha256_json(output["artifacts"])
+    with pytest.raises(ValueError, match="artifact is invalid"):
+        validate_artifact_persistence_output_v2(output)
+
+
+def test_artifact_persistence_output_validator_rejects_duplicate_or_unsorted_ids():
+    output = _artifact_persistence_output()
+    output["artifacts"] = [
+        deepcopy(output["artifacts"][0]),
+        deepcopy(output["artifacts"][0]),
+    ]
+    output["artifact_set_root"] = sha256_json(output["artifacts"])
+    with pytest.raises(ValueError, match="artifact is invalid"):
+        validate_artifact_persistence_output_v2(output)
+
+    output = _artifact_persistence_output()
+    output["artifacts"].reverse()
+    output["artifact_set_root"] = sha256_json(output["artifacts"])
+    with pytest.raises(ValueError, match="artifact set is invalid"):
+        validate_artifact_persistence_output_v2(output)
+
+
+def test_artifact_persistence_output_validator_rejects_wrong_set_root():
+    output = _artifact_persistence_output()
+    output["artifact_set_root"] = "sha256:" + "f" * 64
+    with pytest.raises(ValueError, match="artifact set is invalid"):
+        validate_artifact_persistence_output_v2(output)
 
 
 def _weight_snapshot():

--- a/tests/test_coordinator_weight_source_v2.py
+++ b/tests/test_coordinator_weight_source_v2.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import copy
 
 import pytest
@@ -15,12 +16,16 @@ from leadpoet_canonical.attested_v2 import (
     EMPTY_ARTIFACT_ROOT,
     EMPTY_HOST_OPERATION_ROOT,
     EMPTY_TRANSPORT_ROOT,
+    build_boot_identity_body,
     build_execution_receipt_body,
+    build_receipt_graph,
+    create_boot_identity,
     create_signed_execution_receipt,
     sha256_json,
 )
 from leadpoet_canonical.hotkey_authority_v2 import (
     DISABLED_LEADERBOARD_WINDOW_V1,
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
 )
 from leadpoet_canonical.sourcing_history_v2 import (
     build_sourcing_decision_v2,
@@ -153,6 +158,179 @@ def _sourcing_epoch_receipt(source_doc):
         body=body,
         enclave_pubkey=pubkey,
         sign_digest=key.sign,
+    )
+
+
+def _weight_input_receipt(category, document):
+    """Build one valid direct coordinator receipt for a measured document."""
+
+    key = Ed25519PrivateKey.generate()
+    pubkey = key.public_key().public_bytes(
+        serialization.Encoding.Raw,
+        serialization.PublicFormat.Raw,
+    ).hex()
+    role, purpose = WEIGHT_INPUT_PURPOSES[category]
+    body = build_execution_receipt_body(
+        role=role,
+        purpose=purpose,
+        job_id="weight-input:%s:%d" % (category, document["epoch_id"]),
+        epoch_id=document["epoch_id"],
+        sequence=0,
+        commit_sha="b" * 40,
+        pcr0="c" * 96,
+        build_manifest_hash="sha256:" + "d" * 64,
+        dependency_lock_hash="sha256:" + "e" * 64,
+        config_hash="sha256:" + "f" * 64,
+        boot_identity_hash="sha256:" + "1" * 64,
+        input_root=sha256_json(document),
+        output_root=sha256_json(document),
+        transport_root_hash=EMPTY_TRANSPORT_ROOT,
+        host_operation_root_hash=EMPTY_HOST_OPERATION_ROOT,
+        artifact_root=EMPTY_ARTIFACT_ROOT,
+        parent_receipt_hashes=(),
+        status="succeeded",
+        failure_code=None,
+        issued_at="2026-07-10T20:00:00Z",
+    )
+    return create_signed_execution_receipt(
+        body=body,
+        enclave_pubkey=pubkey,
+        sign_digest=key.sign,
+    )
+
+
+def _durable_bans_graph(
+    bans_document,
+    *,
+    source_purpose="research_lab.ban_input.v2",
+    source_epoch=100,
+    terminal_epoch=None,
+    source_count=1,
+    source_output=None,
+    persistence_output=None,
+    persistence_output_mutator=None,
+    extra_parent=False,
+):
+    """Build canonical durable ban ancestry without bypassing graph checks."""
+
+    key = Ed25519PrivateKey.generate()
+    pubkey = key.public_key().public_bytes(
+        serialization.Encoding.Raw,
+        serialization.PublicFormat.Raw,
+    ).hex()
+    boot = create_boot_identity(
+        body=build_boot_identity_body(
+            role="gateway_coordinator",
+            physical_role="gateway_coordinator",
+            commit_sha="b" * 40,
+            pcr0="c" * 96,
+            build_manifest_hash="sha256:" + "d" * 64,
+            dependency_lock_hash="sha256:" + "e" * 64,
+            config_hash="sha256:" + "f" * 64,
+            boot_nonce="1" * 32,
+            signing_pubkey=pubkey,
+            transport_pubkey="2" * 64,
+            transport_certificate_hash="sha256:" + "3" * 64,
+            attestation_user_data_hash="sha256:" + "4" * 64,
+            issued_at="2026-07-10T20:00:00Z",
+        ),
+        attestation_document_b64=base64.b64encode(b"bans-graph").decode(),
+    )
+
+    def receipt(*, purpose, job_id, epoch_id, output_root, parents=()):
+        return create_signed_execution_receipt(
+            body=build_execution_receipt_body(
+                role="gateway_coordinator",
+                purpose=purpose,
+                job_id=job_id,
+                epoch_id=epoch_id,
+                sequence=0,
+                commit_sha="b" * 40,
+                pcr0="c" * 96,
+                build_manifest_hash="sha256:" + "d" * 64,
+                dependency_lock_hash="sha256:" + "e" * 64,
+                config_hash="sha256:" + "f" * 64,
+                boot_identity_hash=boot["boot_identity_hash"],
+                input_root=sha256_json({"job_id": job_id}),
+                output_root=output_root,
+                transport_root_hash=EMPTY_TRANSPORT_ROOT,
+                host_operation_root_hash=EMPTY_HOST_OPERATION_ROOT,
+                artifact_root=EMPTY_ARTIFACT_ROOT,
+                parent_receipt_hashes=parents,
+                status="succeeded",
+                failure_code=None,
+                issued_at="2026-07-10T20:00:00Z",
+            ),
+            enclave_pubkey=pubkey,
+            sign_digest=key.sign,
+        )
+
+    sources = [
+        receipt(
+            purpose=source_purpose,
+            job_id="weight-input-bans:%d" % index,
+            epoch_id=source_epoch,
+            output_root=(
+                sha256_json(source_output)
+                if source_output is not None
+                else sha256_json(bans_document)
+            ),
+        )
+        for index in range(source_count)
+    ]
+    if persistence_output is None:
+        artifacts = [
+            {
+                "artifact_id": "sha256:" + "7" * 64,
+                "plaintext_hash": sha256_json(bans_document["value"]),
+                "ciphertext_hash": "sha256:" + "8" * 64,
+                "artifact_ref": "s3://immutable/bans.json",
+                "storage_document_hash": "sha256:" + "9" * 64,
+                "encryption_context_hash": "sha256:" + "a" * 64,
+                "object_lock_mode": "COMPLIANCE",
+                "retain_until": "2027-07-10T20:00:00Z",
+                "transport_root": "sha256:" + "b" * 64,
+            }
+        ]
+        persistence_output = {
+            "source_receipt_hash": sources[0]["receipt_hash"],
+            "artifacts": artifacts,
+            "artifact_set_root": sha256_json(artifacts),
+        }
+    if persistence_output_mutator is not None:
+        persistence_output = persistence_output_mutator(
+            copy.deepcopy(persistence_output)
+        )
+    extra = (
+        receipt(
+            purpose="research_lab.leaderboard_input.v2",
+            job_id="weight-input-unrelated",
+            epoch_id=source_epoch,
+            output_root="sha256:" + "c" * 64,
+        )
+        if extra_parent
+        else None
+    )
+    terminal = receipt(
+        purpose="leadpoet.artifact_persistence.v2",
+        job_id="weight-input-bans-persistence",
+        epoch_id=(source_epoch if terminal_epoch is None else terminal_epoch),
+        output_root=sha256_json(persistence_output),
+        parents=[
+            *[item["receipt_hash"] for item in sources],
+            *([extra["receipt_hash"]] if extra is not None else []),
+        ],
+    )
+    return (
+        build_receipt_graph(
+            root_receipt_hash=terminal["receipt_hash"],
+            boot_identities=[boot],
+            receipts=[*sources, *([extra] if extra is not None else []), terminal],
+            transport_attempts=[],
+        ),
+        sources,
+        terminal,
+        persistence_output,
     )
 
 
@@ -338,6 +516,206 @@ def test_sourcing_history_is_rebuilt_only_from_signed_epoch_receipts():
         "rolling_lead_count": 2,
         "rolling_scores": [{"hotkey": "miner", "score": 10}],
     }
+
+
+def test_signed_sourcing_replays_bans_only_from_one_bound_bans_parent():
+    decision = build_sourcing_decision_v2(
+        epoch_id=99,
+        sequence=0,
+        lead_id_hash=sha256_json({"lead": "banned"}),
+        miner_hotkey="banned",
+        decision="approve",
+        rep_score=4,
+        is_icp_multiplier=0,
+    )
+    source_doc = build_sourcing_epoch_v2(epoch_id=99, decisions=[decision])
+    source_receipt = _sourcing_epoch_receipt(source_doc)
+    snapshot = _snapshot(
+        rolling_lead_count=1,
+        rolling_scores=[{"hotkey": "banned", "score": 4}],
+    )
+    documents = gateway_weight_input_value_documents_v2(
+        calculation_snapshot=snapshot,
+        gateway_authority_event_hash="sha256:" + "2" * 64,
+    )
+    bans_document = {
+        **documents["bans"],
+        "value": {
+            "banned_hotkeys": ["banned"],
+            "banned_lookup_ok": True,
+        },
+    }
+    reader = FakeReader(
+        {
+            "sourcing_epoch_inputs": [
+                {
+                    "epoch_id": 99,
+                    "epoch_hash": source_doc["epoch_hash"],
+                    "receipt_hash": source_receipt["receipt_hash"],
+                    "source_doc": source_doc,
+                    "receipt_doc": source_receipt,
+                },
+            ],
+            "attested_receipt_by_hash": [{"receipt_doc": source_receipt}],
+        }
+    )
+    def resolve_with_bans_graph(graph, parent_hash, persistence_output):
+        context = _context(
+            "research_lab.sourcing_input.v2",
+            parents=(source_receipt["receipt_hash"], parent_hash),
+        )
+        context.external_receipt_graphs = [graph]
+        return CoordinatorWeightSourceV2(reader).resolve(
+            payload=_payload(
+                "sourcing_history",
+                snapshot=snapshot,
+                snapshot_authority_mode=(
+                    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+                ),
+                bans_document=bans_document,
+                bans_persistence_output=persistence_output,
+            ),
+            context=context,
+        )
+
+    (
+        persisted_graph,
+        source_receipts,
+        terminal_receipt,
+        persistence_output,
+    ) = _durable_bans_graph(bans_document)
+
+    document = resolve_with_bans_graph(
+        persisted_graph,
+        terminal_receipt["receipt_hash"],
+        persistence_output,
+    )
+
+    assert document["value"] == {
+        "rolling_lead_count": 1,
+        "rolling_scores": [{"hotkey": "banned", "score": -100000}],
+    }
+
+    direct_graph = build_receipt_graph(
+        root_receipt_hash=source_receipts[0]["receipt_hash"],
+        boot_identities=persisted_graph["boot_identities"],
+        receipts=[source_receipts[0]],
+        transport_attempts=[],
+    )
+    duplicated_graph, _, duplicated_terminal, duplicated_output = _durable_bans_graph(
+        bans_document, source_count=2
+    )
+    forged_graph = copy.deepcopy(persisted_graph)
+    forged_graph["receipts"][0]["enclave_signature"] = "0" * 128
+    wrong_purpose_graph, _, wrong_purpose_terminal, wrong_purpose_output = (
+        _durable_bans_graph(
+            bans_document,
+            source_purpose="research_lab.leaderboard_input.v2",
+        )
+    )
+    wrong_epoch_graph, _, wrong_epoch_terminal, wrong_epoch_output = (
+        _durable_bans_graph(bans_document, source_epoch=99)
+    )
+    wrong_output_graph, _, wrong_output_terminal, wrong_output = _durable_bans_graph(
+        bans_document,
+        source_output={"not": "the-bans-document"},
+    )
+
+    def tamper_persisted_bans(output):
+        output["artifacts"][0]["plaintext_hash"] = sha256_json(
+            {"not": "the-bans-value"}
+        )
+        output["artifact_set_root"] = sha256_json(output["artifacts"])
+        return output
+
+    terminal_output_graph, _, terminal_output, terminal_output_evidence = (
+        _durable_bans_graph(
+            bans_document,
+            persistence_output_mutator=tamper_persisted_bans,
+        )
+    )
+    extra_parent_graph, _, extra_parent_terminal, extra_parent_output = (
+        _durable_bans_graph(bans_document, extra_parent=True)
+    )
+
+    cases = (
+        ("missing", None, None, persistence_output),
+        (
+            "direct ephemeral",
+            direct_graph,
+            source_receipts[0]["receipt_hash"],
+            persistence_output,
+        ),
+        (
+            "duplicated",
+            duplicated_graph,
+            duplicated_terminal["receipt_hash"],
+            duplicated_output,
+        ),
+        (
+            "forged",
+            forged_graph,
+            terminal_receipt["receipt_hash"],
+            persistence_output,
+        ),
+        (
+            "wrong purpose",
+            wrong_purpose_graph,
+            wrong_purpose_terminal["receipt_hash"],
+            wrong_purpose_output,
+        ),
+        (
+            "wrong epoch",
+            wrong_epoch_graph,
+            wrong_epoch_terminal["receipt_hash"],
+            wrong_epoch_output,
+        ),
+        (
+            "output root mismatch",
+            wrong_output_graph,
+            wrong_output_terminal["receipt_hash"],
+            wrong_output,
+        ),
+        (
+            "terminal output mismatch",
+            terminal_output_graph,
+            terminal_output["receipt_hash"],
+            terminal_output_evidence,
+        ),
+        (
+            "extra terminal parent",
+            extra_parent_graph,
+            extra_parent_terminal["receipt_hash"],
+            extra_parent_output,
+        ),
+    )
+    for _label, graph, parent_hash, case_persistence_output in cases:
+        if graph is None:
+            context = _context(
+                "research_lab.sourcing_input.v2",
+                parents=(source_receipt["receipt_hash"],),
+            )
+            context.external_receipt_graphs = []
+            action = lambda: CoordinatorWeightSourceV2(reader).resolve(
+                payload=_payload(
+                    "sourcing_history",
+                    snapshot=snapshot,
+                    snapshot_authority_mode=(
+                        GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+                    ),
+                    bans_document=bans_document,
+                    bans_persistence_output=case_persistence_output,
+                ),
+                context=context,
+            )
+        else:
+            action = lambda graph=graph, parent_hash=parent_hash, case_persistence_output=case_persistence_output: resolve_with_bans_graph(
+                graph,
+                parent_hash,
+                case_persistence_output,
+            )
+        with pytest.raises(CoordinatorWeightSourceV2Error):
+            action()
 
 
 def test_sourcing_history_rejects_undeclared_or_modified_epoch_receipt():

--- a/tests/test_gateway_weight_inputs_client_v2.py
+++ b/tests/test_gateway_weight_inputs_client_v2.py
@@ -6,9 +6,16 @@ import hashlib
 import pytest
 
 from leadpoet_canonical.attested_v2 import sha256_json
+from leadpoet_canonical.hotkey_authority_v2 import (
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+)
 from leadpoet_canonical.weight_authority_v2 import (
     GATEWAY_WEIGHT_INPUT_CATEGORIES,
     WEIGHT_INPUT_PURPOSES,
+)
+from leadpoet_canonical.weight_computation import (
+    WEIGHT_SNAPSHOT_SCHEMA_VERSION,
+    weight_config_hash,
 )
 from validator_tee.host import gateway_weight_inputs_v2 as client_module
 from validator_tee.host.gateway_weight_inputs_v2 import (
@@ -102,6 +109,52 @@ def _calculation():
     }
 
 
+def _full_calculation(**overrides):
+    value = {
+        "schema_version": WEIGHT_SNAPSHOT_SCHEMA_VERSION,
+        "netuid": 71,
+        "epoch_id": 100,
+        "block": 36099,
+        "commit_sha": "a" * 40,
+        "config_hash": "",
+        "parent_receipt_hashes": [],
+        "research_lab_allocation_receipt_hash": "",
+        "burn_target_uid": 0,
+        "expected_burn_target_hotkey": "burn",
+        "metagraph_hotkeys": ["burn", "miner"],
+        "banned_hotkeys": [],
+        "banned_lookup_ok": True,
+        "ff_enabled": True,
+        "base_burn_share": 0.0,
+        "champion_share": 0.0,
+        "champion_uid": None,
+        "effective_champion_share": 0.0,
+        "research_lab_fallback_share": 0.2,
+        "research_lab_allocation_doc": {
+            "lab_cap_percent": 20.0,
+            "unallocated_percent": 20.0,
+            "champion_allocations": [],
+            "queued_champion_allocations": [],
+            "reimbursement_allocations": [],
+            "source_add_allocations": [],
+        },
+        "leaderboard_bonus_share": 0.095,
+        "leaderboard_rank_shares": [0.05, 0.03, 0.015],
+        "leaderboard_entries": [],
+        "leaderboard_fetch_ok": True,
+        "fulfillment_share": 0.705,
+        "fulfillment_rows": [{"hotkey": "miner", "share": 0.705}],
+        "fulfillment_fetch_ok": True,
+        "rolling_lead_count": 0,
+        "rolling_scores": [],
+        "sourcing_floor_threshold": 125000,
+        "min_total_rep_for_distribution": 100,
+    }
+    value.update(overrides)
+    value["config_hash"] = weight_config_hash(value)
+    return value
+
+
 def _response(request):
     authority_hash = "sha256:" + "4" * 64
     allocation_parent = {
@@ -184,6 +237,71 @@ async def test_client_signs_exact_request_and_preserves_complete_receipt_set(mon
     assert len(client.messages) == 1
     assert set(result["input_receipt_hashes"]) == set(GATEWAY_WEIGHT_INPUT_CATEGORIES)
     assert result["gateway_authority_event_hash"] == "sha256:" + "4" * 64
+
+
+@pytest.mark.asyncio
+async def test_client_reconstructs_signed_gateway_measured_authority(monkeypatch):
+    monkeypatch.setattr(client_module, "validate_boot_identity", lambda _value: None)
+    monkeypatch.setattr(
+        client_module, "validate_signed_execution_receipt", lambda _value: None
+    )
+    monkeypatch.setattr(client_module, "validate_transport_attempt", lambda _value: None)
+    monkeypatch.setattr(
+        client_module, "validate_host_operation_record", lambda _value: None
+    )
+    provisional = _full_calculation()
+    authoritative = _full_calculation(
+        banned_hotkeys=["banned"],
+        fulfillment_share=0.6,
+        fulfillment_rows=[{"hotkey": "miner", "share": 0.6}],
+        leaderboard_entries=[{"miner_hotkey": "miner", "wins": 1}],
+        rolling_lead_count=1,
+        rolling_scores=[{"hotkey": "banned", "score": -100000}],
+    )
+    observed = {}
+
+    async def post_json(_url, payload, _timeout):
+        observed.update(payload)
+        response = _response(payload["request"])
+        response.update(
+            {
+                "snapshot_authority_mode": (
+                    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+                ),
+                "authoritative_calculation_snapshot": authoritative,
+                "authoritative_calculation_snapshot_hash": sha256_json(authoritative),
+                "normalized_source_categories": [
+                    "bans",
+                    "fulfillment_rewards",
+                    "leaderboard",
+                    "sourcing_history",
+                ],
+            }
+        )
+        return response
+
+    result = await fetch_gateway_weight_inputs_v2(
+        gateway_url="https://gateway.example",
+        calculation_snapshot=provisional,
+        validator_hotkey=HOTKEY,
+        allocation_hash="sha256:" + "3" * 64,
+        leaderboard_window_start="2026-07-03T20:00:00Z",
+        leaderboard_window_end="2026-07-10T20:00:00Z",
+        client=FakeClient(),
+        post_json=post_json,
+        snapshot_authority_mode=GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+    )
+
+    assert observed["request"]["snapshot_authority_mode"] == (
+        GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+    )
+    assert result["authoritative_calculation_snapshot"] == authoritative
+    assert result["normalized_source_categories"] == [
+        "bans",
+        "fulfillment_rewards",
+        "leaderboard",
+        "sourcing_history",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway_weights_v2.py
+++ b/tests/test_gateway_weights_v2.py
@@ -12,6 +12,7 @@ from leadpoet_canonical.attested_v2 import sha256_json
 from leadpoet_canonical.binding import create_binding_message
 from leadpoet_canonical.hotkey_authority_v2 import (
     DISABLED_LEADERBOARD_WINDOW_V1,
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
     build_weight_inputs_request_v2,
 )
 from leadpoet_canonical.weight_authority_v2 import (
@@ -210,6 +211,7 @@ def _weight_inputs_authorization(
     *,
     leaderboard_window_start: str = "2026-07-03T20:00:00Z",
     leaderboard_window_end: str = "2026-07-10T20:00:00Z",
+    snapshot_authority_mode: str | None = None,
 ):
     calculation = {
         "netuid": 71,
@@ -228,6 +230,7 @@ def _weight_inputs_authorization(
         allocation_hash=calculation["research_lab_allocation_doc"]["allocation_hash"],
         leaderboard_window_start=leaderboard_window_start,
         leaderboard_window_end=leaderboard_window_end,
+        snapshot_authority_mode=snapshot_authority_mode,
     )
     return weights_api.WeightInputsV2Authorization(
         request=request,
@@ -809,6 +812,66 @@ async def test_weight_inputs_v2_authenticates_and_returns_complete_measured_set(
     )
     assert calls[1][1]["leaderboard_window_start"] == "2026-07-03T20:00:00Z"
     assert calls[1][1]["leaderboard_window_end"] == "2026-07-10T20:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_weight_inputs_v2_returns_normalized_authority_only_when_signed(
+    monkeypatch,
+):
+    from gateway.research_lab import attested_v2_store, attested_weight_inputs_v2
+
+    authorization = _weight_inputs_authorization(
+        snapshot_authority_mode=GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+    )
+    authoritative = dict(authorization.calculation_snapshot)
+    expected = {
+        "input_receipt_hashes": {"research_lab_allocation": "sha256:" + "7" * 64},
+        "gateway_authority_event_hash": "sha256:" + "6" * 64,
+        "upstream_receipt_set": {
+            "boot_identities": [],
+            "receipts": [],
+            "transport_attempts": [],
+            "host_operations": [],
+        },
+        "snapshot_authority_mode": GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+        "authoritative_calculation_snapshot": authoritative,
+        "authoritative_calculation_snapshot_hash": sha256_json(authoritative),
+        "normalized_source_categories": [],
+    }
+    observed = {}
+    _patch_epoch_authority(monkeypatch)
+
+    async def load_graph(**_kwargs):
+        return {"root_receipt_hash": "sha256:" + "6" * 64}
+
+    async def build_inputs(**kwargs):
+        observed.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(weights_api, "PRIMARY_VALIDATOR_HOTKEYS", {VALIDATOR_HOTKEY})
+    monkeypatch.setattr(weights_api, "ALLOWED_NETUIDS", {71})
+    monkeypatch.setattr(weights_api, "get_subtensor", lambda: _Subtensor())
+    monkeypatch.setattr(weights_api, "verify_wallet_signature", lambda *args: True)
+    monkeypatch.setattr(weights_api, "_WEIGHT_INPUT_LOADS_INFLIGHT", {})
+    monkeypatch.setattr(weights_api, "_WEIGHT_INPUT_RESULTS", {})
+    monkeypatch.setattr(
+        attested_v2_store, "load_business_artifact_graph_v2", load_graph
+    )
+    monkeypatch.setattr(
+        attested_weight_inputs_v2, "build_gateway_weight_inputs_v2", build_inputs
+    )
+
+    response = await weights_api.get_weight_inputs_v2(authorization, _request())
+    response_doc = json.loads(response.body)
+
+    assert observed["snapshot_authority_mode"] == (
+        GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+    )
+    assert response_doc["snapshot_authority_mode"] == (
+        GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+    )
+    assert response_doc["authoritative_calculation_snapshot"] == authoritative
+    assert response_doc["normalized_source_categories"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_hotkey_authority_v2.py
+++ b/tests/test_hotkey_authority_v2.py
@@ -8,6 +8,7 @@ import pytest
 from leadpoet_canonical.hotkey_authority_v2 import (
     APPLICATION_SIGNATURE_SCHEMA_VERSION,
     CHAIN_SIGNING_PROFILE_SCHEMA_VERSION,
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
     HotkeyAuthorityV2Error,
     MAX_WEIGHT_TRANSPORT_LOGICAL_BYTES,
     build_application_signature_request_v2,
@@ -500,6 +501,49 @@ def test_weight_input_request_rejects_other_hotkeys_and_inverted_windows():
         classify_application_message_v2(
             weight_inputs_request_message_v2(request).encode("utf-8"),
             validator_hotkey=HOTKEY,
+        )
+
+
+def test_weight_input_request_signed_measured_mode_isolated_from_legacy():
+    legacy = build_weight_inputs_request_v2(
+        validator_hotkey=HOTKEY,
+        netuid=71,
+        epoch_id=23860,
+        block=8589630,
+        calculation_snapshot_hash="sha256:" + "1" * 64,
+        allocation_hash="sha256:" + "2" * 64,
+        leaderboard_window_start="2026-07-03T20:00:00Z",
+        leaderboard_window_end="2026-07-10T20:00:00Z",
+    )
+    normalized = build_weight_inputs_request_v2(
+        validator_hotkey=HOTKEY,
+        netuid=71,
+        epoch_id=23860,
+        block=8589630,
+        calculation_snapshot_hash="sha256:" + "1" * 64,
+        allocation_hash="sha256:" + "2" * 64,
+        leaderboard_window_start="2026-07-03T20:00:00Z",
+        leaderboard_window_end="2026-07-10T20:00:00Z",
+        snapshot_authority_mode=GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+    )
+
+    assert "snapshot_authority_mode" not in legacy
+    assert normalized["snapshot_authority_mode"] == (
+        GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+    )
+    assert normalized["request_hash"] != legacy["request_hash"]
+    assert validate_weight_inputs_request_v2(normalized) == normalized
+    with pytest.raises(HotkeyAuthorityV2Error, match="mode is invalid"):
+        build_weight_inputs_request_v2(
+            validator_hotkey=HOTKEY,
+            netuid=71,
+            epoch_id=23860,
+            block=8589630,
+            calculation_snapshot_hash="sha256:" + "1" * 64,
+            allocation_hash="sha256:" + "2" * 64,
+            leaderboard_window_start="2026-07-03T20:00:00Z",
+            leaderboard_window_end="2026-07-10T20:00:00Z",
+            snapshot_authority_mode="untrusted-authority",
         )
 
 

--- a/tests/test_sourcing_history_v2.py
+++ b/tests/test_sourcing_history_v2.py
@@ -122,3 +122,28 @@ def test_rolling_window_excludes_current_and_old_epochs_exactly():
     )
     assert scores == {"miner": 169}
     assert count == 2
+
+
+def test_ban_aware_replay_penalizes_present_rows_without_mutating_epochs():
+    epoch_10 = build_sourcing_epoch_v2(
+        epoch_id=10,
+        decisions=[_decision(0, "banned", "approve", 40, 0, epoch=10)],
+    )
+    epoch_11 = build_sourcing_epoch_v2(
+        epoch_id=11,
+        decisions=[_decision(0, "banned", "approve", 20, 0, epoch=11)],
+    )
+    original_10 = copy.deepcopy(epoch_10)
+    original_11 = copy.deepcopy(epoch_11)
+
+    scores, count = rolling_sourcing_history_v2(
+        current_epoch=12,
+        epochs=[epoch_10, epoch_11],
+        banned_hotkeys=["banned", "absent"],
+    )
+
+    assert scores == {"banned": -200_000}
+    assert "absent" not in scores
+    assert count == 2
+    assert epoch_10 == original_10
+    assert epoch_11 == original_11

--- a/tests/test_validator_weight_authority_v2.py
+++ b/tests/test_validator_weight_authority_v2.py
@@ -29,6 +29,7 @@ from leadpoet_canonical.attested_v2 import (
 )
 from leadpoet_canonical.binding import create_binding_message
 from leadpoet_canonical.hotkey_authority_v2 import (
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
     build_application_signature_request_v2,
 )
 from leadpoet_canonical.weight_authority_v2 import (
@@ -733,6 +734,55 @@ def test_validator_authority_computes_and_signs_exact_canonical_weights():
         fixture["validator_boot"]["boot_identity_hash"]: True,
         fixture["gateway_boot"]["boot_identity_hash"]: True,
     }
+
+
+def test_validator_authority_rechecks_signed_gateway_measured_overlay():
+    fixture = _fixture()
+    authoritative = copy.deepcopy(fixture["request"]["calculation_snapshot"])
+    request = {
+        **fixture["request"],
+        "snapshot_authority_mode": GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+        "authoritative_calculation_snapshot": authoritative,
+        "authoritative_calculation_snapshot_hash": sha256_json(authoritative),
+        "normalized_source_categories": [],
+    }
+
+    value = fixture["authority"].compute(request)
+
+    finalized_authoritative = {
+        **authoritative,
+        "parent_receipt_hashes": sorted(
+            value["weight_snapshot"]["input_receipt_hashes"].values()
+        ),
+        "research_lab_allocation_receipt_hash": value["weight_snapshot"][
+            "input_receipt_hashes"
+        ]["research_lab_allocation"],
+    }
+    assert value["weight_snapshot"]["calculation_snapshot"] == (
+        finalized_authoritative
+    )
+    assert value["weight_result"] == compute_final_weights(
+        finalized_authoritative
+    )
+
+    forged = copy.deepcopy(request)
+    forged_authoritative = copy.deepcopy(authoritative)
+    forged_authoritative.update(
+        {
+            "banned_hotkeys": ["source-hotkey"],
+            "rolling_lead_count": 1,
+            "rolling_scores": [
+                {"hotkey": "source-hotkey", "score": -100000}
+            ],
+        }
+    )
+    forged["authoritative_calculation_snapshot"] = forged_authoritative
+    forged["authoritative_calculation_snapshot_hash"] = sha256_json(
+        forged_authoritative
+    )
+    forged["normalized_source_categories"] = ["bans", "sourcing_history"]
+    with pytest.raises(ValidatorWeightAuthorityV2Error):
+        fixture["authority"].compute(forged)
 
 
 def test_validator_authority_preserves_approved_historical_validator_ancestry():

--- a/tests/test_weight_authority_v2.py
+++ b/tests/test_weight_authority_v2.py
@@ -56,6 +56,7 @@ from leadpoet_canonical.weight_authority_v2 import (
     weight_input_output_roots_v2,
     weight_input_value_documents_v2,
     gateway_weight_input_value_documents_v2,
+    normalize_gateway_measured_weight_inputs_v2,
 )
 from leadpoet_canonical.weight_computation import (
     WEIGHT_SNAPSHOT_SCHEMA_VERSION,
@@ -494,6 +495,79 @@ def _bundle(*, category_purpose_override=None, category_output_override=None):
         "weights_signature": weight_key.sign(bytes.fromhex(result["weights_hash"])).hex(),
         "receipt_graph": graph,
     }
+
+
+def test_signed_gateway_normalizer_overlays_only_measured_dynamic_fields():
+    snapshot = _calculation_snapshot([], "")
+    authority_hash = sha256_json({"epoch": snapshot["epoch_id"]})
+    measured = gateway_weight_input_value_documents_v2(
+        calculation_snapshot=snapshot,
+        gateway_authority_event_hash=authority_hash,
+    )
+    measured = {
+        category: copy.deepcopy(measured[category])
+        for category in (
+            "bans",
+            "fulfillment_rewards",
+            "leaderboard",
+            "sourcing_history",
+        )
+    }
+    measured["bans"]["value"] = {
+        "banned_hotkeys": ["source-hotkey"],
+        "banned_lookup_ok": True,
+    }
+    measured["fulfillment_rewards"]["value"] = {
+        "fulfillment_share": 0.6,
+        "fulfillment_rows": [
+            {"hotkey": "fulfillment-hotkey", "share": 0.5},
+            {"hotkey": "lab-hotkey", "share": 0.1},
+        ],
+        "fulfillment_fetch_ok": True,
+    }
+    measured["leaderboard"]["value"]["leaderboard_entries"] = [
+        {"miner_hotkey": "lab-hotkey", "wins": 1}
+    ]
+    measured["sourcing_history"]["value"] = {
+        "rolling_lead_count": 125_000,
+        "rolling_scores": [{"hotkey": "source-hotkey", "score": -100_000}],
+    }
+
+    normalized = normalize_gateway_measured_weight_inputs_v2(
+        calculation_snapshot=snapshot,
+        measured_documents=measured,
+        gateway_authority_event_hash=authority_hash,
+    )
+    authoritative = normalized["authoritative_calculation_snapshot"]
+    assert normalized["normalized_source_categories"] == [
+        "bans",
+        "fulfillment_rewards",
+        "leaderboard",
+        "sourcing_history",
+    ]
+    assert authoritative["research_lab_allocation_doc"] == snapshot[
+        "research_lab_allocation_doc"
+    ]
+    assert authoritative["banned_hotkeys"] == ["source-hotkey"]
+    assert authoritative["fulfillment_rows"] == measured["fulfillment_rewards"][
+        "value"
+    ]["fulfillment_rows"]
+    assert compute_final_weights(authoritative)["weights_hash"]
+    regenerated = gateway_weight_input_value_documents_v2(
+        calculation_snapshot=authoritative,
+        gateway_authority_event_hash=authority_hash,
+    )
+    for category, document in measured.items():
+        assert regenerated[category] == document
+
+    tampered = copy.deepcopy(measured)
+    tampered["leaderboard"]["value"]["leaderboard_bonus_share"] = 0.1
+    with pytest.raises(WeightAuthorityV2Error, match="immutable field"):
+        normalize_gateway_measured_weight_inputs_v2(
+            calculation_snapshot=snapshot,
+            measured_documents=tampered,
+            gateway_authority_event_hash=authority_hash,
+        )
 
 
 def test_complete_v2_weight_authority_graph_validates():

--- a/validator_tee/enclave/protected_workflows_v2.json
+++ b/validator_tee/enclave/protected_workflows_v2.json
@@ -387,6 +387,11 @@
       "symbol": "validate_compact_weight_submission_shape_v2"
     },
     {
+      "ast_sha256": "sha256:909e3844e13605252787c525a626f5125400c2f97502d456f5bd395031ebedc1",
+      "path": "leadpoet_canonical/hotkey_authority_v2.py",
+      "symbol": "GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2"
+    },
+    {
       "ast_sha256": "sha256:4e9d832cf6e7c722c578ce1dff953194f292df3ec6e0b56cbc3901869ef6e410",
       "path": "leadpoet_canonical/hotkey_authority_v2.py",
       "symbol": "build_application_signature_request_v2"
@@ -400,6 +405,11 @@
       "ast_sha256": "sha256:f4aa084acd0bded8b3ca7a141771adb79e31b7d0380dd59d15c33cdb36a84e88",
       "path": "leadpoet_canonical/hotkey_authority_v2.py",
       "symbol": "build_weight_extrinsic_authorization_v2"
+    },
+    {
+      "ast_sha256": "sha256:9c3fb03ceca70d1d63d16115296be740c25a41485c8873ab64462305b45478da",
+      "path": "leadpoet_canonical/hotkey_authority_v2.py",
+      "symbol": "build_weight_inputs_request_v2"
     },
     {
       "ast_sha256": "sha256:db570f46bfffec5408436ca84e724dad379c29e598b277785e567fd651ccf140",
@@ -452,6 +462,11 @@
       "symbol": "validate_weight_extrinsic_authorization_v2"
     },
     {
+      "ast_sha256": "sha256:ca3d6da2d4143cef596bd0cfad85ea69125cc56e13caaa28a2207a96e4319a93",
+      "path": "leadpoet_canonical/hotkey_authority_v2.py",
+      "symbol": "validate_weight_inputs_request_v2"
+    },
+    {
       "ast_sha256": "sha256:8a525238de87dc028703ee21d79c7a7f4e563bc15b66a405fe6b8b48040e1960",
       "path": "leadpoet_canonical/hotkey_authority_v2.py",
       "symbol": "validate_weight_transport_authorization_v2"
@@ -467,6 +482,16 @@
       "symbol": "decrypt_kms_recipient_ciphertext"
     },
     {
+      "ast_sha256": "sha256:a7ca9b2cf159d66a64d453895ddd3d316101f169d932c940e7a94e77ba3046d8",
+      "path": "leadpoet_canonical/sourcing_history_v2.py",
+      "symbol": "SOURCING_BANNED_HOTKEY_PENALTY_V2"
+    },
+    {
+      "ast_sha256": "sha256:e9c971d8e6c66fe2048bed5a73c46606be16568758dd6129bca76e56927bbdc6",
+      "path": "leadpoet_canonical/sourcing_history_v2.py",
+      "symbol": "rolling_sourcing_history_v2"
+    },
+    {
       "ast_sha256": "sha256:9da83659412c65a826b0c1e9c6aa9d7b9cce7bf255ae164fc120ea09f0641378",
       "path": "leadpoet_canonical/weight_authority_v2.py",
       "symbol": "build_weight_snapshot_v2"
@@ -475,6 +500,11 @@
       "ast_sha256": "sha256:1f522a1f8ac8edbd984c0ef39606574b2a9dd0595b7bdb95ec7de1ebdbc44105",
       "path": "leadpoet_canonical/weight_authority_v2.py",
       "symbol": "gateway_weight_input_value_documents_v2"
+    },
+    {
+      "ast_sha256": "sha256:b1c299b7319f5a9965c2178b2b5106ec3189e575bcd5ab17cd006e83eacbf411",
+      "path": "leadpoet_canonical/weight_authority_v2.py",
+      "symbol": "normalize_gateway_measured_weight_inputs_v2"
     },
     {
       "ast_sha256": "sha256:d20544a7f9e324c4edb69c7168a5df059ac835d64e7737896ad524f215fbffd8",
@@ -577,7 +607,7 @@
       "symbol": "Validator.__init__"
     },
     {
-      "ast_sha256": "sha256:c239545f80c82f50a63737a15976e9750b5a1a62d8dd1b016741fa96d9384e2f",
+      "ast_sha256": "sha256:f5d72650c9aca92237e832be06c02847a08f769e7099353e3ed2568c88bb7286",
       "path": "neurons/validator.py",
       "symbol": "Validator._authorize_and_set_weights_v2"
     },
@@ -712,7 +742,7 @@
       "symbol": "ValidatorHotkeyAuthorityV2.sign_weight_extrinsic"
     },
     {
-      "ast_sha256": "sha256:feca10f176af52c6fc3811bea7257fca2a31c695ebd2b59ad30e9f207f05b3b5",
+      "ast_sha256": "sha256:770791383c7422205633b8c09e7b91c4984f7aff5c27b7ed43d7e7c589d6dbc7",
       "path": "validator_tee/enclave/weight_authority_v2.py",
       "symbol": "ValidatorWeightAuthorityV2.compute"
     },
@@ -742,7 +772,7 @@
       "symbol": "finalize_authoritative_weight_publication_v2"
     },
     {
-      "ast_sha256": "sha256:68a8e63a76912bc3e1301bacc437ea88f3606cb6123eb78019987cea2b73ef7c",
+      "ast_sha256": "sha256:32c25a57a7fb702a13a504f941b74b20c71ab0269b9612030c0d6a380df7f51a",
       "path": "validator_tee/host/authoritative_weight_flow_v2.py",
       "symbol": "prepare_authoritative_weight_publication_v2"
     },
@@ -757,7 +787,7 @@
       "symbol": "_validate_compact_ancestry"
     },
     {
-      "ast_sha256": "sha256:45f0d92aff4c65e17d0b02e94d97b161dfc50f5e8f3b9224fd06dd1d16ba06f1",
+      "ast_sha256": "sha256:58981cc0ccba657fcd0c48fddeadd58e1e144ac4ba3306e79d8d521aa481a74c",
       "path": "validator_tee/host/gateway_weight_inputs_v2.py",
       "symbol": "fetch_gateway_weight_inputs_v2"
     },
@@ -802,7 +832,7 @@
       "symbol": "normalize_weight_protocol"
     }
   ],
-  "manifest_hash": "sha256:7622b35a315359a2b8d408d6006f47156f0dd4ba1f9045fe35979dcf0405ea2c",
+  "manifest_hash": "sha256:89199e5e6828d5b4d2c9e8a1a34bf352292f2699449b287c56b4e83f1a45710b",
   "protected_source_commit": "5d90b4807cd57f4cb166773828c9c74e93b5ccb9",
   "schema_version": "leadpoet.validator_protected_workflows.v2"
 }

--- a/validator_tee/enclave/weight_authority_v2.py
+++ b/validator_tee/enclave/weight_authority_v2.py
@@ -34,11 +34,17 @@ from leadpoet_canonical.compact_weight_authority_v2 import (
     compact_gateway_frontier_receipt_hashes_v2,
     validate_compact_weight_ancestry_v2,
 )
+from leadpoet_canonical.hotkey_authority_v2 import (
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
+)
 from leadpoet_canonical.weight_authority_v2 import (
+    GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2,
     GATEWAY_WEIGHT_INPUT_CATEGORIES,
     VALIDATOR_WEIGHT_INPUT_CATEGORIES,
     WEIGHT_INPUT_PURPOSES,
     build_weight_snapshot_v2,
+    gateway_weight_input_value_documents_v2,
+    normalize_gateway_measured_weight_inputs_v2,
     validate_weight_input_source_evidence_v2,
     weight_input_value_documents_v2,
 )
@@ -102,13 +108,31 @@ class ValidatorWeightAuthorityV2:
             "upstream_ancestry_proofs",
             "upstream_transport_attempts",
         }
+        normalized_fields = {
+            "snapshot_authority_mode",
+            "authoritative_calculation_snapshot",
+            "authoritative_calculation_snapshot_hash",
+            "normalized_source_categories",
+        }
+        normalized_full_fields = full_fields | normalized_fields
+        normalized_compact_fields = compact_fields | normalized_fields
         request_fields = set(request) if isinstance(request, Mapping) else set()
         if (
             not isinstance(request, Mapping)
-            or request_fields not in (full_fields, compact_fields)
+            or request_fields
+            not in (
+                full_fields,
+                compact_fields,
+                normalized_full_fields,
+                normalized_compact_fields,
+            )
         ):
             raise ValidatorWeightAuthorityV2Error("weight authority request fields are invalid")
-        compact_transport = request_fields == compact_fields
+        compact_transport = request_fields in (compact_fields, normalized_compact_fields)
+        normalized_mode = request_fields in (
+            normalized_full_fields,
+            normalized_compact_fields,
+        )
         boot = dict(self._boot_identity_supplier())
         validate_boot_identity(boot)
         if boot.get("role") != "validator_weights":
@@ -118,7 +142,68 @@ class ValidatorWeightAuthorityV2:
             raise ValidatorWeightAuthorityV2Error(
                 "gateway weight input categories are incomplete"
             )
-        proposed_calculation = dict(request["calculation_snapshot"])
+        provisional_calculation = dict(request["calculation_snapshot"])
+        proposed_calculation = dict(provisional_calculation)
+        if normalized_mode:
+            if (
+                request.get("snapshot_authority_mode")
+                != GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+            ):
+                raise ValidatorWeightAuthorityV2Error(
+                    "weight authority normalized mode is invalid"
+                )
+            authoritative = request.get("authoritative_calculation_snapshot")
+            authoritative_hash = str(
+                request.get("authoritative_calculation_snapshot_hash") or ""
+            )
+            categories = request.get("normalized_source_categories")
+            if (
+                not isinstance(authoritative, Mapping)
+                or sha256_json(authoritative) != authoritative_hash
+                or not isinstance(categories, list)
+                or any(not isinstance(category, str) for category in categories)
+                or categories != sorted(set(categories))
+                or not set(categories).issubset(
+                    GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2
+                )
+            ):
+                raise ValidatorWeightAuthorityV2Error(
+                    "weight authority normalized response is invalid"
+                )
+            try:
+                measured_documents = {
+                    category: gateway_weight_input_value_documents_v2(
+                        calculation_snapshot=authoritative,
+                        gateway_authority_event_hash=str(
+                            request["gateway_authority_event_hash"]
+                        ),
+                    )[category]
+                    for category in sorted(
+                        GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2
+                    )
+                }
+                normalized = normalize_gateway_measured_weight_inputs_v2(
+                    calculation_snapshot=provisional_calculation,
+                    measured_documents=measured_documents,
+                    gateway_authority_event_hash=str(
+                        request["gateway_authority_event_hash"]
+                    ),
+                )
+            except Exception as exc:
+                raise ValidatorWeightAuthorityV2Error(
+                    "weight authority normalized calculation is invalid"
+                ) from exc
+            if (
+                dict(authoritative)
+                != normalized["authoritative_calculation_snapshot"]
+                or authoritative_hash
+                != normalized["authoritative_calculation_snapshot_hash"]
+                or categories != normalized["normalized_source_categories"]
+            ):
+                raise ValidatorWeightAuthorityV2Error(
+                    "weight authority normalized calculation differs"
+                )
+            proposed_calculation = dict(authoritative)
         try:
             chain_snapshot = self._chain_source.read_finalized_snapshot(
                 netuid=int(proposed_calculation["netuid"]),
@@ -231,7 +316,7 @@ class ValidatorWeightAuthorityV2:
                     "weight input receipt role/purpose differs: %s" % category
                 )
             if int(receipt.get("epoch_id", -1)) != int(
-                request["calculation_snapshot"]["epoch_id"]
+                provisional_calculation["epoch_id"]
             ):
                 raise ValidatorWeightAuthorityV2Error(
                     "weight input receipt epoch differs: %s" % category

--- a/validator_tee/host/authoritative_weight_flow_v2.py
+++ b/validator_tee/host/authoritative_weight_flow_v2.py
@@ -19,6 +19,7 @@ from leadpoet_canonical.compact_weight_authority_v2 import (
     compact_weight_bundle_hash_v2,
 )
 from leadpoet_canonical.hotkey_authority_v2 import (
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
     MAX_WEIGHT_TRANSPORT_LOGICAL_BYTES,
     MAX_WEIGHT_TRANSPORT_WIRE_BYTES,
     build_weight_transport_authorization_v2,
@@ -34,7 +35,10 @@ from validator_tee.host.weight_authority_v2 import (
     build_compact_weight_submission_v2,
     build_stateful_epoch_evidence_v1,
 )
-from leadpoet_canonical.weight_computation import normalize_to_u16_with_uids_pure
+from leadpoet_canonical.weight_computation import (
+    compute_final_weights,
+    normalize_to_u16_with_uids_pure,
+)
 from leadpoet_canonical.weight_authority_v2 import (
     build_weight_finalization_submission_v2,
     validate_published_weight_bundle_v2,
@@ -311,11 +315,34 @@ async def prepare_authoritative_weight_publication_v2(
     before_publish: Optional[Callable[[Mapping[str, Any]], Any]] = None,
     input_timeout_seconds: float = 90.0,
     publication_timeout_seconds: float = 600.0,
+    snapshot_authority_mode: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build, publish, and return the only vector authorized for chain use."""
 
     enclave_client = client or ValidatorEnclaveClient()
     calculation = dict(calculation_snapshot)
+    normalized_mode = (
+        snapshot_authority_mode == GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+    )
+    if snapshot_authority_mode is not None and not normalized_mode:
+        raise AuthoritativeWeightFlowV2Error(
+            "weight publication snapshot authority mode is invalid"
+        )
+    if normalized_mode:
+        # The caller's vector is only evidence about the signed provisional
+        # snapshot.  Prove that claim before allowing measured gateway values
+        # to replace the explicitly bounded mutable fields.
+        try:
+            provisional_result = compute_final_weights(calculation)
+            _verify_host_vector(
+                host_uids=host_uids,
+                host_weights=host_weights,
+                enclave_result=provisional_result,
+            )
+        except Exception as exc:
+            raise AuthoritativeWeightFlowV2Error(
+                "caller vector differs from canonical provisional calculation"
+            ) from exc
     try:
         gateway_endpoint = _gateway_endpoint(gateway_url)
     except Exception as exc:
@@ -330,6 +357,7 @@ async def prepare_authoritative_weight_publication_v2(
             leaderboard_window_end=leaderboard_window_end,
             client=enclave_client,
             timeout_seconds=input_timeout_seconds,
+            snapshot_authority_mode=snapshot_authority_mode,
         )
         weight_request = {
             "validator_hotkey": validator_hotkey,
@@ -339,6 +367,23 @@ async def prepare_authoritative_weight_publication_v2(
                 "gateway_authority_event_hash"
             ],
         }
+        if normalized_mode:
+            normalized_fields = {
+                "snapshot_authority_mode",
+                "authoritative_calculation_snapshot",
+                "authoritative_calculation_snapshot_hash",
+                "normalized_source_categories",
+            }
+            if not normalized_fields.issubset(set(gateway_inputs)):
+                raise AuthoritativeWeightFlowV2Error(
+                    "gateway normalized weight inputs are incomplete"
+                )
+            weight_request.update(
+                {
+                    field: gateway_inputs[field]
+                    for field in sorted(normalized_fields)
+                }
+            )
         if "upstream_ancestry_proofs" in gateway_inputs:
             weight_request.update(
                 {
@@ -358,11 +403,26 @@ async def prepare_authoritative_weight_publication_v2(
             enclave_client.compute_authoritative_weights_v2,
             weight_request,
         )
-        _verify_host_vector(
-            host_uids=host_uids,
-            host_weights=host_weights,
-            enclave_result=enclave_response["weight_result"],
-        )
+        if normalized_mode:
+            try:
+                authoritative_result = compute_final_weights(
+                    gateway_inputs["authoritative_calculation_snapshot"]
+                )
+                _verify_host_vector(
+                    host_uids=authoritative_result["uids"],
+                    host_weights=authoritative_result["weights"],
+                    enclave_result=enclave_response["weight_result"],
+                )
+            except Exception as exc:
+                raise AuthoritativeWeightFlowV2Error(
+                    "authoritative host and enclave vectors differ"
+                ) from exc
+        else:
+            _verify_host_vector(
+                host_uids=host_uids,
+                host_weights=host_weights,
+                enclave_result=enclave_response["weight_result"],
+            )
         boot = enclave_response["boot_identity"]
         compact = "receipt_graph_delta" in enclave_response
         graph = (

--- a/validator_tee/host/gateway_weight_inputs_v2.py
+++ b/validator_tee/host/gateway_weight_inputs_v2.py
@@ -18,12 +18,16 @@ from leadpoet_canonical.attested_v2 import (
     validate_transport_attempt,
 )
 from leadpoet_canonical.hotkey_authority_v2 import (
+    GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2,
     build_weight_inputs_request_v2,
     weight_inputs_request_message_v2,
 )
 from leadpoet_canonical.weight_authority_v2 import (
+    GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2,
     GATEWAY_WEIGHT_INPUT_CATEGORIES,
     WEIGHT_INPUT_PURPOSES,
+    gateway_weight_input_value_documents_v2,
+    normalize_gateway_measured_weight_inputs_v2,
 )
 from validator_tee.host.vsock_client import ValidatorEnclaveClient
 from leadpoet_observability import (
@@ -375,10 +379,18 @@ async def fetch_gateway_weight_inputs_v2(
     # which does force a rebuild and compounds the delay.
     max_attempts: int = 10,
     retry_delay_seconds: float = 2.0,
+    snapshot_authority_mode: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Request one exact, enclave-signed gateway input set and verify its shape."""
 
     calculation = dict(calculation_snapshot)
+    normalized_mode = (
+        snapshot_authority_mode == GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2
+    )
+    if snapshot_authority_mode is not None and not normalized_mode:
+        raise GatewayWeightInputsV2Error(
+            "gateway V2 weight input snapshot authority mode is invalid"
+        )
     runtime_sha = str(
         os.environ.get("GITHUB_SHA")
         or os.environ.get("GIT_COMMIT")
@@ -409,6 +421,7 @@ async def fetch_gateway_weight_inputs_v2(
             allocation_hash=allocation_hash,
             leaderboard_window_start=leaderboard_window_start,
             leaderboard_window_end=leaderboard_window_end,
+            snapshot_authority_mode=snapshot_authority_mode,
         )
     except Exception as exc:
         raise GatewayWeightInputsV2Error(
@@ -521,10 +534,24 @@ async def fetch_gateway_weight_inputs_v2(
         "upstream_ancestry_proofs",
         "upstream_transport_attempts",
     }
+    normalized_fields = {
+        "snapshot_authority_mode",
+        "authoritative_calculation_snapshot",
+        "authoritative_calculation_snapshot_hash",
+        "normalized_source_categories",
+    }
+    normalized_full_fields = full_fields | normalized_fields
+    normalized_compact_fields = compact_fields | normalized_fields
     response_fields = set(response) if isinstance(response, Mapping) else set()
     if (
         not isinstance(response, Mapping)
-        or response_fields not in (full_fields, compact_fields)
+        or response_fields
+        not in (
+            full_fields,
+            compact_fields,
+            normalized_full_fields,
+            normalized_compact_fields,
+        )
     ):
         raise GatewayWeightInputsV2Error("gateway V2 weight input response fields are invalid")
     if (
@@ -551,7 +578,76 @@ async def fetch_gateway_weight_inputs_v2(
         "gateway_authority_event_hash": authority_hash,
         "request_authorization": dict(signature_result),
     }
-    if response_fields == full_fields:
+    if normalized_mode:
+        if response_fields not in (normalized_full_fields, normalized_compact_fields):
+            raise GatewayWeightInputsV2Error(
+                "gateway V2 normalized response fields are invalid"
+            )
+        if response.get("snapshot_authority_mode") != snapshot_authority_mode:
+            raise GatewayWeightInputsV2Error(
+                "gateway V2 normalized response mode differs from request"
+            )
+        authoritative = response.get("authoritative_calculation_snapshot")
+        authoritative_hash = str(
+            response.get("authoritative_calculation_snapshot_hash") or ""
+        )
+        categories = response.get("normalized_source_categories")
+        if (
+            not isinstance(authoritative, Mapping)
+            or sha256_json(authoritative) != authoritative_hash
+            or not isinstance(categories, list)
+            or any(not isinstance(category, str) for category in categories)
+            or categories != sorted(set(categories))
+            or not set(categories).issubset(
+                GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2
+            )
+        ):
+            raise GatewayWeightInputsV2Error(
+                "gateway V2 normalized response authority is invalid"
+            )
+        try:
+            authoritative_documents = gateway_weight_input_value_documents_v2(
+                calculation_snapshot=authoritative,
+                gateway_authority_event_hash=authority_hash,
+            )
+            measured_documents = {
+                category: authoritative_documents[category]
+                for category in sorted(
+                    GATEWAY_MEASURED_NORMALIZATION_CATEGORIES_V2
+                )
+            }
+            normalized = normalize_gateway_measured_weight_inputs_v2(
+                calculation_snapshot=calculation,
+                measured_documents=measured_documents,
+                gateway_authority_event_hash=authority_hash,
+            )
+        except Exception as exc:
+            raise GatewayWeightInputsV2Error(
+                "gateway V2 normalized authority does not reproduce canonically"
+            ) from exc
+        if (
+            dict(authoritative)
+            != normalized["authoritative_calculation_snapshot"]
+            or authoritative_hash
+            != normalized["authoritative_calculation_snapshot_hash"]
+            or categories != normalized["normalized_source_categories"]
+        ):
+            raise GatewayWeightInputsV2Error(
+                "gateway V2 normalized authority differs from canonical overlay"
+            )
+        result.update(
+            {
+                "snapshot_authority_mode": snapshot_authority_mode,
+                "authoritative_calculation_snapshot": dict(authoritative),
+                "authoritative_calculation_snapshot_hash": authoritative_hash,
+                "normalized_source_categories": list(categories),
+            }
+        )
+    elif response_fields in (normalized_full_fields, normalized_compact_fields):
+        raise GatewayWeightInputsV2Error(
+            "gateway V2 returned normalized authority without signed selection"
+        )
+    if response_fields in (full_fields, normalized_full_fields):
         receipt_set = _validate_receipt_set(
             value=response["upstream_receipt_set"],
             input_receipt_hashes=input_hashes,

--- a/validator_tee/host/protected_workflows_v2.py
+++ b/validator_tee/host/protected_workflows_v2.py
@@ -113,6 +113,7 @@ PROTECTED_SYMBOLS = {
     ),
     "leadpoet_canonical/weight_authority_v2.py": (
         "gateway_weight_input_value_documents_v2",
+        "normalize_gateway_measured_weight_inputs_v2",
         "weight_input_value_documents_v2",
         "validate_weight_input_source_evidence_v2",
         "build_weight_snapshot_v2",
@@ -120,6 +121,9 @@ PROTECTED_SYMBOLS = {
         "validate_weight_finalization_submission_v2",
     ),
     "leadpoet_canonical/hotkey_authority_v2.py": (
+        "GATEWAY_MEASURED_SNAPSHOT_AUTHORITY_MODE_V2",
+        "build_weight_inputs_request_v2",
+        "validate_weight_inputs_request_v2",
         "validate_chain_signing_profile",
         "chain_signing_profiles",
         "select_chain_signing_profile",
@@ -135,6 +139,10 @@ PROTECTED_SYMBOLS = {
         "classify_application_message_v2",
         "build_application_signature_request_v2",
         "validate_application_signature_request_v2",
+    ),
+    "leadpoet_canonical/sourcing_history_v2.py": (
+        "SOURCING_BANNED_HOTKEY_PENALTY_V2",
+        "rolling_sourcing_history_v2",
     ),
     "leadpoet_canonical/auditor_v2.py": (
         "verify_attested_weight_bundle_v2",


### PR DESCRIPTION
## Summary

- triage the 35 unique Sentry issues observed in project `4511844334239744` over 14 days
- fix Sentry issue `7648740574`, where provisional validator weight inputs drift from gateway-measured bans, fulfillment rewards, and sourcing history
- add optional signed `snapshot_authority_mode="gateway-measured-v2"` while preserving the legacy wire contract
- limit mutation to the nine measured ban, fulfillment, leaderboard, and sourcing fields
- verify provisional inputs, recompute at the gateway, independently bind receipts/vector in the enclave, and publish only the enclave-authorized result
- persist strict artifacts and extend restart-rehearsal coverage

## Sentry assessment

The full classification is recorded in `sentry-weight-input-authorityv1.md`. The other issues were classified as current-main fixes pending rollout evidence, downstream fail-closed operational symptoms, superseded Research Lab failures, or a bad manual probe. This PR does not suppress those events or mark any Sentry issue resolved.

## Verification performed

- focused product slice: 247 passed
- restart rehearsal integrity: 112 passed
- broad adjacent regression set: 257 passed after binding the disposable clone's exact `origin/main` ref
- 30 touched Python files compiled
- protected manifests validated
- `git diff --check origin/main..HEAD` passed
- live deployed `99fb514e` build/authority health and its Deploy Checks / Attested V2 Release workflows were verified before push

## Known blocker

The official exact `prepush` rehearsal is **not green**. The latest run confirmed the workflow Git-trust and output-ownership repairs, but fixture archive generation still invokes Git in a container entrypoint that does not trust the exact read-only `/source` mount. That prevents gateway/validator stages from being exercised. Per operator direction, testing and remediation stopped and this PR is intentionally a draft.

No deployment, restart, production mutation, chain submission, or Sentry resolution was performed.