### PR TITLE
Isolate restart ownership normalization in stage-order test

### DIFF
--- a/tests/restart_rehearsal/test_rehearsal_integrity.py
+++ b/tests/restart_rehearsal/test_rehearsal_integrity.py
@@ -7185,6 +7185,14 @@ def test_prepush_runs_validator_and_workflow_after_gateway_failure(
         lambda **_kwargs: tmp_path,
     )
     monkeypatch.setattr(rehearsal, "_prepared_fixture_seed", fixture_seed)
+    # This test exercises stage ordering after a gateway failure. Ownership
+    # normalization has its own coverage and would otherwise try to run the
+    # fake image tag below through Docker.
+    monkeypatch.setattr(
+        rehearsal,
+        "_normalize_evidence_ownership",
+        lambda *_args, **_kwargs: None,
+    )
 
     def run_component(_tag, *, component, **_kwargs):
         calls.append(component)


### PR DESCRIPTION
## Summary

- Keep `test_prepush_runs_validator_and_workflow_after_gateway_failure` focused on stage ordering after a gateway failure.
- Mock the independently tested evidence-ownership normalizer so the fake image tag used by this unit test is not sent to real Docker.
- Change tests only; production restart and rehearsal code is unchanged.

## Verification

- Prepush stage-ordering regression: `1 passed`.
- Stage-ordering regression plus exact ownership-normalizer contract test: `2 passed`.
- Python compilation and `git diff --check`: passed.

## Restart evidence

- Exact restart-orchestration rehearsal: skipped because this is a test-only mock correction and does not change a launcher, controller, rehearsal harness, protected workflow, release identity, or runtime behavior.
- The production ownership-normalizer command remains covered by its exact bounded unit test.
