### PR TITLE
Superseded: common model runner host

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -404,13 +404,57 @@ helper. If the helper is unavailable, synchronize the canonical checkout with
 
 ## Research Lab and sourcing boundaries
 
+### Single model runner parity (non-negotiable)
+
+Leadpoet Site production, local champion/parity execution, and the Research Lab
+champion lane must execute the same model-owned runner from one immutable
+`leadpoet/Sourcing_model` release. "Same" requires all of the following:
+
+- The source commit, model artifact digest, dependency-lock hash, runtime/base
+  image digest, consumer-contract hash, routing catalog/policy/profile hashes,
+  feature-schema hash, verifier identity, tool-binding manifest hashes, and LLM
+  configuration identity are exact matches.
+- All three paths use the same model-owned start, continuation, action,
+  completion, result, and canonical-receipt contracts. The model alone owns ICP
+  normalization; candidate, intent, and contact routing; provider order;
+  budgets, retries, and stop conditions; evidence parsing; and qualification
+  decisions.
+- Hosts own only credentials, network calls, queues, leases, provider rate
+  limits, durable storage, actual cost/latency reporting, health, and
+  deployment. A host must not add a route, reorder tools, reinterpret evidence,
+  select an alternate verifier, or make a qualification decision.
+- A legacy `run_icp()`, direct Exa segmented executor, Site-owned intent
+  router, or consumer-specific verifier cannot satisfy champion or parity
+  execution. An external verifier is allowed only when every path uses the
+  same immutable verifier artifact and digest bound into the release identity.
+- The same normalized input, evaluation date, capability contract, and recorded
+  provider responses must produce byte-identical model action sequences,
+  provider request fingerprints, evidence admission/rejection decisions, final
+  results, and canonical model receipts. Host receipts may differ only for
+  host-owned operational facts.
+- A local working-tree run or Research Lab challenger may use a different model
+  only when it is clearly labeled non-champion and non-parity. Challenger
+  results must never be mixed with champion parity results. The
+  `leadpoet-lab` branch artifact is challenger-only until its exact release is
+  promoted to `main`, pinned by Site, and selected as the shared champion.
+- Any change that could make Site, local, and Lab behavior differ must start in
+  `Sourcing_model`, update the versioned consumer contract and deterministic
+  cross-consumer replay fixtures, and update both thin host adapters in the
+  same reviewed release.
+- Every consumer must fail startup or activation when a required identity,
+  binding, protocol member, or parity proof is missing or different. Never
+  fall back silently to a legacy or consumer-owned execution path.
+
 - This repository owns Research Lab consumption, benchmarking, fulfillment
   infrastructure, gateway, and validator runtimes. `leadpoet/Sourcing_model`
   owns model semantics and industry taxonomy.
-- Research Lab consumes the signed branch-specific
-  `research-lab/sourcing-model/branches/leadpoet-lab/current.json` artifact.
-  Verify repository, commit, signature, image digest, and lineage. Never fall
-  back to the shared `main` pointer.
+- Research Lab champion and local parity execution consume the exact signed
+  immutable artifact selected by Site production. The branch-specific
+  `research-lab/sourcing-model/branches/leadpoet-lab/current.json` artifact is
+  challenger-only until that exact release is promoted to `main`, pinned by
+  Site, and selected as the shared champion. Verify repository, commit,
+  signature, image digest, and lineage for both lanes, and never substitute
+  one lane for the other.
 - Model-quality fixes belong in `Sourcing_model`; consumers may bind
   credentials and transport but may not reinterpret model-owned plans.
 - Preserve exactly one official candidate entering paid scoring. Keep

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,13 +404,57 @@ helper. If the helper is unavailable, synchronize the canonical checkout with
 
 ## Research Lab and sourcing boundaries
 
+### Single model runner parity (non-negotiable)
+
+Leadpoet Site production, local champion/parity execution, and the Research Lab
+champion lane must execute the same model-owned runner from one immutable
+`leadpoet/Sourcing_model` release. "Same" requires all of the following:
+
+- The source commit, model artifact digest, dependency-lock hash, runtime/base
+  image digest, consumer-contract hash, routing catalog/policy/profile hashes,
+  feature-schema hash, verifier identity, tool-binding manifest hashes, and LLM
+  configuration identity are exact matches.
+- All three paths use the same model-owned start, continuation, action,
+  completion, result, and canonical-receipt contracts. The model alone owns ICP
+  normalization; candidate, intent, and contact routing; provider order;
+  budgets, retries, and stop conditions; evidence parsing; and qualification
+  decisions.
+- Hosts own only credentials, network calls, queues, leases, provider rate
+  limits, durable storage, actual cost/latency reporting, health, and
+  deployment. A host must not add a route, reorder tools, reinterpret evidence,
+  select an alternate verifier, or make a qualification decision.
+- A legacy `run_icp()`, direct Exa segmented executor, Site-owned intent
+  router, or consumer-specific verifier cannot satisfy champion or parity
+  execution. An external verifier is allowed only when every path uses the
+  same immutable verifier artifact and digest bound into the release identity.
+- The same normalized input, evaluation date, capability contract, and recorded
+  provider responses must produce byte-identical model action sequences,
+  provider request fingerprints, evidence admission/rejection decisions, final
+  results, and canonical model receipts. Host receipts may differ only for
+  host-owned operational facts.
+- A local working-tree run or Research Lab challenger may use a different model
+  only when it is clearly labeled non-champion and non-parity. Challenger
+  results must never be mixed with champion parity results. The
+  `leadpoet-lab` branch artifact is challenger-only until its exact release is
+  promoted to `main`, pinned by Site, and selected as the shared champion.
+- Any change that could make Site, local, and Lab behavior differ must start in
+  `Sourcing_model`, update the versioned consumer contract and deterministic
+  cross-consumer replay fixtures, and update both thin host adapters in the
+  same reviewed release.
+- Every consumer must fail startup or activation when a required identity,
+  binding, protocol member, or parity proof is missing or different. Never
+  fall back silently to a legacy or consumer-owned execution path.
+
 - This repository owns Research Lab consumption, benchmarking, fulfillment
   infrastructure, gateway, and validator runtimes. `leadpoet/Sourcing_model`
   owns model semantics and industry taxonomy.
-- Research Lab consumes the signed branch-specific
-  `research-lab/sourcing-model/branches/leadpoet-lab/current.json` artifact.
-  Verify repository, commit, signature, image digest, and lineage. Never fall
-  back to the shared `main` pointer.
+- Research Lab champion and local parity execution consume the exact signed
+  immutable artifact selected by Site production. The branch-specific
+  `research-lab/sourcing-model/branches/leadpoet-lab/current.json` artifact is
+  challenger-only until that exact release is promoted to `main`, pinned by
+  Site, and selected as the shared champion. Verify repository, commit,
+  signature, image digest, and lineage for both lanes, and never substitute
+  one lane for the other.
 - Model-quality fixes belong in `Sourcing_model`; consumers may bind
   credentials and transport but may not reinterpret model-owned plans.
 - Preserve exactly one official candidate entering paid scoring. Keep

--- a/research_lab/champion_model_runner.py
+++ b/research_lab/champion_model_runner.py
@@ -1,0 +1,58 @@
+"""Focused Research Lab champion entry for the common model runner."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from research_lab.eval.private_runtime import DockerPrivateModelRunner
+
+from .common_model_runner_host import (
+    CommonModelRunnerHost,
+    HostActionBinding,
+    LoadCompletion,
+    PersistTransition,
+)
+from .docker_model_runner_transport import DockerModelRunnerTransport
+from .model_runner_protocol import ResearchLabModelRunnerProtocol
+
+
+def run_common_champion(
+    *,
+    runner: DockerPrivateModelRunner,
+    input: Mapping[str, Any],
+    execution_mode: str,
+    target_count: int,
+    evaluated_on: str,
+    host_capability_manifest: Mapping[str, Any],
+    release_identity: Mapping[str, Any],
+    bindings: Sequence[HostActionBinding],
+    persist_transition: PersistTransition,
+    load_completion: LoadCompletion | None = None,
+    continuation: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    """Run one champion request without the legacy segmented executor."""
+
+    transport = DockerModelRunnerTransport(runner)
+    start_request = transport.build_runner_start(
+        input=input,
+        execution_mode=execution_mode,
+        target_count=target_count,
+        evaluated_on=evaluated_on,
+        host_capability_manifest=host_capability_manifest,
+        release_identity=release_identity,
+    )
+    protocol = ResearchLabModelRunnerProtocol(
+        transport=transport,
+        expected_release_identity=release_identity,
+    )
+    host = CommonModelRunnerHost(
+        consumer_id="research-lab-champion",
+        protocol=protocol,
+        bindings=bindings,
+        persist_transition=persist_transition,
+        load_completion=load_completion,
+    )
+    return host.run(start_request, continuation=continuation)
+
+
+__all__ = ["run_common_champion"]

--- a/research_lab/common_model_runner_host.py
+++ b/research_lab/common_model_runner_host.py
@@ -1,0 +1,317 @@
+"""Consumer-neutral host loop for the model-owned continuation protocol.
+
+This module owns no routing, policy, parsing, or qualification behavior.  It
+dispatches only the exact action emitted by the immutable model artifact.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any, Callable, Mapping, Optional, Protocol, Sequence
+
+
+HOST_EXECUTION_RECEIPT_SCHEMA_VERSION = "model-runner-host-receipt:v1"
+_ACTION_TYPES = frozenset({
+    "execute_candidate_tool",
+    "verify_company",
+    "execute_intent_tool",
+    "verify_intent",
+    "execute_contact_tool",
+    "verify_contact",
+})
+_OUTCOMES = frozenset({
+    "succeeded",
+    "empty",
+    "unavailable",
+    "timeout",
+    "failed",
+})
+
+
+class ModelRunnerHostError(RuntimeError):
+    """A model action cannot be dispatched without changing its contract."""
+
+
+@dataclass(frozen=True)
+class HostActionResult:
+    """One host call result before model-owned parsing and qualification."""
+
+    outcome: str
+    reason_code: str
+    provider_response: Mapping[str, Any] | None
+    calls: int
+    cost_credits: float
+    latency_ms: float
+    provider_request_id: str | None = None
+
+
+@dataclass(frozen=True)
+class HostActionBinding:
+    """Credentialed execution for one exact model-owned action and tool ID."""
+
+    action_type: str
+    tool_id: str
+    binding_contract_sha256: str
+    execute: Callable[[Mapping[str, Any]], HostActionResult]
+
+
+class ModelRunnerProtocol(Protocol):
+    """Artifact transport used by either an in-process or OCI model runner."""
+
+    def advance(
+        self,
+        start_request: Mapping[str, Any],
+        *,
+        continuation: Mapping[str, Any] | None,
+        completion: Mapping[str, Any] | None,
+    ) -> Mapping[str, Any]: ...
+
+    def build_completion(
+        self,
+        action: Mapping[str, Any],
+        result: HostActionResult,
+    ) -> Mapping[str, Any]: ...
+
+
+PersistTransition = Callable[..., None]
+LoadCompletion = Callable[[str], Optional[Mapping[str, Any]]]
+
+
+def _canonical_sha256(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _binding_key(value: Mapping[str, Any]) -> tuple[str, str]:
+    return (
+        str(value.get("action_type") or ""),
+        str(value.get("tool_id") or "").strip().casefold(),
+    )
+
+
+def _available_manifest_bindings(
+    start_request: Mapping[str, Any],
+) -> dict[tuple[str, str], str]:
+    manifest = start_request.get("host_capability_manifest")
+    if not isinstance(manifest, Mapping):
+        raise ModelRunnerHostError("start request has no host capability manifest")
+    raw_bindings = manifest.get("bindings")
+    if not isinstance(raw_bindings, Sequence) or isinstance(
+        raw_bindings,
+        (str, bytes, bytearray),
+    ):
+        raise ModelRunnerHostError("host capability bindings are invalid")
+    available: dict[tuple[str, str], str] = {}
+    for item in raw_bindings:
+        if not isinstance(item, Mapping):
+            raise ModelRunnerHostError("host capability binding is invalid")
+        if item.get("available") is not True:
+            continue
+        key = _binding_key(item)
+        contract_hash = str(item.get("binding_contract_sha256") or "")
+        if key in available:
+            raise ModelRunnerHostError("host capability binding is duplicated")
+        available[key] = contract_hash
+    if not available:
+        raise ModelRunnerHostError("host capability manifest has no bindings")
+    return available
+
+
+def _binding_index(
+    bindings: Sequence[HostActionBinding],
+) -> dict[tuple[str, str], HostActionBinding]:
+    indexed: dict[tuple[str, str], HostActionBinding] = {}
+    for binding in bindings:
+        key = (binding.action_type, binding.tool_id.strip().casefold())
+        if key in indexed:
+            raise ModelRunnerHostError("host action binding is duplicated")
+        if binding.action_type not in _ACTION_TYPES:
+            raise ModelRunnerHostError("host action binding type is invalid")
+        if not callable(binding.execute):
+            raise ModelRunnerHostError("host action binding is not executable")
+        indexed[key] = binding
+    return indexed
+
+
+def _host_receipt(
+    *,
+    consumer_id: str,
+    action: Mapping[str, Any],
+    completion: Mapping[str, Any],
+    provider_request_id: str | None,
+    replayed: bool,
+) -> dict[str, Any]:
+    request_id_hash = (
+        _canonical_sha256(provider_request_id)
+        if provider_request_id
+        else None
+    )
+    payload = {
+        "schema_version": HOST_EXECUTION_RECEIPT_SCHEMA_VERSION,
+        "consumer_id": consumer_id,
+        "action_sha256": str(action.get("action_sha256") or ""),
+        "idempotency_key": str(action.get("idempotency_key") or ""),
+        "binding_contract_sha256": str(
+            action.get("binding_contract_sha256") or ""
+        ),
+        "provider_request_id_sha256": request_id_hash,
+        "provider_response_sha256": str(
+            completion.get("provider_response_sha256") or ""
+        ),
+        "completion_sha256": str(completion.get("completion_sha256") or ""),
+        "outcome": str(completion.get("outcome") or ""),
+        "calls": completion.get("calls"),
+        "cost_credits": completion.get("cost_credits"),
+        "latency_ms": completion.get("latency_ms"),
+        "replayed": replayed,
+    }
+    return {**payload, "receipt_sha256": _canonical_sha256(payload)}
+
+
+class CommonModelRunnerHost:
+    """Run the exact artifact continuation until it reaches a terminal result."""
+
+    def __init__(
+        self,
+        *,
+        consumer_id: str,
+        protocol: ModelRunnerProtocol,
+        bindings: Sequence[HostActionBinding],
+        persist_transition: PersistTransition,
+        load_completion: LoadCompletion | None = None,
+        max_actions: int = 10_000,
+    ) -> None:
+        if not consumer_id or len(consumer_id) > 80:
+            raise ModelRunnerHostError("consumer_id is invalid")
+        if not callable(persist_transition):
+            raise ModelRunnerHostError("durable transition sink is required")
+        if isinstance(max_actions, bool) or not 1 <= max_actions <= 10_000:
+            raise ModelRunnerHostError("max_actions must be between 1 and 10000")
+        self._consumer_id = consumer_id
+        self._protocol = protocol
+        self._bindings = _binding_index(bindings)
+        self._persist_transition = persist_transition
+        self._load_completion = load_completion
+        self._max_actions = max_actions
+
+    def run(
+        self,
+        start_request: Mapping[str, Any],
+        *,
+        continuation: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        expected = _available_manifest_bindings(start_request)
+        actual = {
+            key: binding.binding_contract_sha256
+            for key, binding in self._bindings.items()
+        }
+        if actual != expected:
+            raise ModelRunnerHostError(
+                "executable bindings differ from the capability manifest"
+            )
+
+        state = self._protocol.advance(
+            start_request,
+            continuation=continuation,
+            completion=None,
+        )
+        completed_actions = 0
+        while state.get("status") == "action_required":
+            if completed_actions >= self._max_actions:
+                raise ModelRunnerHostError("model action limit was reached")
+            action = state.get("action")
+            next_continuation = state.get("continuation")
+            if not isinstance(action, Mapping) or not isinstance(
+                next_continuation,
+                Mapping,
+            ):
+                raise ModelRunnerHostError("model action response is invalid")
+            action_type = str(action.get("action_type") or "")
+            tool_id = str(action.get("tool_id") or "").strip().casefold()
+            binding = self._bindings.get((action_type, tool_id))
+            if binding is None:
+                raise ModelRunnerHostError("model selected an unbound host action")
+            if (
+                str(action.get("binding_contract_sha256") or "")
+                != binding.binding_contract_sha256
+            ):
+                raise ModelRunnerHostError("model action binding hash differs")
+            idempotency_key = str(action.get("idempotency_key") or "")
+            if not idempotency_key:
+                raise ModelRunnerHostError("model action has no idempotency key")
+
+            cached = (
+                self._load_completion(idempotency_key)
+                if self._load_completion is not None
+                else None
+            )
+            if cached is None:
+                host_result = binding.execute(action)
+                if not isinstance(host_result, HostActionResult):
+                    raise ModelRunnerHostError(
+                        "host binding must return HostActionResult"
+                    )
+                if host_result.outcome not in _OUTCOMES:
+                    raise ModelRunnerHostError("host binding outcome is invalid")
+                completion = self._protocol.build_completion(
+                    action,
+                    host_result,
+                )
+                provider_request_id = host_result.provider_request_id
+                replayed = False
+            else:
+                completion = cached
+                provider_request_id = None
+                replayed = True
+
+            advanced = self._protocol.advance(
+                start_request,
+                continuation=next_continuation,
+                completion=completion,
+            )
+            advanced_continuation = advanced.get("continuation")
+            if not isinstance(advanced_continuation, Mapping):
+                raise ModelRunnerHostError("model continuation is missing")
+            receipt = _host_receipt(
+                consumer_id=self._consumer_id,
+                action=action,
+                completion=completion,
+                provider_request_id=provider_request_id,
+                replayed=replayed,
+            )
+            self._persist_transition(
+                idempotency_key=idempotency_key,
+                action=dict(action),
+                completion=dict(completion),
+                continuation=dict(advanced_continuation),
+                host_receipt=receipt,
+            )
+            state = advanced
+            completed_actions += 1
+
+        if state.get("status") != "completed":
+            raise ModelRunnerHostError("model runner returned an invalid status")
+        if not isinstance(state.get("result"), Mapping) or not isinstance(
+            state.get("model_receipt"),
+            Mapping,
+        ):
+            raise ModelRunnerHostError("model runner terminal result is invalid")
+        return state
+
+
+__all__ = [
+    "CommonModelRunnerHost",
+    "HOST_EXECUTION_RECEIPT_SCHEMA_VERSION",
+    "HostActionBinding",
+    "HostActionResult",
+    "ModelRunnerHostError",
+    "ModelRunnerProtocol",
+]

--- a/research_lab/deepline_model_runner_bindings.py
+++ b/research_lab/deepline_model_runner_bindings.py
@@ -1,0 +1,153 @@
+"""Deepline transport bindings for reviewed common-runner tool IDs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+
+from .common_model_runner_host import (
+    HostActionBinding,
+    HostActionResult,
+    ModelRunnerHostError,
+)
+
+
+HOST_PROVIDER_RESPONSE_SCHEMA_VERSION = "host-provider-response:v1"
+DEEPLINE_RUNNER_REQUEST_SCHEMA_VERSION = "model-runner-deepline-action:v1"
+
+
+@dataclass(frozen=True)
+class DeeplineToolContract:
+    deepline_tool_id: str
+    timeout_seconds: float
+    maximum_cost_credits: float
+
+
+DEEPLINE_TOOL_CONTRACTS = {
+    "intent.source_add.predictleads_financing": DeeplineToolContract(
+        deepline_tool_id="predictleads_company_financing_events",
+        timeout_seconds=30,
+        maximum_cost_credits=0.56,
+    ),
+    "intent.source_add.predictleads_jobs": DeeplineToolContract(
+        deepline_tool_id="predictleads_company_job_openings",
+        timeout_seconds=30,
+        maximum_cost_credits=0.56,
+    ),
+    "intent.source_add.predictleads_connections": DeeplineToolContract(
+        deepline_tool_id="predictleads_company_connections",
+        timeout_seconds=30,
+        maximum_cost_credits=1.68,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class DeeplineCallReceipt:
+    status_code: int
+    body: Mapping[str, Any]
+    calls: int
+    cost_credits: float
+    latency_ms: float
+    provider_request_id: str | None = None
+
+
+class DeeplineRunnerClient(Protocol):
+    """Credentialed Lab client that performs the host-owned network call."""
+
+    def execute_tool(
+        self,
+        *,
+        tool_id: str,
+        payload: Mapping[str, Any],
+        idempotency_key: str,
+        timeout_seconds: float,
+    ) -> DeeplineCallReceipt: ...
+
+
+def _execute_deepline_action(
+    *,
+    client: DeeplineRunnerClient,
+    contract: DeeplineToolContract,
+    action: Mapping[str, Any],
+) -> HostActionResult:
+    arguments = action.get("arguments")
+    if not isinstance(arguments, Mapping):
+        raise ModelRunnerHostError("model Deepline action arguments are invalid")
+    idempotency_key = str(action.get("idempotency_key") or "")
+    if not idempotency_key:
+        raise ModelRunnerHostError("model Deepline action is not idempotent")
+    tool_id = str(action.get("tool_id") or "")
+    receipt = client.execute_tool(
+        tool_id=contract.deepline_tool_id,
+        payload={
+            "schema_version": DEEPLINE_RUNNER_REQUEST_SCHEMA_VERSION,
+            "model_tool_id": tool_id,
+            "arguments": dict(arguments),
+        },
+        idempotency_key=idempotency_key,
+        timeout_seconds=contract.timeout_seconds,
+    )
+    if not isinstance(receipt, DeeplineCallReceipt):
+        raise ModelRunnerHostError("Deepline client receipt is invalid")
+    if receipt.calls < 1:
+        raise ModelRunnerHostError("Deepline call receipt has no call")
+    if not 0 <= receipt.cost_credits <= contract.maximum_cost_credits:
+        raise ModelRunnerHostError("Deepline call exceeded its cost limit")
+    if not 200 <= receipt.status_code < 300:
+        return HostActionResult(
+            outcome="failed",
+            reason_code=f"deepline_http_{receipt.status_code}",
+            provider_response=None,
+            calls=receipt.calls,
+            cost_credits=receipt.cost_credits,
+            latency_ms=receipt.latency_ms,
+            provider_request_id=receipt.provider_request_id,
+        )
+    return HostActionResult(
+        outcome="succeeded",
+        reason_code="deepline_completed",
+        provider_response={
+            "schema_version": HOST_PROVIDER_RESPONSE_SCHEMA_VERSION,
+            "provider": "deepline",
+            "status_code": receipt.status_code,
+            "body": dict(receipt.body),
+        },
+        calls=receipt.calls,
+        cost_credits=receipt.cost_credits,
+        latency_ms=receipt.latency_ms,
+        provider_request_id=receipt.provider_request_id,
+    )
+
+
+def build_deepline_runner_binding(
+    *,
+    model_tool_id: str,
+    binding_contract_sha256: str,
+    client: DeeplineRunnerClient,
+) -> HostActionBinding:
+    """Bind one reviewed model tool ID without adding host routing policy."""
+
+    contract = DEEPLINE_TOOL_CONTRACTS.get(model_tool_id)
+    if contract is None:
+        raise ModelRunnerHostError("Deepline model tool ID is not reviewed")
+    return HostActionBinding(
+        action_type="execute_intent_tool",
+        tool_id=model_tool_id,
+        binding_contract_sha256=binding_contract_sha256,
+        execute=lambda action: _execute_deepline_action(
+            client=client,
+            contract=contract,
+            action=action,
+        ),
+    )
+
+
+__all__ = [
+    "DEEPLINE_RUNNER_REQUEST_SCHEMA_VERSION",
+    "DEEPLINE_TOOL_CONTRACTS",
+    "DeeplineCallReceipt",
+    "DeeplineRunnerClient",
+    "DeeplineToolContract",
+    "build_deepline_runner_binding",
+]

--- a/research_lab/docker_model_runner_transport.py
+++ b/research_lab/docker_model_runner_transport.py
@@ -1,0 +1,141 @@
+"""Credential-free OCI calls to the common champion runner adapter."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Mapping
+
+from research_lab.eval.private_runtime import (
+    DockerPrivateModelRunner,
+    PrivateModelRuntimeError,
+)
+
+
+_COMMON_RUNNER_BOOTSTRAP = r"""
+import contextlib
+import importlib
+import json
+import sys
+
+module_name, operation = sys.argv[1:3]
+payload = json.load(sys.stdin)
+module = importlib.import_module(module_name)
+if operation == "build_runner_start":
+    result = module.build_runner_start(
+        input=payload["input"],
+        execution_mode=payload["execution_mode"],
+        target_count=payload["target_count"],
+        evaluated_on=payload["evaluated_on"],
+        host_capability_manifest=payload["host_capability_manifest"],
+        release_identity=payload["release_identity"],
+    )
+elif operation == "continue_runner":
+    result = module.continue_runner(
+        payload["start_request"],
+        expected_release_identity=payload["expected_release_identity"],
+        continuation=payload.get("continuation"),
+        completion=payload.get("completion"),
+    )
+elif operation == "build_runner_completion":
+    result = module.build_runner_completion(
+        payload["action"],
+        payload["result"],
+    )
+else:
+    raise RuntimeError("unsupported common runner operation")
+with contextlib.redirect_stdout(sys.stderr):
+    encoded = json.dumps(result, sort_keys=True, separators=(",", ":"))
+sys.stdout.write(encoded)
+"""
+
+
+class DockerModelRunnerTransport:
+    """Invoke only runner APIs, without forwarding provider credentials."""
+
+    def __init__(self, runner: DockerPrivateModelRunner) -> None:
+        if not isinstance(runner, DockerPrivateModelRunner):
+            raise PrivateModelRuntimeError("Docker model runner is required")
+        isolated_spec = replace(
+            runner.spec,
+            env_passthrough=(),
+            extra_env={},
+            pull_before_run=False,
+        )
+        self._runner = DockerPrivateModelRunner(isolated_spec)
+
+    def _call(
+        self,
+        operation: str,
+        payload: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        result = self._runner._run_json(
+            bootstrap=_COMMON_RUNNER_BOOTSTRAP,
+            argv=(self._runner.spec.module_name, operation),
+            stdin_payload=payload,
+        )
+        if not isinstance(result, Mapping):
+            raise PrivateModelRuntimeError(
+                "common model runner returned a non-object response"
+            )
+        return result
+
+    def continue_runner(
+        self,
+        start_request: Mapping[str, Any],
+        *,
+        expected_release_identity: Mapping[str, Any],
+        continuation: Mapping[str, Any] | None,
+        completion: Mapping[str, Any] | None,
+    ) -> Mapping[str, Any]:
+        return self._call(
+            "continue_runner",
+            {
+                "start_request": dict(start_request),
+                "expected_release_identity": dict(
+                    expected_release_identity
+                ),
+                "continuation": (
+                    None if continuation is None else dict(continuation)
+                ),
+                "completion": (
+                    None if completion is None else dict(completion)
+                ),
+            },
+        )
+
+    def build_runner_start(
+        self,
+        *,
+        input: Mapping[str, Any],
+        execution_mode: str,
+        target_count: int,
+        evaluated_on: str,
+        host_capability_manifest: Mapping[str, Any],
+        release_identity: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        return self._call(
+            "build_runner_start",
+            {
+                "input": dict(input),
+                "execution_mode": execution_mode,
+                "target_count": target_count,
+                "evaluated_on": evaluated_on,
+                "host_capability_manifest": dict(
+                    host_capability_manifest
+                ),
+                "release_identity": dict(release_identity),
+            },
+        )
+
+    def build_runner_completion(
+        self,
+        action: Mapping[str, Any],
+        result: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        return self._call(
+            "build_runner_completion",
+            {"action": dict(action), "result": dict(result)},
+        )
+
+
+__all__ = ["DockerModelRunnerTransport"]

--- a/research_lab/model_runner_protocol.py
+++ b/research_lab/model_runner_protocol.py
@@ -1,0 +1,84 @@
+"""Research Lab transport for the immutable champion runner artifact."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol
+
+from .common_model_runner_host import HostActionResult, ModelRunnerHostError
+
+
+class ArtifactRunnerTransport(Protocol):
+    """OCI boundary exposed by the reviewed Research Lab adapter."""
+
+    def continue_runner(
+        self,
+        start_request: Mapping[str, Any],
+        *,
+        expected_release_identity: Mapping[str, Any],
+        continuation: Mapping[str, Any] | None,
+        completion: Mapping[str, Any] | None,
+    ) -> Mapping[str, Any]: ...
+
+    def build_runner_completion(
+        self,
+        action: Mapping[str, Any],
+        result: Mapping[str, Any],
+    ) -> Mapping[str, Any]: ...
+
+
+class ResearchLabModelRunnerProtocol:
+    """Advance the champion only through its signed OCI adapter methods."""
+
+    def __init__(
+        self,
+        *,
+        transport: ArtifactRunnerTransport,
+        expected_release_identity: Mapping[str, Any],
+    ) -> None:
+        if not isinstance(expected_release_identity, Mapping):
+            raise ModelRunnerHostError("model release identity is required")
+        self._transport = transport
+        self._release_identity = dict(expected_release_identity)
+
+    def advance(
+        self,
+        start_request: Mapping[str, Any],
+        *,
+        continuation: Mapping[str, Any] | None,
+        completion: Mapping[str, Any] | None,
+    ) -> Mapping[str, Any]:
+        result = self._transport.continue_runner(
+            start_request,
+            expected_release_identity=self._release_identity,
+            continuation=continuation,
+            completion=completion,
+        )
+        if not isinstance(result, Mapping):
+            raise ModelRunnerHostError("artifact continuation is invalid")
+        return result
+
+    def build_completion(
+        self,
+        action: Mapping[str, Any],
+        result: HostActionResult,
+    ) -> Mapping[str, Any]:
+        completion = self._transport.build_runner_completion(
+            action,
+            {
+                "outcome": result.outcome,
+                "reason_code": result.reason_code,
+                "provider_response": result.provider_response,
+                "calls": result.calls,
+                "cost_credits": result.cost_credits,
+                "latency_ms": result.latency_ms,
+            },
+        )
+        if not isinstance(completion, Mapping):
+            raise ModelRunnerHostError("artifact completion is invalid")
+        return completion
+
+
+__all__ = [
+    "ArtifactRunnerTransport",
+    "ResearchLabModelRunnerProtocol",
+]

--- a/tests/test_common_model_runner_host.py
+++ b/tests/test_common_model_runner_host.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from research_lab.common_model_runner_host import (
+    CommonModelRunnerHost,
+    HostActionBinding,
+    HostActionResult,
+    ModelRunnerHostError,
+)
+from research_lab.deepline_model_runner_bindings import (
+    DEEPLINE_RUNNER_REQUEST_SCHEMA_VERSION,
+    DeeplineCallReceipt,
+    build_deepline_runner_binding,
+)
+from research_lab.model_runner_protocol import ResearchLabModelRunnerProtocol
+from research_lab.docker_model_runner_transport import (
+    DockerModelRunnerTransport,
+)
+from research_lab.eval.private_runtime import (
+    DockerPrivateModelRunner,
+    DockerPrivateModelSpec,
+)
+
+
+CONTRACT_HASH = "a" * 64
+
+
+def _start_request():
+    return {
+        "host_capability_manifest": {
+            "bindings": [{
+                "action_type": "execute_intent_tool",
+                "tool_id": "intent.source_add.predictleads_financing",
+                "binding_contract_sha256": CONTRACT_HASH,
+                "available": True,
+            }]
+        }
+    }
+
+
+def _action():
+    return {
+        "action_type": "execute_intent_tool",
+        "tool_id": "intent.source_add.predictleads_financing",
+        "binding_contract_sha256": CONTRACT_HASH,
+        "action_sha256": "b" * 64,
+        "idempotency_key": "c" * 64,
+        "arguments": {"candidate": {"official_domain": "acme.test"}},
+    }
+
+
+class FakeArtifactTransport:
+    def __init__(self):
+        self.completion_inputs = []
+
+    def continue_runner(
+        self,
+        _start,
+        *,
+        expected_release_identity,
+        continuation,
+        completion,
+    ):
+        assert expected_release_identity == {"release": "exact"}
+        if continuation is None:
+            return {
+                "status": "action_required",
+                "action": _action(),
+                "continuation": {"step": 1},
+            }
+        assert completion["completion_sha256"] == "e" * 64
+        return {
+            "status": "completed",
+            "continuation": {"step": 2},
+            "result": {"leads": []},
+            "model_receipt": {"receipt_sha256": "f" * 64},
+        }
+
+    def build_runner_completion(self, _action_value, result):
+        self.completion_inputs.append(result)
+        return {
+            "outcome": result["outcome"],
+            "calls": result["calls"],
+            "cost_credits": result["cost_credits"],
+            "latency_ms": result["latency_ms"],
+            "provider_response_sha256": "d" * 64,
+            "completion_sha256": "e" * 64,
+        }
+
+
+class FakeDeeplineClient:
+    def __init__(self, *, cost=0.56):
+        self.cost = cost
+        self.requests = []
+
+    def execute_tool(self, **request):
+        self.requests.append(request)
+        return DeeplineCallReceipt(
+            status_code=200,
+            body={
+                "run": {"status": "completed"},
+                "outputs": {"model_provider_records": []},
+            },
+            calls=1,
+            cost_credits=self.cost,
+            latency_ms=20,
+            provider_request_id="private-provider-id",
+        )
+
+
+def test_lab_dispatches_deepline_through_the_artifact_protocol():
+    artifact = FakeArtifactTransport()
+    protocol = ResearchLabModelRunnerProtocol(
+        transport=artifact,
+        expected_release_identity={"release": "exact"},
+    )
+    client = FakeDeeplineClient()
+    binding = build_deepline_runner_binding(
+        model_tool_id="intent.source_add.predictleads_financing",
+        binding_contract_sha256=CONTRACT_HASH,
+        client=client,
+    )
+    persisted = []
+    result = CommonModelRunnerHost(
+        consumer_id="research-lab-champion",
+        protocol=protocol,
+        bindings=[binding],
+        persist_transition=lambda **value: persisted.append(value),
+    ).run(_start_request())
+
+    assert result["status"] == "completed"
+    assert client.requests[0]["tool_id"] == (
+        "predictleads_company_financing_events"
+    )
+    assert client.requests[0]["payload"]["schema_version"] == (
+        DEEPLINE_RUNNER_REQUEST_SCHEMA_VERSION
+    )
+    assert artifact.completion_inputs[0]["provider_response"]["provider"] == (
+        "deepline"
+    )
+    assert "private-provider-id" not in str(persisted[0]["host_receipt"])
+
+
+def test_deepline_binding_enforces_reviewed_cost_limit():
+    binding = build_deepline_runner_binding(
+        model_tool_id="intent.source_add.predictleads_financing",
+        binding_contract_sha256=CONTRACT_HASH,
+        client=FakeDeeplineClient(cost=0.57),
+    )
+    try:
+        binding.execute(_action())
+    except ModelRunnerHostError as exc:
+        assert "cost limit" in str(exc)
+    else:
+        raise AssertionError("over-budget Deepline call must fail closed")
+
+
+def test_oci_runner_transport_does_not_forward_provider_credentials(
+    monkeypatch,
+):
+    source = object.__new__(DockerPrivateModelRunner)
+    source.spec = DockerPrivateModelSpec(
+        image_digest="model@sha256:" + "1" * 64,
+        env_passthrough=("DEEPLINE_API_KEY", "EXA_API_KEY"),
+        extra_env={"DEEPLINE_API_KEY": "must-not-cross"},
+        pull_before_run=False,
+    )
+
+    def capture_spec(instance, spec):
+        instance.spec = spec
+
+    monkeypatch.setattr(DockerPrivateModelRunner, "__init__", capture_spec)
+    transport = DockerModelRunnerTransport(source)
+
+    assert transport._runner.spec.env_passthrough == ()
+    assert transport._runner.spec.extra_env == {}
+    assert transport._runner.spec.pull_before_run is False


### PR DESCRIPTION
## Superseded

Do not merge or activate this PR.

PR93 now carries all eight runner-host files changed here with stricter artifact identity, exact baseline/challenger lineage, startup preflight, terminal-state validation, durable provider receipt references, and routing-control integration. PR98 has no unique safe behavior and no independent production call site.

This branch also has unresolved safety limits:

- caller-provided release identity and capability data are not bound to the exact dual-artifact registry;
- only a partial intent SOURCE_ADD binding set exists, with no complete company or contact chain;
- the older Docker/execute path differs from the reviewed shared protocol;
- paid work is not protected by an atomic lease, cost reservation, and authoritative receipt boundary;
- terminal validation and upstream artifact-operation enforcement are incomplete.

Keep this PR draft and open pending explicit owner confirmation. Do not merge it alongside PR93 or use it as a Lab or production runner.
