### PR TITLE
Single-flight measured catalog snapshots per epoch

### DIFF
--- a/gateway/research_lab/model_authority_v2.py
+++ b/gateway/research_lab/model_authority_v2.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
+import concurrent.futures
 from dataclasses import replace
 import json
 import logging
@@ -599,6 +600,7 @@ class AttestedPrivateModelRunnerV2:
             "authorities": [],
             "generated_caches": {},
             "evidence_summaries": {},
+            "catalog_snapshot_futures": {},
             "lock": threading.Lock(),
         }
 
@@ -622,6 +624,37 @@ class AttestedPrivateModelRunnerV2:
     def attested_authorities(self) -> list[dict[str, Any]]:
         with self._shared_state["lock"]:
             return [dict(item) for item in self._shared_state["authorities"]]
+
+    async def _load_catalog_snapshot(self, *, epoch_id: int) -> Mapping[str, Any]:
+        """Load one exact measured catalog outcome per shared runner epoch."""
+
+        with self._shared_state["lock"]:
+            futures = self._shared_state.setdefault("catalog_snapshot_futures", {})
+            future = futures.get(epoch_id)
+            leader = future is None
+            if leader:
+                future = concurrent.futures.Future()
+                futures[epoch_id] = future
+
+        if leader:
+            catalog_loader = (
+                self._catalog_snapshot_loader or load_source_add_catalog_snapshot_v2
+            )
+            try:
+                outcome = await catalog_loader(epoch_id=epoch_id)
+            except BaseException as exc:
+                future.set_exception(exc)
+                # Mark the exception observed for the leader-only case while
+                # preserving it for any followers already awaiting this future.
+                future.exception()
+                with self._shared_state["lock"]:
+                    if futures.get(epoch_id) is future:
+                        del futures[epoch_id]
+                raise
+            future.set_result(outcome)
+            return outcome
+
+        return await asyncio.shield(asyncio.wrap_future(future))
 
     async def __call__(
         self,
@@ -833,10 +866,9 @@ class AttestedPrivateModelRunnerV2:
                 dict(input_doc.get("context") or {}).get("evaluation_epoch") or 0
             )
         )
-        catalog_loader = (
-            self._catalog_snapshot_loader or load_source_add_catalog_snapshot_v2
+        catalog_outcome = await self._load_catalog_snapshot(
+            epoch_id=int(execution_epoch)
         )
-        catalog_outcome = await catalog_loader(epoch_id=int(execution_epoch))
         catalog_result = catalog_outcome.get("result")
         catalog_graph = catalog_outcome.get("receipt_graph")
         catalog_lineage_receipt = catalog_outcome.get("receipt")

--- a/tests/test_model_authority_v2.py
+++ b/tests/test_model_authority_v2.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import subprocess
 
@@ -194,6 +195,73 @@ def _catalog_outcome(rows=()):
 async def _load_empty_catalog(*, epoch_id):
     assert epoch_id >= 0
     return _catalog_outcome()
+
+
+@pytest.mark.asyncio
+async def test_catalog_snapshot_load_is_singleflight_across_shared_runner_clones(
+    tmp_path,
+):
+    artifact = _artifact(tmp_path)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = []
+
+    async def load_catalog(*, epoch_id):
+        calls.append(epoch_id)
+        started.set()
+        await release.wait()
+        return _catalog_outcome()
+
+    runner = AttestedPrivateModelRunnerV2(
+        artifact=artifact,
+        spec=DockerPrivateModelSpec(image_digest=artifact["image_digest"]),
+        model_kind="private",
+        worker_index=0,
+        epoch_id=24001,
+        catalog_snapshot_loader=load_catalog,
+    )
+    clone = runner.with_spec(runner.spec)
+
+    loads = [
+        asyncio.create_task(candidate._load_catalog_snapshot(epoch_id=24001))
+        for candidate in (runner, clone, runner, clone)
+    ]
+    await started.wait()
+    await asyncio.sleep(0)
+    assert calls == [24001]
+
+    release.set()
+    outcomes = await asyncio.gather(*loads)
+    assert all(outcome is outcomes[0] for outcome in outcomes)
+    assert calls == [24001]
+
+
+@pytest.mark.asyncio
+async def test_catalog_snapshot_failed_load_is_not_cached(tmp_path):
+    artifact = _artifact(tmp_path)
+    calls = []
+
+    async def load_catalog(*, epoch_id):
+        calls.append(epoch_id)
+        if len(calls) == 1:
+            raise RuntimeError("catalog unavailable")
+        return _catalog_outcome()
+
+    runner = AttestedPrivateModelRunnerV2(
+        artifact=artifact,
+        spec=DockerPrivateModelSpec(image_digest=artifact["image_digest"]),
+        model_kind="private",
+        worker_index=0,
+        epoch_id=24001,
+        catalog_snapshot_loader=load_catalog,
+    )
+
+    with pytest.raises(RuntimeError, match="catalog unavailable"):
+        await runner._load_catalog_snapshot(epoch_id=24001)
+    outcome = await runner._load_catalog_snapshot(epoch_id=24001)
+
+    assert outcome == _catalog_outcome()
+    assert calls == [24001, 24001]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- single-flight the measured SOURCE_ADD catalog snapshot per epoch across shared V2 model-runner clones
- preserve the exact signed catalog outcome for every concurrent ICP evaluation
- clear failed loads so a later attempt can retry without weakening receipt uniqueness or fail-closed validation

## Sentry evidence
Concurrent baseline ICPs were each creating the same logical catalog receipt with different hashes. The store correctly rejected the duplicate logical key, then failed to reload it by the losing receipt hash, producing the current AttestedV2StoreError -> AttestedScoringV2Error -> AncestryCheckpointV2Error / TEEEnclaveRPCError chain.

## Verification
- git diff --check passed
- both touched Python files compile under Linux
- added concurrent shared-clone and failed-load retry regressions
- focused pytest collection is currently blocked on unchanged origin/main because research_lab/sourcing_model_contract*.json byte hashes differ from the reviewed constants before these tests execute
- Docker/restart rehearsal intentionally not run per operator instruction; keep this PR draft until the required gate is run

## Release safety
This keeps Postgres uniqueness, receipt identity, ancestry validation, and fail-closed behavior unchanged. It only deduplicates the upstream epoch-scoped measured catalog load.