### PR TITLE
Expose structural failure detail from enclave execution jobs

### DIFF
--- a/gateway/research_lab/attested_autoresearch_v2.py
+++ b/gateway/research_lab/attested_autoresearch_v2.py
@@ -12,6 +12,7 @@ import asyncio
 import base64
 from datetime import datetime, timezone
 import json
+import logging
 from pathlib import Path
 import re
 from typing import Any, Awaitable, Callable, Dict, Iterable, Mapping, Optional, Sequence
@@ -63,6 +64,8 @@ from leadpoet_canonical.ancestry_checkpoint_v2 import (
 from Leadpoet.utils.subnet_epoch import load_subnet_epoch_cutover
 
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_RELEASE_MANIFEST_PATH = Path(
     "/home/ec2-user/tee/gateway-v2-release-manifest.json"
 )
@@ -88,6 +91,9 @@ class AttestedAutoresearchV2Error(RuntimeError):
     ) -> None:
         super().__init__(message)
         self.authority = dict(authority or {})
+        # Diagnostic-only text from the enclave job status side-channel; never
+        # part of the attested failure document or the exception message.
+        self.failure_detail: Optional[str] = None
 
 
 def _canonical_bytes(value: Any) -> bytes:
@@ -869,7 +875,12 @@ async def execute_autoresearch_v2(
                 "autoresearch receipt output differs"
             )
     else:
+        from gateway.research_lab.attested_scoring_v2 import (
+            bounded_status_failure_detail,
+        )
+
         failure_code = str(status.get("error_code") or state)
+        failure_detail = bounded_status_failure_detail(status.get("error_detail"))
         result = {"status": "failed", "failure_code": failure_code}
         if (
             receipt.get("status") != "failed"
@@ -1031,10 +1042,21 @@ async def execute_autoresearch_v2(
             "physical_role": "gateway_autoresearch",
         }
         if not succeeded:
-            raise AttestedAutoresearchV2Error(
+            if failure_detail:
+                logger.error(
+                    "attested_autoresearch_v2_failure_detail job_id=%s "
+                    "purpose=%s failure_code=%s detail=%s",
+                    job_id,
+                    purpose,
+                    result["failure_code"],
+                    failure_detail,
+                )
+            failure_error = AttestedAutoresearchV2Error(
                 "autoresearch enclave failed closed: %s" % result["failure_code"],
                 authority=outcome,
             )
+            failure_error.failure_detail = failure_detail or None
+            raise failure_error
         return outcome
 
     if persist_graph is None:
@@ -1078,8 +1100,19 @@ async def execute_autoresearch_v2(
         "physical_role": "gateway_autoresearch",
     }
     if not succeeded:
-        raise AttestedAutoresearchV2Error(
+        if failure_detail:
+            logger.error(
+                "attested_autoresearch_v2_failure_detail job_id=%s "
+                "purpose=%s failure_code=%s detail=%s",
+                job_id,
+                purpose,
+                result["failure_code"],
+                failure_detail,
+            )
+        failure_error = AttestedAutoresearchV2Error(
             "autoresearch enclave failed closed: %s" % result["failure_code"],
             authority=outcome,
         )
+        failure_error.failure_detail = failure_detail or None
+        raise failure_error
     return outcome

--- a/gateway/research_lab/attested_scoring_v2.py
+++ b/gateway/research_lab/attested_scoring_v2.py
@@ -121,6 +121,18 @@ class AttestedScoringV2Error(RuntimeError):
     def __init__(self, message: str, *, authority: Optional[Mapping[str, Any]] = None):
         super().__init__(message)
         self.authority = dict(authority) if isinstance(authority, Mapping) else None
+        # Diagnostic-only text from the enclave job status side-channel; never
+        # part of the attested failure document or the exception message.
+        self.failure_detail: Optional[str] = None
+
+
+def bounded_status_failure_detail(value: Any) -> str:
+    """Defensively bound the diagnostic detail read from a job status."""
+
+    if not isinstance(value, str):
+        return ""
+    detail = "".join(ch if ch.isprintable() else " " for ch in value)
+    return detail[:220]
 
 
 def scoring_enclave_shard_for_worker(worker_index: int) -> int:
@@ -1618,6 +1630,7 @@ async def execute_scoring_v2(
             raise AttestedScoringV2Error("V2 scoring receipt output mismatch")
     else:
         failure_code = str(status.get("error_code") or state)
+        failure_detail = bounded_status_failure_detail(status.get("error_detail"))
         result = {"status": "failed", "failure_code": failure_code}
         if (
             receipt.get("status") != "failed"
@@ -1851,10 +1864,22 @@ async def execute_scoring_v2(
             outcome["ancestry_compact_proof"] = dict(
                 ancestry_compact_proof
             )
-        raise AttestedScoringV2Error(
+        if failure_detail:
+            logger.error(
+                "attested_scoring_v2_failure_detail job_id=%s operation=%s "
+                "purpose=%s failure_code=%s detail=%s",
+                job_id,
+                operation,
+                purpose,
+                result["failure_code"],
+                failure_detail,
+            )
+        failure_error = AttestedScoringV2Error(
             "V2 scoring failed closed: %s" % result["failure_code"],
             authority=outcome,
         )
+        failure_error.failure_detail = failure_detail or None
+        raise failure_error
     sealed_model_artifacts = result.get("sealed_artifacts") or []
     if not isinstance(sealed_model_artifacts, list) or any(
         not isinstance(item, Mapping) for item in sealed_model_artifacts

--- a/gateway/tee/execution_job_manager_v2.py
+++ b/gateway/tee/execution_job_manager_v2.py
@@ -51,6 +51,10 @@ from leadpoet_canonical.allocation_settlement_frontier_v2 import (
 
 
 JOB_SCHEMA_VERSION = "leadpoet.enclave_execution_job.v2"
+# Diagnostic-only failure detail exposed through the job status side-channel.
+# It never enters the canonical failure result document or any receipt, so the
+# attested surface (failure_code, output_root, receipt graph) is unchanged.
+MAX_FAILURE_DETAIL_CHARS = 300
 PARENT_RECEIPT_GRAPHS_FIELD = "_v2_parent_receipt_graphs"
 PARENT_RECEIPT_GRAPH_SET_FIELD = "_v2_parent_receipt_graph_set"
 LEGACY_PARENT_RECEIPT_GRAPH_SET_SCHEMA_VERSION = (
@@ -704,6 +708,45 @@ def _canonical_bytes(value: Any) -> bytes:
     return canonical_json(value).encode("utf-8")
 
 
+def structural_failure_detail(exc: BaseException) -> str:
+    """Type-chain and raise-site fingerprint for a failed execution job.
+
+    Contains only exception class names plus file, line, and function names
+    of the innermost raise site -- never exception message text -- so
+    confidential payload or credential data cannot leave the enclave through
+    this side-channel. Exception messages are intentionally discarded, exactly
+    as they are for the canonical ``failure_code``.
+
+    Format: ``Outer<-Inner @ pkg/module.py:123:func < pkg/other.py:45:helper``
+    where the frames are the innermost exception's deepest call sites.
+    """
+
+    chain = []
+    seen: set[int] = set()
+    current: Optional[BaseException] = exc
+    deepest: BaseException = exc
+    while current is not None and id(current) not in seen and len(chain) < 4:
+        seen.add(id(current))
+        chain.append(type(current).__name__)
+        deepest = current
+        current = current.__cause__ or current.__context__
+    frames = []
+    traceback = deepest.__traceback__
+    while traceback is not None:
+        code = traceback.tb_frame.f_code
+        path_tail = code.co_filename.replace("\\", "/").rsplit("/", 3)[-2:]
+        frames.append(
+            "%s:%s:%s"
+            % ("/".join(path_tail), traceback.tb_lineno, code.co_name)
+        )
+        traceback = traceback.tb_next
+    detail = "<-".join(chain)
+    if frames:
+        detail = "%s @ %s" % (detail, " < ".join(frames[-3:]))
+    detail = "".join(ch if ch.isprintable() else " " for ch in detail)
+    return detail[:MAX_FAILURE_DETAIL_CHARS]
+
+
 def _hash(value: Any, field: str) -> str:
     normalized = str(value or "").strip().lower()
     if not _HASH_RE.fullmatch(normalized):
@@ -1297,6 +1340,7 @@ class ExecutionJobManagerV2:
                 "ancestry_compact_proof": None,
                 "host_operation_channel": None,
                 "error_code": None,
+                "error_detail": None,
                 "cancel_requested": False,
                 "created_at": now,
                 "updated_at": now,
@@ -1526,6 +1570,7 @@ class ExecutionJobManagerV2:
                     if job is not None and job["state"] not in TERMINAL_STATES:
                         job["state"] = "failed"
                         job["error_code"] = "receipt_unavailable"
+                        job["error_detail"] = structural_failure_detail(exc)
                         job["input"] = bytearray()
                         job["updated_at"] = self._clock()
                 print(
@@ -2025,6 +2070,7 @@ class ExecutionJobManagerV2:
                 job["updated_at"] = self._clock()
         except Exception as exc:
             failure_code = "execution_%s" % type(exc).__name__.lower()[:80]
+            failure_detail = structural_failure_detail(exc)
             failure_bytes = _canonical_bytes(
                 {"status": "failed", "failure_code": failure_code}
             )
@@ -2080,6 +2126,7 @@ class ExecutionJobManagerV2:
                 if job is not None:
                     job["state"] = "failed"
                     job["error_code"] = failure_code
+                    job["error_detail"] = failure_detail
                     job["result"] = failure_bytes
                     job["result_hash"] = sha256_bytes(failure_bytes)
                     job["receipt"] = receipt
@@ -2263,6 +2310,7 @@ class ExecutionJobManagerV2:
                 else None
             ),
             "error_code": job["error_code"],
+            "error_detail": job.get("error_detail"),
             "cancel_requested": bool(job["cancel_requested"]),
         }
 

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -142,7 +142,7 @@
       "symbol": "_trusted_parent_authorities_v2"
     },
     {
-      "ast_sha256": "sha256:487385875807da1971d0a296f76035a3a57123e0c9fbae100ac0848242f4639e",
+      "ast_sha256": "sha256:2515cf8dc10571fa439e03161e1af37e2d3a4b7ee7a78db78d319ece60cedf39",
       "path": "gateway/research_lab/attested_autoresearch_v2.py",
       "symbol": "execute_autoresearch_v2"
     },
@@ -187,7 +187,7 @@
       "symbol": "_validate_output_ancestry_checkpoint_v2"
     },
     {
-      "ast_sha256": "sha256:9e206701884452554f6c263622f1f8e0e48ff3c123d793768c9b9648d48a7aab",
+      "ast_sha256": "sha256:8ff959410c61375e41af5bc151d538932b88f52ee3b999fd7f6ad34dcbce6ec3",
       "path": "gateway/research_lab/attested_scoring_v2.py",
       "symbol": "execute_scoring_v2"
     },
@@ -1232,7 +1232,7 @@
       "symbol": "_parse_proxy_request"
     },
     {
-      "ast_sha256": "sha256:4e67bf654cb46e0ff990514f49a0ee38b568b30c0d4bd37e525ff78af1ae2ec0",
+      "ast_sha256": "sha256:46237886044818c4b99a4b6a46d2a7543ece8926ce254ba62a35591115c71a61",
       "path": "gateway/tee/execution_job_manager_v2.py",
       "symbol": "ExecutionJobManagerV2"
     },
@@ -2737,7 +2737,7 @@
       "symbol": "verify_source_tree_contract"
     }
   ],
-  "manifest_hash": "sha256:37572d42ca0908c4b2d0f9a8444cd84059f0b98accfefbe3b8f6fb3e54b0c9ec",
-  "protected_source_commit": "5ee99cd7a064cfa259cdee5e90164880af4d2fda",
+  "manifest_hash": "sha256:9c678c5c7a9a748ecb2e69d3ca8558edd582857631e04572da0e7d44d41293a1",
+  "protected_source_commit": "ab4c7ad287050261de8cfa51d1c73d872d5f22ee",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_attested_scoring_v2_bridge.py
+++ b/tests/test_attested_scoring_v2_bridge.py
@@ -2405,6 +2405,14 @@ async def test_v2_bridge_ignores_uncommitted_orphans_and_persists_failure(
         "failure_code": "execution_valueerror",
     }
     assert persisted[0] == authority["receipt_graph"]
+    # The diagnostic side-channel names the exception type and raise site but
+    # never carries enclave exception message text, and it stays out of the
+    # exception message so message-based classifiers are unaffected.
+    assert captured.value.failure_detail
+    assert "ValueError" in captured.value.failure_detail
+    assert "test_attested_scoring_v2_bridge.py" in captured.value.failure_detail
+    assert "measured scoring failure" not in captured.value.failure_detail
+    assert str(captured.value) == "V2 scoring failed closed: execution_valueerror"
 
 
 @pytest.mark.asyncio

--- a/tests/test_execution_job_manager_v2.py
+++ b/tests/test_execution_job_manager_v2.py
@@ -952,6 +952,60 @@ def test_executor_failure_has_signed_failure_receipt_and_canonical_terminal_resu
     )
 
 
+def test_failure_status_exposes_structural_detail_without_message_text():
+    def _executor(_operation, _payload, _context):
+        try:
+            raise ValueError("inner secret token sk-test-1234567890")
+        except ValueError as inner:
+            raise RuntimeError("outer private detail") from inner
+
+    manager, _ = _manager(_executor)
+    status = _run(manager, _payload())
+    assert status["state"] == "failed"
+    detail = status["error_detail"]
+    assert detail
+    assert detail.startswith("RuntimeError<-ValueError")
+    assert "test_execution_job_manager_v2.py" in detail
+    assert "_executor" in detail
+    # Message text never leaves the enclave through any status field.
+    assert "private detail" not in str(status)
+    assert "secret token" not in str(status)
+    assert "sk-test" not in str(status)
+    # The attested terminal result and receipt are unchanged by the detail.
+    receipt = manager.receipt("score-job-1")
+    assert "error_detail" not in receipt
+    result = manager.result_chunk(job_id="score-job-1")
+    terminal = json.loads(base64.b64decode(result["data_b64"]))
+    assert terminal == {
+        "status": "failed",
+        "failure_code": "execution_runtimeerror",
+    }
+    assert receipt["output_root"] == sha256_bytes(
+        json.dumps(terminal, sort_keys=True, separators=(",", ":")).encode()
+    )
+
+
+def test_structural_failure_detail_is_bounded_and_cycle_safe():
+    plain = job_manager_v2.structural_failure_detail(ValueError("x" * 4096))
+    assert plain == "ValueError"
+    assert len(plain) <= job_manager_v2.MAX_FAILURE_DETAIL_CHARS
+
+    first = ValueError("a")
+    second = TypeError("b")
+    first.__cause__ = second
+    second.__cause__ = first
+    cyclic = job_manager_v2.structural_failure_detail(first)
+    assert cyclic == "ValueError<-TypeError"
+
+    chained = ValueError("v")
+    for name in ("B", "C", "D", "E", "F"):
+        outer = type(name, (RuntimeError,), {})("m")
+        outer.__cause__ = chained
+        chained = outer
+    capped = job_manager_v2.structural_failure_detail(chained)
+    assert capped.count("<-") == 3
+
+
 def test_stage_receipts_form_a_measured_chain_before_root_receipt():
     def _executor(_operation, payload, context):
         context.record_stage(


### PR DESCRIPTION
## Why

Failed V2 execution jobs report only a lowercased exception class name (`execution_<classname>`, `execution_job_manager_v2.py:2027` discards the message). During the current weight outage (no durable submission since epoch 24489, 2026-08-11T10:35Z), the gateway logged `authoritative_weight_inputs_v2_failed ... execution_supabasesourcev2error` — an error that maps to ~40 distinct raise sites in `supabase_source_v2.py`. With the production enclave running non-debug (no console), there was no way to see **which** call site was failing; the ~30 fix deploys over Aug 11–12 were made without that evidence. This PR is recommendation A.1 from `weightsubmissionhardening.md`.

## What

**Enclave (`gateway/tee/execution_job_manager_v2.py`)**
- On job failure, record a `structural_failure_detail`: the exception **type chain** plus the innermost raise-site **frames** (`file:line:function`), e.g. `SupabaseSourceV2Error<-ProviderBrokerV2Error @ tee/supabase_source_v2.py:1332:_read_page`.
- Exposed as `error_detail` in the `get_status` job summary — a diagnostic side-channel only.
- **Message text is still discarded**, exactly as before: the detail contains only class names, file basenames, line numbers, and function names, so confidential payload/credential data cannot leave the enclave (the existing `"private detail" not in str(status)` invariant test still passes, and a new test pins this).
- The canonical failure result document, `failure_code`, receipts, `output_root`, and the receipt graph are **byte-identical** — the attested surface is unchanged, verified by the receipt/output-root assertions in the tests.

**Host (`attested_scoring_v2.py`, `attested_autoresearch_v2.py`)**
- On a failed job, log `attested_scoring_v2_failure_detail` / `attested_autoresearch_v2_failure_detail` with the bounded detail and attach it as `failure_detail` on the raised error.
- Exception **messages are unchanged** (`V2 scoring failed closed: <code>`), so message-substring retry classifiers (`has_retryable_attested_provider_transport_failure`), Sentry grouping, and existing test assertions are unaffected.

**Protected identity** — second commit re-pins the AST hashes for the three touched protected symbols (`ExecutionJobManagerV2`, `execute_scoring_v2`, `execute_autoresearch_v2`) per the manifest convention.

**Compatibility** — old enclave + new host: `status.get("error_detail")` is absent → no detail, no behavior change. New enclave + old host: extra status key ignored. No lockstep deploy required.

## Verification

- 126 tests pass across `test_execution_job_manager_v2` (31, incl. 2 new), `test_attested_scoring_v2_bridge` (39, extended failure-path test asserts detail present, message text absent, exception message unchanged), `test_attested_autoresearch_v2_bridge`, `test_attested_scoring_host_bridge`, `test_model_authority_v2`, `test_attested_execution_upload_v2`, `test_gateway_scoring_rpc_contract`, `test_protected_workflows` (9, manifest parity green).
- `git diff --check` and `py_compile` clean.
- **Not verified locally:** `test_gateway_weights_v2.py` cannot collect on this Mac (known bittensor 11 vs pinned 10.5 environment issue) — CI covers it. The `prepush` restart rehearsal was attempted 3× locally; its container stages all fail on this machine with `invalid mount config ... bind source path does not exist` because Docker Desktop's file sharing does not expose the rehearsal's temp mounts to the VM (tried both `$TMPDIR` and `/private/tmp`). Independent stages that could run (drand artifacts, fixture cleanup, time budget) passed; `gateway-forward-1`, `validator-forward-1`, `workflow-prepush`, `evidence-join-prepush` went unexercised locally and must be covered by CI / the Linux release rehearsal before deploy.

## Expected payoff

The next `authoritative_weight_inputs_v2_failed` line in `gateway.log` (and Sentry) is accompanied by the exact raise site inside the enclave — one epoch of production evidence identifies the failing transport path instead of another blind fix cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)