### PR TITLE
Bind Production Parity bundles with exact sidecars

### DIFF
--- a/.github/workflows/physical-v2-staging.yml
+++ b/.github/workflows/physical-v2-staging.yml
@@ -227,10 +227,49 @@ jobs:
             *[!0-9a-f]*|'') exit 1 ;;
           esac
           test "${#bundle_sha256}" -eq 64
+          bundle_binding="$PARITY_TEMP/candidate-bundle-binding.json"
+          python3 - "$bundle_binding" "$CANDIDATE_SHA" \
+            "$bundle_sha256" "$bundle_size_bytes" <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import sys
+
+          output = Path(sys.argv[1])
+          descriptor = os.open(
+              output,
+              os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+              0o600,
+          )
+          try:
+              with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                  json.dump(
+                      {
+                          "candidate-sha": sys.argv[2],
+                          "bundle-sha256": sys.argv[3],
+                          "bundle-size-bytes": sys.argv[4],
+                      },
+                      handle,
+                      separators=(",", ":"),
+                      sort_keys=True,
+                  )
+                  handle.write("\n")
+          except BaseException:
+              try:
+                  os.close(descriptor)
+              except OSError:
+                  pass
+              raise
+          PY
+          test -f "$bundle_binding"
+          test ! -L "$bundle_binding"
           aws s3 cp "$PARITY_TEMP/candidate.bundle" \
             "s3://${{ steps.stack.outputs.artifact_bucket }}/${{ steps.inputs.outputs.prefix }}/candidate.bundle" \
-            --metadata "candidate-sha=$CANDIDATE_SHA,bundle-sha256=$bundle_sha256,bundle-size-bytes=$bundle_size_bytes" \
             --only-show-errors
+          aws s3 cp "$bundle_binding" \
+            "s3://${{ steps.stack.outputs.artifact_bucket }}/${{ steps.inputs.outputs.prefix }}/candidate-bundle-binding.json" \
+            --only-show-errors
+          rm -f "$bundle_binding"
           printf 'sha256=%s\nsize_bytes=%s\n' \
             "$bundle_sha256" "$bundle_size_bytes" >> "$GITHUB_OUTPUT"
 
@@ -279,24 +318,24 @@ jobs:
               "production_parity_bootstrap_evidence.py",
               "exec",
           )
-          candidate_bundle_metadata_validator = r'''import json
+          candidate_bundle_binding_validator = r'''import json
           import os
           import stat
           import sys
 
-          MAX_METADATA_BYTES = 4096
+          MAX_BINDING_BYTES = 4096
 
           def exact_object(pairs):
               value = {}
               for key, item in pairs:
                   if type(key) is not str or key in value:
-                      raise ValueError("metadata object keys are not unique strings")
+                      raise ValueError("binding object keys are not unique strings")
                   value[key] = item
               return value
 
           try:
               if len(sys.argv) != 5:
-                  raise ValueError("metadata arguments are invalid")
+                  raise ValueError("binding arguments are invalid")
               descriptor = os.open(
                   sys.argv[1],
                   os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
@@ -306,16 +345,16 @@ jobs:
                   if (
                       not stat.S_ISREG(metadata.st_mode)
                       or metadata.st_size <= 0
-                      or metadata.st_size > MAX_METADATA_BYTES
+                      or metadata.st_size > MAX_BINDING_BYTES
                   ):
-                      raise ValueError("metadata file is outside its bound")
-                  raw = os.read(descriptor, MAX_METADATA_BYTES + 1)
+                      raise ValueError("binding file is outside its bound")
+                  raw = os.read(descriptor, MAX_BINDING_BYTES + 1)
                   if len(raw) != metadata.st_size:
-                      raise ValueError("metadata file changed during read")
+                      raise ValueError("binding file changed during read")
               finally:
                   os.close(descriptor)
-              if not raw or len(raw) > MAX_METADATA_BYTES:
-                  raise ValueError("metadata input is outside its bound")
+              if not raw or len(raw) > MAX_BINDING_BYTES:
+                  raise ValueError("binding input is outside its bound")
               actual = json.loads(
                   raw.decode("utf-8"),
                   object_pairs_hook=exact_object,
@@ -335,8 +374,8 @@ jobs:
               raise SystemExit(1)
           '''
           compile(
-              candidate_bundle_metadata_validator,
-              "candidate_bundle_metadata_validator.py",
+              candidate_bundle_binding_validator,
+              "candidate_bundle_binding_validator.py",
               "exec",
           )
           q = shlex.quote
@@ -352,7 +391,7 @@ jobs:
           evidence=/run/leadpoet-production-parity/full-evidence.json
           authoritative_evidence={q(root + "/full-evidence.json")}
           candidate_bundle={q(root + "/candidate.bundle")}
-          candidate_bundle_metadata=""
+          candidate_bundle_binding=""
           candidate_bundle_verifier={q(root + "/candidate-bundle-verifier.git")}
           candidate_repo={q(root + "/repo")}
           candidate_bundle_sha256={q(candidate_bundle_sha256)}
@@ -415,7 +454,7 @@ jobs:
             elif [ "$final_status" -ne 0 ]; then
               final_status="$(failure_response_code)" || final_status=1
             fi
-            rm -f "$candidate_bundle" "$candidate_bundle_metadata" \
+            rm -f "$candidate_bundle" "$candidate_bundle_binding" \
               >/dev/null 2>&1 || true
             exit "$final_status"
           }}
@@ -430,28 +469,30 @@ jobs:
           failure_stage=bootstrap-workspace
           sudo mkdir -p {q(root)}
           sudo chown ec2-user:ec2-user {q(root)}
-          candidate_bundle_metadata="$(
-            mktemp {q(root + "/candidate-bundle-metadata.XXXXXX")}
+          candidate_bundle_binding="$(
+            mktemp {q(root + "/candidate-bundle-binding.XXXXXX")}
           )"
-          test -f "$candidate_bundle_metadata"
-          test ! -L "$candidate_bundle_metadata"
+          test -f "$candidate_bundle_binding"
+          test ! -L "$candidate_bundle_binding"
           failure_stage=candidate-bundle-download
           aws s3api get-object \
             --bucket {q(artifact_bucket)} \
             --key {q(prefix + "/candidate.bundle")} \
-            --query Metadata \
-            --output json \
             --region {q(required['AWS_REGION'])} \
-            "$candidate_bundle" \
-            > "$candidate_bundle_metadata" 2>/dev/null
+            "$candidate_bundle" >/dev/null 2>&1
+          aws s3api get-object \
+            --bucket {q(artifact_bucket)} \
+            --key {q(prefix + "/candidate-bundle-binding.json")} \
+            --region {q(required['AWS_REGION'])} \
+            "$candidate_bundle_binding" >/dev/null 2>&1
           failure_stage=candidate-bundle-metadata
-          /usr/bin/python3.11 -c {q(candidate_bundle_metadata_validator)} \
-            "$candidate_bundle_metadata" \
+          /usr/bin/python3.11 -c {q(candidate_bundle_binding_validator)} \
+            "$candidate_bundle_binding" \
             {q(required['CANDIDATE_SHA'])} \
             "$candidate_bundle_sha256" \
             "$candidate_bundle_size_bytes"
-          rm -f "$candidate_bundle_metadata"
-          candidate_bundle_metadata=""
+          rm -f "$candidate_bundle_binding"
+          candidate_bundle_binding=""
           failure_stage=candidate-bundle-file-integrity
           test -f "$candidate_bundle"
           test ! -L "$candidate_bundle"

--- a/tests/test_production_parity_bootstrap_evidence.py
+++ b/tests/test_production_parity_bootstrap_evidence.py
@@ -651,9 +651,12 @@ def test_full_workflow_candidate_bundle_is_exact_and_metadata_bound() -> None:
     assert "git bundle verify" in script
     assert "bundle_size_bytes=" in script
     assert "bundle_sha256=" in script
-    assert "bundle-sha256=$bundle_sha256" in script
-    assert "bundle-size-bytes=$bundle_size_bytes" in script
-    assert "candidate-sha=$CANDIDATE_SHA" in script
+    assert 'bundle_binding="$PARITY_TEMP/candidate-bundle-binding.json"' in script
+    assert '"bundle-sha256": sys.argv[3]' in script
+    assert '"bundle-size-bytes": sys.argv[4]' in script
+    assert '"candidate-sha": sys.argv[2]' in script
+    assert "candidate-bundle-binding.json" in script
+    assert script.count("aws s3 cp") == 2
     assert 'printf \'sha256=%s\\nsize_bytes=%s\\n\'' in script
     assert "--all" not in script
 
@@ -662,7 +665,7 @@ def test_full_workflow_candidate_bundle_is_exact_and_metadata_bound() -> None:
         for step in steps
         if step.get("name") == "Start candidate production paths"
     )["run"]
-    assert "MAX_METADATA_BYTES = 4096" in execute
+    assert "MAX_BINDING_BYTES = 4096" in execute
     assert "object_pairs_hook=exact_object" in execute
     metadata_stage = execute.split(
         "failure_stage=candidate-bundle-metadata", 1
@@ -670,17 +673,17 @@ def test_full_workflow_candidate_bundle_is_exact_and_metadata_bound() -> None:
     download_stage = execute.split(
         "failure_stage=candidate-bundle-download", 1
     )[1].split("failure_stage=candidate-bundle-metadata", 1)[0]
-    assert "aws s3api get-object" in download_stage
-    assert "--query Metadata" in download_stage
-    assert "--output json" in download_stage
+    assert download_stage.count("aws s3api get-object") == 2
+    assert "candidate-bundle-binding.json" in download_stage
     assert '"$candidate_bundle"' in download_stage
-    assert '> "$candidate_bundle_metadata"' in download_stage
+    assert '"$candidate_bundle_binding"' in download_stage
+    assert "--query Metadata" not in download_stage
     assert "head-object" not in execute
-    assert '"$candidate_bundle_metadata"' in metadata_stage
+    assert '"$candidate_bundle_binding"' in metadata_stage
     assert "os.O_NOFOLLOW" in execute
     assert "stat.S_ISREG(metadata.st_mode)" in execute
     assert "--output text" not in metadata_stage
-    assert 'rm -f "$candidate_bundle_metadata"' in metadata_stage
+    assert 'rm -f "$candidate_bundle_binding"' in metadata_stage
 
 
 def test_rendered_ssm_bootstrap_is_valid_and_bounded(tmp_path: Path) -> None:
@@ -735,14 +738,19 @@ with open(os.environ["AWS_CALLS"], "a", encoding="utf-8") as handle:
 if arguments[:2] == ["s3api", "get-object"]:
     destination = Path(arguments[-1])
     destination.parent.mkdir(parents=True, exist_ok=True)
-    payload = bytes.fromhex(os.environ["BUNDLE_HEX"])
-    if os.environ.get("BUNDLE_AS_SYMLINK") == "1":
-        symlink_target = destination.with_name(destination.name + ".payload")
-        symlink_target.write_bytes(payload)
-        destination.symlink_to(symlink_target)
+    key = arguments[arguments.index("--key") + 1]
+    if key.endswith("/candidate.bundle"):
+        payload = bytes.fromhex(os.environ["BUNDLE_HEX"])
+        if os.environ.get("BUNDLE_AS_SYMLINK") == "1":
+            symlink_target = destination.with_name(destination.name + ".payload")
+            symlink_target.write_bytes(payload)
+            destination.symlink_to(symlink_target)
+        else:
+            destination.write_bytes(payload)
+    elif key.endswith("/candidate-bundle-binding.json"):
+        destination.write_text(os.environ["METADATA_RAW_JSON"], encoding="utf-8")
     else:
-        destination.write_bytes(payload)
-    sys.stdout.write(os.environ["METADATA_RAW_JSON"])
+        raise SystemExit(2)
 elif arguments[:2] == ["s3api", "put-object"]:
     if os.environ.get("FAIL_EVIDENCE_UPLOAD") == "1":
         raise SystemExit(73)
@@ -954,12 +962,12 @@ def test_rendered_ssm_preserves_success_and_uploads_host_evidence(
         "authority": "host",
     }
     assert not (tmp_path / "work" / "candidate.bundle").exists()
-    assert not list((tmp_path / "work").glob("candidate-bundle-metadata.*"))
+    assert not list((tmp_path / "work").glob("candidate-bundle-binding.*"))
     assert result.stdout == ""
     assert result.stderr == ""
 
 
-def test_rendered_ssm_downloads_body_and_metadata_in_one_get(
+def test_rendered_ssm_downloads_bundle_and_exact_binding(
     tmp_path: Path,
 ) -> None:
     result, _capture = _run_rendered_ssm(tmp_path)
@@ -972,9 +980,18 @@ def test_rendered_ssm_downloads_body_and_metadata_in_one_get(
         ).splitlines()
     ]
     reads = [call for call in calls if call[:2] == ["s3api", "get-object"]]
-    assert len(reads) == 1
-    assert reads[0][reads[0].index("--query") + 1] == "Metadata"
+    assert len(reads) == 2
+    assert reads[0][reads[0].index("--key") + 1].endswith(
+        "/candidate.bundle"
+    )
     assert reads[0][-1] == str(tmp_path / "work" / "candidate.bundle")
+    assert reads[1][reads[1].index("--key") + 1].endswith(
+        "/candidate-bundle-binding.json"
+    )
+    assert reads[1][-1].startswith(
+        str(tmp_path / "work" / "candidate-bundle-binding.")
+    )
+    assert all("--query" not in call for call in reads)
     assert not any(call[:2] == ["s3api", "head-object"] for call in calls)
 
 


### PR DESCRIPTION
Repairs the confirmed Production Parity Full bootstrap failure at candidate-bundle-metadata.

The controller now emits and uploads a bounded exact candidate/SHA256/size binding sidecar. The transient host downloads that sidecar and the bundle, strictly validates the binding, then retains all existing file size, SHA256, bundle-head, bundle verification, exact-main, and fail-closed checks. No production scoring, persistence, Supabase, transport, restart, weight, or model-routing code changes.

Focused validation: 164 tests passed in 21.22s, including every bootstrap failure stage and malformed/tampered binding negative; git diff --check passed.