### PR TITLE
Preserve snapshot cancellation and interpreter identity

### DIFF
--- a/gateway/research_lab/snapshot_refresh.py
+++ b/gateway/research_lab/snapshot_refresh.py
@@ -486,13 +486,15 @@ async def _run_record_command_with_active_guard(
                 "active private model changed during snapshot recording"
             )
         return output
-    except asyncio.CancelledError:
+    except asyncio.CancelledError as cancellation:
         task.cancel()
         try:
             await task
         except asyncio.CancelledError:
             pass
-        raise
+        except Exception as teardown_exc:
+            raise cancellation from teardown_exc
+        raise cancellation
 
 
 def _state_artifact_identity(
@@ -861,7 +863,12 @@ async def maybe_refresh_dev_snapshot(
                 completed["snapshot_manifest_hash"][:24],
             )
             return completed
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as exc:
+            teardown_error = (
+                _safe_error(exc.__cause__)
+                if isinstance(exc.__cause__, Exception)
+                else "CancelledError:snapshot refresh cancelled"
+            )
             failure = {
                 **failure_base,
                 "schema_version": "research_lab.dev_snapshot_refresh_state.v1",
@@ -870,7 +877,7 @@ async def maybe_refresh_dev_snapshot(
                 "last_check_at": datetime.fromtimestamp(
                     timestamp, tz=timezone.utc
                 ).isoformat(),
-                "last_error": "CancelledError:snapshot refresh cancelled",
+                "last_error": teardown_error,
             }
             _write_state(state_path, failure)
             logger.warning(

--- a/gateway/research_lab/snapshot_refresh.py
+++ b/gateway/research_lab/snapshot_refresh.py
@@ -376,6 +376,8 @@ async def _await_command_completion(
     command: Sequence[str],
     env: Mapping[str, str],
     timeout_seconds: int,
+    *,
+    cancellation_teardown_errors: list[Exception] | None = None,
 ) -> str:
     """Defer cancellation until the command-owning thread has fully stopped."""
 
@@ -410,6 +412,12 @@ async def _await_command_completion(
         if cancellation is not None:
             raise cancellation
         raise
+    except Exception as teardown_exc:
+        if cancellation is not None:
+            if cancellation_teardown_errors is not None:
+                cancellation_teardown_errors.append(teardown_exc)
+            raise cancellation from teardown_exc
+        raise
     if cancellation is not None:
         raise cancellation
     return result
@@ -438,12 +446,14 @@ async def _run_record_command_with_active_guard(
 ) -> str:
     """Record while polling model authority; cancel only at recorder boundaries."""
 
+    cancellation_teardown_errors: list[Exception] = []
     task = asyncio.create_task(
         _await_command_completion(
             command_runner,
             command,
             env,
             timeout_seconds,
+            cancellation_teardown_errors=cancellation_teardown_errors,
         )
     )
     superseded = False
@@ -490,10 +500,13 @@ async def _run_record_command_with_active_guard(
         task.cancel()
         try:
             await task
-        except asyncio.CancelledError:
-            pass
+        except asyncio.CancelledError as task_cancellation:
+            if isinstance(task_cancellation.__cause__, Exception):
+                raise cancellation from task_cancellation.__cause__
         except Exception as teardown_exc:
             raise cancellation from teardown_exc
+        if cancellation_teardown_errors:
+            raise cancellation from cancellation_teardown_errors[0]
         raise cancellation
 
 

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1132,7 +1132,7 @@
       "symbol": "_run_command"
     },
     {
-      "ast_sha256": "sha256:94998872d6f8f155037340882711759915c0f19aa7d5757c6d72ee55c035f548",
+      "ast_sha256": "sha256:e5683c0e360f2dd2732840af342e9d4ba41921cc56bda2b56cad190b0efc889d",
       "path": "gateway/research_lab/snapshot_refresh.py",
       "symbol": "_run_record_command_with_active_guard"
     },
@@ -1157,7 +1157,7 @@
       "symbol": "_write_record_cancel_marker"
     },
     {
-      "ast_sha256": "sha256:2943f95ef9bf4d0d2fff48899d62007ab3f0abe2bc53f8fba4cc40565f2419b2",
+      "ast_sha256": "sha256:819c69525035b5d2fece8b0db2576a3c930f4ffd60f730b38f4ee1e70e54086e",
       "path": "gateway/research_lab/snapshot_refresh.py",
       "symbol": "maybe_refresh_dev_snapshot"
     },
@@ -4177,7 +4177,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:c30a24e2f6c6e9b16de496af4e7a4fdc50bedb9607e0aa7fff07d4b15dd00c6e",
-  "protected_source_commit": "d6d4fc5eca58f906765ee763f21839da73e500ae",
+  "manifest_hash": "sha256:599b917cd7236589ca9ad487f69d3cc7fa5f6c646c39fceb5b2908755eed2c0e",
+  "protected_source_commit": "5dd9f6210f90d97c903999d014b4f518fb1d0379",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1112,7 +1112,7 @@
       "symbol": "_CommandCancellationRequested"
     },
     {
-      "ast_sha256": "sha256:3be47e0f7016b65dc1ca26fcb8693c891e330bc3d2759e2773c81b0e8bcda077",
+      "ast_sha256": "sha256:dd0bb94bd9ed51e682819326d6322ab45a5262efe5d3c4f87168e716db24f66d",
       "path": "gateway/research_lab/snapshot_refresh.py",
       "symbol": "_await_command_completion"
     },
@@ -1132,7 +1132,7 @@
       "symbol": "_run_command"
     },
     {
-      "ast_sha256": "sha256:e5683c0e360f2dd2732840af342e9d4ba41921cc56bda2b56cad190b0efc889d",
+      "ast_sha256": "sha256:eb9341e7e13358475c00f6eca3c4fe0b7b22e7052e32e79acf38c8a84b118ee5",
       "path": "gateway/research_lab/snapshot_refresh.py",
       "symbol": "_run_record_command_with_active_guard"
     },
@@ -4177,7 +4177,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:599b917cd7236589ca9ad487f69d3cc7fa5f6c646c39fceb5b2908755eed2c0e",
-  "protected_source_commit": "5dd9f6210f90d97c903999d014b4f518fb1d0379",
+  "manifest_hash": "sha256:716048869fbe9b756b1b02925d98b21cc23e8f601d570f5699366c4023e66d83",
+  "protected_source_commit": "0f042e5a08ccc1aa4ba119958e302f67b259993d",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/restart_rehearsal/dev_snapshot_boundary/sitecustomize.py
+++ b/tests/restart_rehearsal/dev_snapshot_boundary/sitecustomize.py
@@ -862,6 +862,8 @@ if _state_path_raw and not _spawn_gate_invocation:
             raise RuntimeError("dev-snapshot production command is incomplete")
         script_name = Path(str(argv[1])).name
         script_path = (_source_root / "scripts" / script_name).resolve()
+        if str(argv[0]) != sys.executable:
+            raise RuntimeError("dev-snapshot production command identity differs")
         try:
             command_interpreter = Path(str(argv[0])).resolve(strict=True)
             boundary_interpreter = Path(sys.executable).resolve(strict=True)
@@ -1450,7 +1452,6 @@ if _state_path_raw and not _spawn_gate_invocation:
                         "dev-snapshot production process-group contract differs"
                     )
                 phase, argv_contract_hash = _validate_production_command(argv)
-                argv[0] = str(Path(argv[0]).resolve(strict=True))
                 return _ObservedProductionPopen(
                     popenargs,
                     kwargs,
@@ -1646,8 +1647,7 @@ def _run_production_spawn_gate() -> None:
         or command_interpreter != gate_interpreter
     ):
         raise RuntimeError("dev-snapshot production spawn gate contract differs")
-    execution_argv = [str(gate_interpreter), *argv[1:]]
-    os.execve(execution_argv[0], execution_argv, dict(os.environ))
+    os.execve(argv[0], argv, dict(os.environ))
 
 
 if __name__ == "__main__":

--- a/tests/restart_rehearsal/dynamic_docker_collision_workflow.py
+++ b/tests/restart_rehearsal/dynamic_docker_collision_workflow.py
@@ -183,6 +183,23 @@ def _communicate(
     )
 
 
+def _n_minus_one_docker_readiness_evidence(
+    *, exact_root: Path, ready_log: Path
+) -> tuple[bool, list[str]]:
+    readiness_expected = (
+        exact_root / "research_lab/docker_operation_lock_v2.py"
+    ).is_file()
+    ready_calls = (
+        ready_log.read_text(encoding="utf-8").splitlines()
+        if ready_log.is_file()
+        else []
+    )
+    expected_calls = ["info"] if readiness_expected else []
+    if ready_calls != expected_calls:
+        raise RuntimeError("N-1 Docker readiness boundary differs")
+    return readiness_expected, ready_calls
+
+
 def _exclusive_probe(
     *,
     shell_lock_path: Path,
@@ -1089,13 +1106,10 @@ exit 98
             ),
             label="exact N-1 Docker source reader",
         )
-        reader_ready_calls = (
-            (root / "n-minus-reader-docker-ready.log")
-            .read_text(encoding="utf-8")
-            .splitlines()
+        _n_minus_one_docker_readiness_evidence(
+            exact_root=exact_root,
+            ready_log=root / "n-minus-reader-docker-ready.log",
         )
-        if reader_ready_calls != ["info"]:
-            raise RuntimeError("N-1 Docker readiness boundary differs")
         reclaim_result = _communicate(
             reclaim,
             timeout_seconds=collision_timeout,

--- a/tests/restart_rehearsal/dynamic_docker_collision_workflow.py
+++ b/tests/restart_rehearsal/dynamic_docker_collision_workflow.py
@@ -98,6 +98,39 @@ def _run_exact_n_minus_one_source_reader(
     child_environment.update(
         {str(key): str(value) for key, value in environment.items()}
     )
+    reader_bin = event_path.parent / "n-minus-reader-bin"
+    reader_bin.mkdir(mode=0o700)
+    _write_executable(
+        reader_bin / "docker",
+        """#!/bin/sh
+if [ "$#" -eq 1 ] && [ "$1" = "info" ]; then
+  printf 'info\n' >> "$REHEARSAL_N_MINUS_READER_DOCKER_READY_LOG"
+  exit 0
+fi
+echo "unexpected N-1 Docker readiness operation" >&2
+exit 97
+""",
+    )
+    reader_lock_path = event_path.parent / "n-minus-reader.lock"
+    reader_ready_log = event_path.parent / "n-minus-reader-docker-ready.log"
+    child_environment.update(
+        {
+            "LEADPOET_DOCKER_OPERATION_LOCK_FILE": str(reader_lock_path),
+            "LEADPOET_DOCKER_OPERATION_ADMISSION_LOCK_FILE": (
+                f"{reader_lock_path}.admission"
+            ),
+            "LEADPOET_DOCKER_OPERATION_LOCK_TIMEOUT_SECONDS": str(
+                max(1, math.ceil(collision_timeout_seconds))
+            ),
+            "LEADPOET_DOCKER_DAEMON_READY_TIMEOUT_SECONDS": str(
+                max(1, math.ceil(collision_timeout_seconds))
+            ),
+            "REHEARSAL_N_MINUS_READER_DOCKER_READY_LOG": str(reader_ready_log),
+            "PATH": str(reader_bin)
+            + os.pathsep
+            + (child_environment.get("PATH") or os.defpath),
+        }
+    )
     child_environment["PYTHONPATH"] = str(exact_root)
     child = subprocess.Popen(
         [
@@ -1056,6 +1089,13 @@ exit 98
             ),
             label="exact N-1 Docker source reader",
         )
+        reader_ready_calls = (
+            (root / "n-minus-reader-docker-ready.log")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        )
+        if reader_ready_calls != ["info"]:
+            raise RuntimeError("N-1 Docker readiness boundary differs")
         reclaim_result = _communicate(
             reclaim,
             timeout_seconds=collision_timeout,

--- a/tests/test_dev_snapshot_workflow.py
+++ b/tests/test_dev_snapshot_workflow.py
@@ -5,9 +5,11 @@ import json
 import os
 from pathlib import Path
 import signal
+import shutil
 import subprocess
 import sys
 import time
+import venv
 
 import pytest
 
@@ -309,12 +311,26 @@ def test_dev_snapshot_boundary_rejects_popen_execution_and_env_overrides(
         timeout=10,
         env=env,
     )
-    run_override = subprocess.run(
+    interpreter_alias = subprocess.run(
         [
             sys.executable,
             "-c",
             "import os, subprocess\n"
             + common
+            + "subprocess.Popen(command, env=dict(os.environ), **options)\n",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+        env=env,
+    )
+    run_override = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os, subprocess\n"
+            + f"command = {[sys.executable, *production_command[1:]]!r}\n"
             + "subprocess.run(command, text=True, capture_output=True, "
             + "env=dict(os.environ), executable='/bin/true')\n",
         ],
@@ -331,6 +347,11 @@ def test_dev_snapshot_boundary_rejects_popen_execution_and_env_overrides(
             "dev-snapshot production process-group contract differs"
             in completed.stderr
         )
+    assert interpreter_alias.returncode != 0
+    assert (
+        "dev-snapshot production command identity differs"
+        in interpreter_alias.stderr
+    )
     assert run_override.returncode != 0
     assert (
         "dev-snapshot production commands require the private Popen contract"
@@ -386,6 +407,114 @@ def test_dev_snapshot_spawn_gate_accepts_same_interpreter_symlink(
     stdout, stderr = process.communicate(timeout=10)
 
     assert process.returncode == 0, stderr or stdout
+
+
+def test_dev_snapshot_production_spawn_preserves_virtualenv_identity(
+    tmp_path: Path,
+) -> None:
+    source_root = Path(__file__).resolve().parents[1]
+    candidate_root = tmp_path / "candidate"
+    candidate_boundary = (
+        candidate_root
+        / "tests"
+        / "restart_rehearsal"
+        / "dev_snapshot_boundary"
+    )
+    candidate_boundary.mkdir(parents=True)
+    shutil.copyfile(
+        source_root
+        / "tests"
+        / "restart_rehearsal"
+        / "dev_snapshot_boundary"
+        / "sitecustomize.py",
+        candidate_boundary / "sitecustomize.py",
+    )
+    candidate_contract = (
+        candidate_root / "tests" / "restart_rehearsal" / "boundary_contract.json"
+    )
+    shutil.copyfile(
+        source_root / "tests" / "restart_rehearsal" / "boundary_contract.json",
+        candidate_contract,
+    )
+    candidate_scripts = candidate_root / "scripts"
+    candidate_scripts.mkdir()
+    export_script = candidate_scripts / "export_research_lab_dev_icp_inputs.py"
+    export_script.write_text(
+        "import json, leadpoet_venv_probe, sys\n"
+        "print(json.dumps({\n"
+        "    'base_prefix': sys.base_prefix,\n"
+        "    'executable': sys.executable,\n"
+        "    'prefix': sys.prefix,\n"
+        "    'probe': leadpoet_venv_probe.VALUE,\n"
+        "}, sort_keys=True))\n",
+        encoding="utf-8",
+    )
+
+    venv_root = tmp_path / "venv"
+    venv.EnvBuilder(
+        with_pip=False,
+        system_site_packages=True,
+        symlinks=True,
+    ).create(venv_root)
+    venv_python = venv_root / "bin" / "python"
+    site_packages = Path(
+        subprocess.run(
+            [
+                str(venv_python),
+                "-c",
+                (
+                    "import os, site, sys; "
+                    "print(next(path for path in site.getsitepackages() "
+                    "if path.startswith(sys.prefix + os.sep)))"
+                ),
+            ],
+            text=True,
+            capture_output=True,
+            check=True,
+            timeout=10,
+        ).stdout.strip()
+    )
+    (site_packages / "leadpoet_venv_probe.py").write_text(
+        "VALUE = 'venv-only'\n",
+        encoding="utf-8",
+    )
+
+    state_path = _boundary_state(tmp_path, candidate_root)
+    inputs_dir = tmp_path / "work" / "refresh-999-venv" / "inputs"
+    production_arguments = [
+        str(export_script),
+        "--out-dir",
+        str(inputs_dir),
+        "--seed",
+        "exact-rehearsal-snapshot",
+        "--expected-private-model-manifest-hash",
+        "sha256:" + "d" * 64,
+    ]
+    source = (
+        "import os, subprocess, sys\n"
+        f"command = [sys.executable, *{production_arguments!r}]\n"
+        "process = subprocess.Popen(command, text=True, stdout=subprocess.PIPE, "
+        "stderr=subprocess.PIPE, start_new_session=True, env=dict(os.environ))\n"
+        "stdout, stderr = process.communicate(timeout=10)\n"
+        "if process.returncode:\n"
+        "    raise RuntimeError(stderr or stdout)\n"
+        "print(stdout, end='')\n"
+    )
+    completed = subprocess.run(
+        [str(venv_python), "-c", source],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=20,
+        env=_boundary_environment(state_path, candidate_root),
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    result = json.loads(completed.stdout)
+    assert result["executable"] == str(venv_python)
+    assert result["prefix"] == str(venv_root)
+    assert result["base_prefix"] != result["prefix"]
+    assert result["probe"] == "venv-only"
 
 
 def test_dev_snapshot_boundary_real_run_bypass_is_thread_local(

--- a/tests/test_dev_snapshot_workflow.py
+++ b/tests/test_dev_snapshot_workflow.py
@@ -329,8 +329,8 @@ def test_dev_snapshot_boundary_rejects_popen_execution_and_env_overrides(
         [
             sys.executable,
             "-c",
-            "import os, subprocess\n"
-            + f"command = {[sys.executable, *production_command[1:]]!r}\n"
+            "import os, subprocess, sys\n"
+            + f"command = [sys.executable, *{production_command[1:]!r}]\n"
             + "subprocess.run(command, text=True, capture_output=True, "
             + "env=dict(os.environ), executable='/bin/true')\n",
         ],

--- a/tests/test_protected_workflows.py
+++ b/tests/test_protected_workflows.py
@@ -1,6 +1,8 @@
+import io
 from pathlib import Path
 import re
 import subprocess
+import tarfile
 
 import pytest
 
@@ -19,7 +21,7 @@ ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = ROOT / "gateway" / "tee" / "protected_workflows.json"
 
 
-def test_committed_protected_workflow_manifest_matches_source():
+def test_committed_protected_workflow_manifest_matches_source(tmp_path: Path):
     manifest = load_manifest(MANIFEST_PATH)
     verify_manifest(ROOT, manifest)
     assert re.fullmatch(r"[0-9a-f]{40}", manifest["baseline_commit"])
@@ -35,6 +37,36 @@ def test_committed_protected_workflow_manifest_matches_source():
         cwd=ROOT,
         check=True,
     )
+    archived = subprocess.run(
+        [
+            "git",
+            "archive",
+            "--format=tar",
+            protected_source,
+            "--",
+            *sorted(PROTECTED_SYMBOLS),
+        ],
+        cwd=ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        timeout=30,
+    ).stdout
+    protected_root = tmp_path / "protected-source"
+    with tarfile.open(fileobj=io.BytesIO(archived), mode="r:") as archive:
+        for relative_path in PROTECTED_SYMBOLS:
+            member = archive.getmember(relative_path)
+            assert member.isfile()
+            source = archive.extractfile(member)
+            assert source is not None
+            destination = protected_root / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(source.read())
+    reproduced = build_manifest(
+        protected_root,
+        baseline_commit=manifest["baseline_commit"],
+        protected_source_commit=protected_source,
+    )
+    assert reproduced == manifest
     assert len(manifest["entries"]) == sum(len(items) for items in PROTECTED_SYMBOLS.values())
 
 

--- a/tests/test_restart_rehearsal_evidence_identity.py
+++ b/tests/test_restart_rehearsal_evidence_identity.py
@@ -282,6 +282,41 @@ def test_n_minus_one_docker_reader_uses_an_isolated_bounded_lock(
     assert reader_ready_log.read_text(encoding="utf-8").splitlines() == ["info"]
 
 
+def test_n_minus_one_docker_readiness_matches_exact_release_capability(
+    tmp_path: Path,
+) -> None:
+    from tests.restart_rehearsal import dynamic_docker_collision_workflow
+
+    exact_root = tmp_path / "exact"
+    ready_log = tmp_path / "ready.log"
+    assert dynamic_docker_collision_workflow._n_minus_one_docker_readiness_evidence(
+        exact_root=exact_root,
+        ready_log=ready_log,
+    ) == (False, [])
+
+    ready_log.write_text("info\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="readiness boundary differs"):
+        dynamic_docker_collision_workflow._n_minus_one_docker_readiness_evidence(
+            exact_root=exact_root,
+            ready_log=ready_log,
+        )
+    ready_log.unlink()
+
+    (exact_root / "research_lab").mkdir(parents=True)
+    (exact_root / "research_lab/docker_operation_lock_v2.py").touch()
+    with pytest.raises(RuntimeError, match="readiness boundary differs"):
+        dynamic_docker_collision_workflow._n_minus_one_docker_readiness_evidence(
+            exact_root=exact_root,
+            ready_log=ready_log,
+        )
+
+    ready_log.write_text("info\n", encoding="utf-8")
+    assert dynamic_docker_collision_workflow._n_minus_one_docker_readiness_evidence(
+        exact_root=exact_root,
+        ready_log=ready_log,
+    ) == (True, ["info"])
+
+
 def test_release_reuses_candidate_migrated_durable_boundary_state() -> None:
     controller = (
         ROOT / "scripts/run_local_restart_rehearsal.py"

--- a/tests/test_restart_rehearsal_evidence_identity.py
+++ b/tests/test_restart_rehearsal_evidence_identity.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import ast
 import hashlib
+import io
 import os
 from pathlib import Path
 import re
 import subprocess
+from typing import Optional
 
 import pytest
 
@@ -181,6 +183,103 @@ def test_gateway_provider_adapter_tracks_production_transport_interface() -> Non
     production_keywords = {arg.arg for arg in production_call.args.kwonlyargs}
     rehearsal_keywords = {arg.arg for arg in rehearsal_call.args.kwonlyargs}
     assert production_keywords <= rehearsal_keywords
+
+
+@pytest.mark.parametrize(
+    ("ambient_path", "expected_path_suffix"),
+    (("/ambient/bin", "/ambient/bin"), (None, os.defpath)),
+)
+def test_n_minus_one_docker_reader_uses_an_isolated_bounded_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    ambient_path: Optional[str],
+    expected_path_suffix: str,
+) -> None:
+    from tests.restart_rehearsal import dynamic_docker_collision_workflow
+
+    observed: dict[str, object] = {}
+
+    class Child:
+        def __init__(self) -> None:
+            self.stdin = io.StringIO()
+
+    child = Child()
+
+    def popen(command, **kwargs):
+        observed["command"] = command
+        observed["environment"] = kwargs["env"]
+        return child
+
+    event_path = tmp_path / "events.log"
+    exact_root = tmp_path / "exact"
+    launch_environment = {
+        "LEADPOET_DOCKER_OPERATION_LOCK_FILE": "/ambient/operation.lock",
+        "LEADPOET_DOCKER_OPERATION_ADMISSION_LOCK_FILE": (
+            "/ambient/admission.lock"
+        ),
+        "LEADPOET_DOCKER_OPERATION_LOCK_TIMEOUT_SECONDS": "999",
+        "LEADPOET_DOCKER_DAEMON_READY_TIMEOUT_SECONDS": "999",
+    }
+    if ambient_path is not None:
+        launch_environment["PATH"] = ambient_path
+    with monkeypatch.context() as scoped:
+        if ambient_path is None:
+            scoped.delenv("PATH", raising=False)
+        scoped.setattr(
+            dynamic_docker_collision_workflow.subprocess,
+            "Popen",
+            popen,
+        )
+        returned = (
+            dynamic_docker_collision_workflow._run_exact_n_minus_one_source_reader(
+                source_root=ROOT,
+                exact_root=exact_root,
+                environment=launch_environment,
+                event_path=event_path,
+                host_detect_path=tmp_path / "host-detect",
+                image_digest="registry.invalid/model@sha256:" + "a" * 64,
+                timeout_seconds=300,
+                collision_timeout_seconds=7.1,
+            )
+        )
+
+    environment = observed["environment"]
+    assert isinstance(environment, dict)
+    reader_lock = tmp_path / "n-minus-reader.lock"
+    assert environment["LEADPOET_DOCKER_OPERATION_LOCK_FILE"] == str(reader_lock)
+    assert environment["LEADPOET_DOCKER_OPERATION_ADMISSION_LOCK_FILE"] == (
+        f"{reader_lock}.admission"
+    )
+    assert environment["LEADPOET_DOCKER_OPERATION_LOCK_TIMEOUT_SECONDS"] == "8"
+    assert environment["LEADPOET_DOCKER_DAEMON_READY_TIMEOUT_SECONDS"] == "8"
+    reader_docker = tmp_path / "n-minus-reader-bin" / "docker"
+    reader_ready_log = tmp_path / "n-minus-reader-docker-ready.log"
+    assert environment["REHEARSAL_N_MINUS_READER_DOCKER_READY_LOG"] == str(
+        reader_ready_log
+    )
+    assert environment["PATH"] == (
+        f"{reader_docker.parent}{os.pathsep}{expected_path_suffix}"
+    )
+    assert all(environment["PATH"].split(os.pathsep))
+    assert environment["PYTHONPATH"] == str(exact_root)
+    assert returned is child
+    assert (
+        subprocess.run(
+            [str(reader_docker), "info"],
+            check=False,
+            env=environment,
+        ).returncode
+        == 0
+    )
+    assert (
+        subprocess.run(
+            [str(reader_docker), "ps"],
+            check=False,
+            env=environment,
+        ).returncode
+        == 97
+    )
+    assert reader_ready_log.read_text(encoding="utf-8").splitlines() == ["info"]
 
 
 def test_release_reuses_candidate_migrated_durable_boundary_state() -> None:

--- a/tests/test_snapshot_refresh.py
+++ b/tests/test_snapshot_refresh.py
@@ -308,7 +308,7 @@ def test_run_command_bounds_pipe_drain_after_completed_group_exit(monkeypatch):
         )
 
 
-def test_cancellation_does_not_mask_command_teardown_failure(monkeypatch):
+def test_command_teardown_failure_does_not_mask_cancellation(monkeypatch):
     started = threading.Event()
 
     def broken_runner(
@@ -326,22 +326,28 @@ def test_cancellation_does_not_mask_command_teardown_failure(monkeypatch):
     monkeypatch.setattr(snapshot_refresh, "_run_command", broken_runner)
 
     async def scenario() -> None:
-        command = asyncio.create_task(
-            snapshot_refresh._await_command_completion(
+        owner = asyncio.current_task()
+        assert owner is not None
+
+        async def cancel_when_started() -> None:
+            deadline = asyncio.get_running_loop().time() + 5
+            while not started.is_set():
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError("command teardown probe did not start")
+                await asyncio.sleep(0.01)
+            owner.cancel()
+
+        canceller = asyncio.create_task(cancel_when_started())
+        with pytest.raises(asyncio.CancelledError) as cancelled:
+            await snapshot_refresh._await_command_completion(
                 snapshot_refresh._run_command,
                 [sys.executable, "-c", "pass"],
                 os.environ,
                 60,
             )
-        )
-        deadline = asyncio.get_running_loop().time() + 5
-        while not started.is_set():
-            if asyncio.get_running_loop().time() >= deadline:
-                raise AssertionError("command teardown probe did not start")
-            await asyncio.sleep(0.01)
-        command.cancel()
-        with pytest.raises(RuntimeError, match="command teardown failed"):
-            await command
+        await canceller
+        assert isinstance(cancelled.value.__cause__, RuntimeError)
+        assert str(cancelled.value.__cause__) == "snapshot command teardown failed"
 
     asyncio.run(scenario())
 
@@ -1170,35 +1176,55 @@ def test_active_model_guard_cancellation_does_not_mask_teardown_failure(
     asyncio.run(scenario())
 
 
+@pytest.mark.parametrize(
+    "cancelled_phase",
+    ("export", "record", "publish_immutable", "publish_pointer"),
+)
 def test_snapshot_refresh_cancellation_persists_teardown_failure_and_reraises(
     monkeypatch,
     tmp_path,
+    cancelled_phase,
 ):
     _configure(monkeypatch, tmp_path)
     started = threading.Event()
 
-    async def failed_record_completion(
-        _command_runner,
+    def phase_for(command: Sequence[str]) -> str:
+        script_name = Path(command[1]).name
+        if script_name == "export_research_lab_dev_icp_inputs.py":
+            return "export"
+        if script_name == "record_research_lab_dev_snapshots.py":
+            return "record"
+        if "--skip-current-pointer" in command:
+            return "publish_immutable"
+        return "publish_pointer"
+
+    def command_runner(
         command,
         _env,
         _timeout_seconds,
+        *,
+        cancellation_event=None,
     ):
-        if command[1].endswith("export_research_lab_dev_icp_inputs.py"):
+        if phase_for(command) != cancelled_phase:
             return _pipeline_output(command)
         started.set()
-        try:
-            await asyncio.Future()
-        except asyncio.CancelledError as exc:
-            raise RuntimeError("snapshot command teardown failed") from exc
+        assert cancellation_event is not None
+        assert cancellation_event.wait(timeout=5)
+        raise RuntimeError(f"{cancelled_phase} teardown failed")
+
+    monkeypatch.setattr(snapshot_refresh, "_run_command", command_runner)
 
     async def active_loader(*_args, **_kwargs):
         return _active()
 
-    monkeypatch.setattr(
-        snapshot_refresh,
-        "_await_command_completion",
-        failed_record_completion,
-    )
+    readiness_calls = 0
+
+    def readiness_loader(_uri, **_kwargs):
+        nonlocal readiness_calls
+        readiness_calls += 1
+        if readiness_calls == 1:
+            return _ready(ready=False, reason="snapshot_not_ready")
+        return _ready(manifest_hash="sha256:" + "e" * 64)
 
     async def scenario() -> None:
         refresh = asyncio.create_task(
@@ -1207,22 +1233,21 @@ def test_snapshot_refresh_cancellation_persists_teardown_failure_and_reraises(
                 worker_index=0,
                 tree_policy=TreePolicy(mode="active"),
                 now=1000,
-                readiness_loader=lambda _uri, **_kwargs: _ready(
-                    ready=False,
-                    reason="snapshot_not_ready",
-                ),
+                command_runner=snapshot_refresh._run_command,
+                readiness_loader=readiness_loader,
                 active_loader=active_loader,
             )
         )
         deadline = asyncio.get_running_loop().time() + 5
         while not started.is_set():
             if asyncio.get_running_loop().time() >= deadline:
-                raise AssertionError("snapshot recorder did not start")
+                raise AssertionError(f"snapshot {cancelled_phase} did not start")
             await asyncio.sleep(0.01)
         refresh.cancel()
-        with pytest.raises(asyncio.CancelledError):
+        with pytest.raises(asyncio.CancelledError) as cancelled:
             await refresh
         assert refresh.cancelled()
+        assert isinstance(cancelled.value, asyncio.CancelledError)
 
     asyncio.run(scenario())
 
@@ -1231,7 +1256,7 @@ def test_snapshot_refresh_cancellation_persists_teardown_failure_and_reraises(
     )
     assert state["status"] == "failed"
     assert state["last_error"] == (
-        "RuntimeError:snapshot command teardown failed"
+        f"RuntimeError:{cancelled_phase} teardown failed"
     )
     assert not any((tmp_path / "work").glob("refresh-*"))
 

--- a/tests/test_snapshot_refresh.py
+++ b/tests/test_snapshot_refresh.py
@@ -1140,8 +1140,20 @@ def test_active_model_guard_cancellation_does_not_mask_teardown_failure(
     )
 
     async def scenario() -> None:
-        guarded = asyncio.create_task(
-            snapshot_refresh._run_record_command_with_active_guard(
+        owner = asyncio.current_task()
+        assert owner is not None
+
+        async def cancel_when_started() -> None:
+            deadline = asyncio.get_running_loop().time() + 5
+            while not started.is_set():
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError("guarded recorder did not start")
+                await asyncio.sleep(0.01)
+            owner.cancel()
+
+        canceller = asyncio.create_task(cancel_when_started())
+        with pytest.raises(asyncio.CancelledError) as cancelled:
+            await snapshot_refresh._run_record_command_with_active_guard(
                 config=SimpleNamespace(),
                 command_runner=lambda *_args, **_kwargs: "",
                 command=[sys.executable, "-c", "pass"],
@@ -1151,17 +1163,77 @@ def test_active_model_guard_cancellation_does_not_mask_teardown_failure(
                 expected_identity=snapshot_refresh._artifact_identity(_active()),
                 cancel_file=tmp_path / "cancel-recording",
             )
+        await canceller
+        assert isinstance(cancelled.value.__cause__, RuntimeError)
+        assert str(cancelled.value.__cause__) == "snapshot command teardown failed"
+
+    asyncio.run(scenario())
+
+
+def test_snapshot_refresh_cancellation_persists_teardown_failure_and_reraises(
+    monkeypatch,
+    tmp_path,
+):
+    _configure(monkeypatch, tmp_path)
+    started = threading.Event()
+
+    async def failed_record_completion(
+        _command_runner,
+        command,
+        _env,
+        _timeout_seconds,
+    ):
+        if command[1].endswith("export_research_lab_dev_icp_inputs.py"):
+            return _pipeline_output(command)
+        started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError as exc:
+            raise RuntimeError("snapshot command teardown failed") from exc
+
+    async def active_loader(*_args, **_kwargs):
+        return _active()
+
+    monkeypatch.setattr(
+        snapshot_refresh,
+        "_await_command_completion",
+        failed_record_completion,
+    )
+
+    async def scenario() -> None:
+        refresh = asyncio.create_task(
+            snapshot_refresh.maybe_refresh_dev_snapshot(
+                SimpleNamespace(),
+                worker_index=0,
+                tree_policy=TreePolicy(mode="active"),
+                now=1000,
+                readiness_loader=lambda _uri, **_kwargs: _ready(
+                    ready=False,
+                    reason="snapshot_not_ready",
+                ),
+                active_loader=active_loader,
+            )
         )
         deadline = asyncio.get_running_loop().time() + 5
         while not started.is_set():
             if asyncio.get_running_loop().time() >= deadline:
-                raise AssertionError("guarded recorder did not start")
+                raise AssertionError("snapshot recorder did not start")
             await asyncio.sleep(0.01)
-        guarded.cancel()
-        with pytest.raises(RuntimeError, match="command teardown failed"):
-            await guarded
+        refresh.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await refresh
+        assert refresh.cancelled()
 
     asyncio.run(scenario())
+
+    state = json.loads(
+        (tmp_path / "state.json").read_text(encoding="utf-8")
+    )
+    assert state["status"] == "failed"
+    assert state["last_error"] == (
+        "RuntimeError:snapshot command teardown failed"
+    )
+    assert not any((tmp_path / "work").glob("refresh-*"))
 
 
 def test_utc_rollover_never_promotes_stale_snapshot_pointer(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- Preserve caller cancellation across snapshot export, record, immutable-publish, and pointer-publish teardown failures, while durably recording only the sanitized teardown cause.
- Preserve the validated virtualenv interpreter path through the subprocess gate so the snapshot recorder retains its venv prefix and venv-only packages.
- Keep protected-workflow provenance reproducible from the exact source commit.
- Isolate the prepush Docker-collision rehearsal's simulated N-1 reader from ambient host locks and daemon state with a strict, one-call `docker info` boundary.

## Confirmed failures

Current main could convert shutdown cancellation into an ordinary failed result when command teardown also raised. The record phase additionally needed a per-invocation handoff because Python 3.9 drops a child Task's `CancelledError.__cause__` when it crosses the Task boundary.

The snapshot command gate also resolved a virtualenv interpreter symlink to the base interpreter before `execve`, losing the venv prefix and venv-only dependencies despite accepting the command.

The first exact prepush run then exposed an older rehearsal-only defect: the simulated N-1 source reader inherited an unrelated ambient Docker lock and, inside the workflow image, waited for a Docker daemon that is intentionally absent. The harness now uses fresh bounded lock/admission files and permits exactly one logged readiness call. Every other direct Docker argv fails closed; the five real source-extraction operations remain exercised by the existing strict adapter.

## Safety boundaries

This PR does not change:

- sourcing or ICP/company scoring semantics;
- provider transports, retry counts, or provider-cost policy;
- Supabase schema, RPCs, migrations, persistence, or checkpoint formats;
- rebenchmark aggregation, promotion, rewards, allocation, emissions, or weight submission;
- production Docker locking or readiness behavior.

The Docker adapter and isolated lock exist only inside the disposable restart rehearsal. Snapshot teardown remains bounded; cancellation is re-raised after cleanup, and exception details are sanitized before durable state is written.

## Merge requirement

Use a history-preserving merge; **do not squash this PR**. The protected workflow manifest intentionally binds `protected_source_commit` to `0f042e5a08ccc1aa4ba119958e302f67b259993d`, and that exact source commit must remain reachable after merge.

## Verification

- Current merged head: `efb4928d591922312792a17cd5896653d349a55b`
- Focused post-merge suite: **120 passed**
- Independent snapshot review: Python 3.9 **73 passed**, Python 3.11 **73 passed**, adjacent restart/lease checks **2 passed**
- Protected workflow verifier and archive reconstruction passed (835 protected entries; source commit `0f042e5a08ccc1aa4ba119958e302f67b259993d`)
- Exact collision scenario passed inside the previously failing workflow image with event order:
  `cleanup_guard_ready -> n_minus_reader_started -> host_gateway_detect -> n_minus_source_extracted`
- Full frozen-candidate restart rehearsal from `f855c1b442c6362fbed1c1706253558e0baeb987`: **all stages passed in 424.934s**
  - PostgreSQL/Supabase contracts and retry/readback paths passed
  - full rebenchmark publication/restart recovery passed
  - both dynamic Docker collision stages passed
  - gateway/validator exact-release and PCR0 checks passed
  - primary/auditor bundle equality, signing, finalization, LastUpdate/readback, and cleanup passed
- `py_compile`, `git diff --check`, and secret scan passed
