### PR TITLE
Preserve validator activation evidence ledger order

### DIFF
--- a/tests/restart_rehearsal/verify_evidence.py
+++ b/tests/restart_rehearsal/verify_evidence.py
@@ -144,6 +144,21 @@ def events(
     return sorted(rows, key=lambda row: int(row.get("at_ns") or 0))
 
 
+def serialized_adapter_events(
+    state_root: Path = Path("/rehearsal-state"),
+) -> list[dict]:
+    """Return adapter events in their authoritative append order."""
+
+    path = state_root / "events.jsonl"
+    if not path.is_file():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
 def require_order(values: list[str], required: list[str]) -> None:
     cursor = -1
     for expected in required:
@@ -1740,7 +1755,7 @@ def main() -> int:
             raise SystemExit("gateway did not start the exact three-enclave topology")
     else:
         restart_invariants = verify_validator_gateway_activation_barrier(
-            rows,
+            serialized_adapter_events(),
             from_sha=from_sha,
             candidate_sha=candidate_sha,
             late_activation_supported=(

--- a/tests/test_restart_rehearsal_activation_barrier.py
+++ b/tests/test_restart_rehearsal_activation_barrier.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from tests.restart_rehearsal.verify_evidence import (
     VALIDATOR_GATEWAY_ACTIVATION_INVARIANT,
+    serialized_adapter_events,
     verify_validator_gateway_activation_barrier,
 )
 
@@ -104,6 +107,49 @@ def test_late_activation_requires_second_alignment_after_image_prepare() -> None
     with pytest.raises(SystemExit, match="at activation barrier"):
         verify_validator_gateway_activation_barrier(
             rows,
+            from_sha=FROM_SHA,
+            candidate_sha=CANDIDATE_SHA,
+            late_activation_supported=True,
+        )
+
+
+def test_activation_barrier_uses_serialized_adapter_order(tmp_path) -> None:
+    rows = _late_activation_rows()
+    for at_ns, row in enumerate(reversed(rows), start=1):
+        row["at_ns"] = at_ns
+    (tmp_path / "events.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    result = verify_validator_gateway_activation_barrier(
+        serialized_adapter_events(tmp_path),
+        from_sha=FROM_SHA,
+        candidate_sha=CANDIDATE_SHA,
+        late_activation_supported=True,
+    )
+
+    assert result == {VALIDATOR_GATEWAY_ACTIVATION_INVARIANT: True}
+
+
+def test_activation_barrier_rejects_wrong_serialized_adapter_order(
+    tmp_path,
+) -> None:
+    rows = _late_activation_rows()
+    rows[11], rows[12] = rows[12], rows[11]
+    for at_ns, row in enumerate(rows, start=1):
+        row["at_ns"] = at_ns
+    (tmp_path / "events.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        SystemExit,
+        match="candidate validator application commit verification",
+    ):
+        verify_validator_gateway_activation_barrier(
+            serialized_adapter_events(tmp_path),
             from_sha=FROM_SHA,
             candidate_sha=CANDIDATE_SHA,
             late_activation_supported=True,


### PR DESCRIPTION
## Summary

Fix a timing-sensitive false failure in the restart rehearsal's validator activation-barrier verifier.

During Sentry remediation verification, the production-shaped validator restart completed and verified the exact application commit, but the post-run verifier rejected the evidence after globally sorting events from separate ledgers by per-process wall-clock timestamps. Clock inversion/resynchronization could therefore move an already-recorded pre-start image inspection after process start.

This PR intentionally contains only the non-duplicative rehearsal fix. The larger Sentry weight-input branch is excluded because current `main` already landed the simpler strict-snapshot production fixes in `64ffdf41` and `4d9db8b6`.

## Changes

- Read the adapter `events.jsonl` in serialized append order for validator activation-barrier verification only.
- Preserve the existing timestamp-merged view for every unrelated evidence check.
- Add regressions proving correct append order passes despite reversed timestamps and incorrect append order still fails closed.

No production runtime, scoring, rewards, payments, allocation, emissions, weight submission, or trust-policy behavior changes.

## Verification

- Linux `py_compile`: passed
- Focused activation-barrier tests: 4 passed in 4.41s
- `git diff --check`: passed
- Fresh read-only `$bugs` review: passed for draft publication

The Docker `prepush` rehearsal was **not rerun** after this harness fix because the operator explicitly prohibited further Docker execution and requested Docker Desktop be fully stopped. Docker processes and the `docker-desktop` WSL engine were confirmed stopped. This draft is not merge, release, or deployment approval until the deferred gate is completed.