### PR TITLE
Fix restart rehearsal build test contract

### DIFF
--- a/tests/restart_rehearsal/test_rehearsal_integrity.py
+++ b/tests/restart_rehearsal/test_rehearsal_integrity.py
@@ -4438,7 +4438,6 @@ def test_rehearsal_build_binds_the_platform_specific_base(
 ) -> None:
     local_base = "leadpoet-local-rehearsal-base:amd64-exact"
     buildx = Path("/validated/docker-buildx")
-    docker_client_root = tmp_path / "docker-client"
 
     @contextmanager
     def temporary_directory(*, prefix: str):
@@ -4480,21 +4479,11 @@ def test_rehearsal_build_binds_the_platform_specific_base(
             else pytest.fail("unexpected Docker platform")
         ),
     )
-    monkeypatch.setattr(
-        rehearsal,
-        "_provision_official_buildx",
-        lambda root: (
-            buildx
-            if root == docker_client_root
-            else pytest.fail("unexpected Docker client root")
-        ),
-    )
-
     rehearsal._build_image(
         "leadpoet-test:platform",
         harness_sha="a" * 40,
         docker_platform="linux/amd64",
-        docker_client_root=docker_client_root,
+        buildx_executable=buildx,
         wheelhouse_shas=("b" * 40, "a" * 40),
     )
 
@@ -4608,17 +4597,11 @@ def test_rehearsal_build_maps_both_transition_commits_to_exact_lock_content(
         "_prepare_local_rehearsal_base_image",
         lambda _docker_platform: "leadpoet-local-rehearsal-base:exact",
     )
-    monkeypatch.setattr(
-        rehearsal,
-        "_provision_official_buildx",
-        lambda _root: Path("/validated/docker-buildx"),
-    )
-
     rehearsal._build_image(
         "leadpoet-test:transition-locks",
         harness_sha=candidate_sha,
         docker_platform="linux/amd64",
-        docker_client_root=tmp_path / "docker-client",
+        buildx_executable=Path("/validated/docker-buildx"),
         wheelhouse_shas=(from_sha, candidate_sha),
     )
 
@@ -4796,18 +4779,12 @@ def test_rehearsal_build_stages_compact_weight_readiness_dependency(
         "_prepare_local_rehearsal_base_image",
         lambda _docker_platform: "leadpoet-local-rehearsal-base:exact",
     )
-    monkeypatch.setattr(
-        rehearsal,
-        "_provision_official_buildx",
-        lambda _root: Path("/validated/docker-buildx"),
-    )
-
     candidate_sha = "a" * 40
     rehearsal._build_image(
         "leadpoet-test:compact-weight-import",
         harness_sha=candidate_sha,
         docker_platform="linux/amd64",
-        docker_client_root=tmp_path / "docker-client",
+        buildx_executable=Path("/validated/docker-buildx"),
         wheelhouse_shas=(candidate_sha,),
     )
 


### PR DESCRIPTION
## Summary

Update three restart-rehearsal unit tests to use the current `_build_image`
contract. The change is test-only and does not alter restart or production
behavior.

## Root cause

Main moved official Buildx provisioning to `_run_profile` and changed
`_build_image` to accept the already-provisioned `buildx_executable`. Three
direct `_build_image` tests still passed the removed `docker_client_root`
keyword and mocked provisioning inside the lower layer.

## Change

- Pass `buildx_executable` to the three direct `_build_image` calls.
- Remove the obsolete `docker_client_root` setup and
  `_provision_official_buildx` mocks.
- Keep Buildx provisioning coverage in
  `tests/test_restart_rehearsal_controller_profiles.py`, where that behavior
  is owned.

## Verification

- [Deploy Checks run 32306969677](https://github.com/leadpoet/leadpoet/actions/runs/32306969677):
  passed on exact head `7034f5853ea424c1a33212bff737ec9c4f7702c2`.
  The Python job completed with `7401 passed, 4 skipped, 262 subtests passed`;
  the Docker gateway and validator image smoke builds also passed.
- Exact failing test selection: `3 passed`.
- Buildx controller-profile suite: `80 passed, 2 skipped`.
- Full restart-integrity file: the three changed tests pass; local execution
  reached `147 passed` with nine unrelated host-environment failures from
  absent AWS packages, blocked socket binds, and local Buildx/timing limits.
- Python compile and `git diff --check`: passed.
- Exact constrained-host restart rehearsal: unexercised. This candidate does
  not expose `--outer-cpus` or `--outer-memory`, and this host has 10 CPUs and
  24 GiB rather than the production 16 CPUs and 128 GiB contract.

## Stack impact

Merge this PR first. Then update #93 from main and rerun its CI. #96 remains
stacked on #93.

No deployment, production restart, model-pointer change, provider call, or
data mutation occurred.
