### PR TITLE
Recover measured loop event persistence exactly once

### DIFF
--- a/gateway/research_lab/autoresearch_authority_v2.py
+++ b/gateway/research_lab/autoresearch_authority_v2.py
@@ -1102,7 +1102,7 @@ async def run_authoritative_autoresearch_v2(
     component_registry_authority: Mapping[str, Any],
     active_model_authority: Mapping[str, Any],
     expected_event_state_hash: str,
-    record_loop_event: Callable[[AutoResearchLoopEvent], Any],
+    record_loop_event: Callable[..., Any],
     code_builder: Any,
     should_pause: Callable[[], Any],
     record_privacy_proof: Callable[..., Any],
@@ -1526,7 +1526,20 @@ async def run_authoritative_autoresearch_v2(
             cost_ledger=dict(event_doc.get("cost_ledger") or {}),
             event_doc=dict(event_doc.get("event_doc") or {}),
         )
-        row = await _maybe_await(record_loop_event(event))
+        event_operation_id = sha256_json(
+            {
+                "schema_version": "research_lab.autoresearch_event_operation.v1",
+                "job_id": job_id,
+                "event_hash": event_hash,
+                "event_sequence": sequence,
+            }
+        )
+        row = await _maybe_await(
+            record_loop_event(
+                event,
+                event_operation_id=event_operation_id,
+            )
+        )
         row = dict(row or {})
         next_hash = sha256_json(
             {

--- a/gateway/research_lab/store.py
+++ b/gateway/research_lab/store.py
@@ -41,6 +41,8 @@ _TRANSIENT_ERROR_SIGNATURES = (
     "connection aborted",
     "connection refused",
     "server disconnected",
+    "unexpected eof",
+    "unexpected_eof",
     "timed out",
     "timeout",
 )
@@ -1307,6 +1309,125 @@ async def create_auto_research_loop_event(
         },
         event_id=event_id,
     )
+
+
+async def ensure_auto_research_loop_event(
+    *,
+    event_id: str,
+    run_id: str,
+    ticket_id: str,
+    event_type: str,
+    loop_status: str,
+    worker_ref: str,
+    receipt_id: str | None = None,
+    node_id: str | None = None,
+    elapsed_seconds: float = 0.0,
+    candidate_artifact_hash: str | None = None,
+    candidate_patch_hash: str | None = None,
+    provider_usage: list[dict[str, Any]] | None = None,
+    cost_ledger: dict[str, Any] | None = None,
+    event_doc: dict[str, Any] | None = None,
+    attempts: int = 3,
+) -> dict[str, Any]:
+    """Persist one V2 loop event exactly once across ambiguous responses."""
+
+    try:
+        UUID(str(event_id))
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise ValueError("loop event_id must be a UUID") from exc
+    if attempts < 1:
+        raise ValueError("loop event attempts must be positive")
+
+    expected = {
+        "run_id": run_id,
+        "ticket_id": ticket_id,
+        "receipt_id": receipt_id,
+        "event_type": event_type,
+        "loop_status": loop_status,
+        "node_id": node_id,
+        "worker_ref": worker_ref,
+        "elapsed_seconds": round(float(elapsed_seconds), 3),
+        "candidate_artifact_hash": candidate_artifact_hash,
+        "candidate_patch_hash": candidate_patch_hash,
+        "provider_usage": provider_usage or [],
+        "cost_ledger": cost_ledger or {},
+        "event_doc": event_doc or {},
+    }
+
+    def _validate(row: Mapping[str, Any]) -> dict[str, Any]:
+        mismatched: list[str] = []
+        if str(row.get("event_id") or "") != event_id:
+            mismatched.append("event_id")
+        if str(row.get("schema_version") or "") != "1.0":
+            mismatched.append("schema_version")
+        for field, value in expected.items():
+            actual = row.get(field)
+            if field == "elapsed_seconds":
+                try:
+                    actual = round(float(actual), 3)
+                except (TypeError, ValueError):
+                    mismatched.append(field)
+                    continue
+            if actual != value:
+                mismatched.append(field)
+        seq = row.get("seq")
+        if isinstance(seq, bool) or not isinstance(seq, int) or seq < 0:
+            mismatched.append("seq")
+        elif row.get("anchored_hash") != canonical_hash({**expected, "seq": seq}):
+            mismatched.append("anchored_hash")
+        if mismatched:
+            raise RuntimeError(
+                "loop event idempotency collision for fields: "
+                + ",".join(sorted(set(mismatched)))
+            )
+        return dict(row)
+
+    async def _existing() -> dict[str, Any] | None:
+        row = await select_one(
+            "research_lab_auto_research_loop_events",
+            filters=(("event_id", event_id),),
+        )
+        return _validate(row) if row else None
+
+    existing = await _existing()
+    if existing:
+        return existing
+
+    for attempt in range(1, attempts + 1):
+        try:
+            row = await create_auto_research_loop_event(
+                event_id=event_id,
+                run_id=run_id,
+                ticket_id=ticket_id,
+                receipt_id=receipt_id,
+                event_type=event_type,
+                loop_status=loop_status,
+                worker_ref=worker_ref,
+                node_id=node_id,
+                elapsed_seconds=elapsed_seconds,
+                candidate_artifact_hash=candidate_artifact_hash,
+                candidate_patch_hash=candidate_patch_hash,
+                provider_usage=provider_usage,
+                cost_ledger=cost_ledger,
+                event_doc=event_doc,
+            )
+            return _validate(row)
+        except Exception as exc:  # noqa: BLE001 - reconciled and classified below
+            recovered = await _existing()
+            if recovered:
+                return recovered
+            if attempt >= attempts or not _is_transient_store_error(exc):
+                raise
+            logger.warning(
+                "transient_loop_event_write_retry event_id=%s attempt=%s/%s type=%s",
+                event_id,
+                attempt,
+                attempts,
+                type(exc).__name__,
+            )
+            await asyncio.sleep(0.25 * attempt)
+
+    raise RuntimeError("loop event persistence exhausted without a result")
 
 
 async def ensure_auto_research_loop_transition_event(

--- a/gateway/research_lab/worker.py
+++ b/gateway/research_lab/worker.py
@@ -134,6 +134,8 @@ from gateway.research_lab.store import (
     create_reimbursement_schedule,
     create_ticket_event,
     create_openrouter_privacy_proof_event_sync,
+    deterministic_uuid,
+    ensure_auto_research_loop_event,
     ensure_auto_research_loop_transition_event,
     find_queued_receipt_for_run,
     latest_auto_research_checkpoint,
@@ -3350,7 +3352,11 @@ class ResearchLabHostedWorker:
             last_queue_heartbeat_at = 0.0
             recorded_loop_events: list[dict[str, Any]] = []
 
-            async def _record_loop_event(event: AutoResearchLoopEvent) -> None:
+            async def _record_loop_event(
+                event: AutoResearchLoopEvent,
+                *,
+                event_operation_id: str,
+            ) -> None:
                 nonlocal latest_checkpoint, last_queue_heartbeat_at
                 if event.event_type == "checkpoint_saved":
                     checkpoint_doc = event.event_doc.get("checkpoint") if isinstance(event.event_doc, Mapping) else None
@@ -3388,6 +3394,7 @@ class ResearchLabHostedWorker:
                     event=event,
                     event_doc=event_doc,
                     event_provider_usage=event_provider_usage,
+                    event_operation_id=event_operation_id,
                 )
                 recorded_loop_events.append(
                     {
@@ -5729,9 +5736,18 @@ class ResearchLabHostedWorker:
         event: AutoResearchLoopEvent,
         event_doc: dict[str, Any],
         event_provider_usage: list[dict[str, Any]],
+        event_operation_id: str,
     ) -> dict[str, Any]:
         if event.event_type != "loop_resumed":
-            return await create_auto_research_loop_event(
+            if not re.fullmatch(r"sha256:[0-9a-f]{64}", event_operation_id):
+                raise HostedResearchLabWorkerError(
+                    "measured loop event operation identity is invalid"
+                )
+            return await ensure_auto_research_loop_event(
+                event_id=deterministic_uuid(
+                    "research_lab_auto_research_loop_event_v2",
+                    event_operation_id,
+                ),
                 run_id=context.run_id,
                 ticket_id=context.ticket_id,
                 receipt_id=context.receipt_id,

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -402,7 +402,7 @@
       "symbol": "build_gateway_weight_inputs_v2"
     },
     {
-      "ast_sha256": "sha256:4e260b7831ec597bd952e5a13aff72a791e51ca85f13fea68d0f5167e8865b41",
+      "ast_sha256": "sha256:741b65f7cf14b9328552fd63d25979884295e12ed101663bcf8779f962542189",
       "path": "gateway/research_lab/autoresearch_authority_v2.py",
       "symbol": "run_authoritative_autoresearch_v2"
     },
@@ -2852,7 +2852,7 @@
       "symbol": "process_source_add_work_item"
     },
     {
-      "ast_sha256": "sha256:ad8eaa4971c6a18443a98d76fe45be3e000ba7cc419c3b3a32133608620d8343",
+      "ast_sha256": "sha256:4ffa42ef6296c9eb969f58f1d535ab4cd2b0fa23fe86136d5100e9a902c5328e",
       "path": "gateway/research_lab/store.py",
       "symbol": "_TRANSIENT_ERROR_SIGNATURES"
     },
@@ -8077,7 +8077,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:2fbc77fdebcd73de5f08f30f7506abcae4e11a0d908b6b853851246b14efd05d",
-  "protected_source_commit": "350f6f220aeb1d10fd61ca198ff7009cd8a47fbd",
+  "manifest_hash": "sha256:ca6444a6976d8b04369d01aa6a2fe304a6d4ed89ae4afff62523366c3cc7eb00",
+  "protected_source_commit": "fc7ac38b67c8d75ab544d7c8674a73074875e342",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_autoresearch_authority_v2.py
+++ b/tests/test_autoresearch_authority_v2.py
@@ -811,6 +811,20 @@ def test_authoritative_loop_binds_measured_provider_outcome_parent(
         "execution_receipt_graph": component_execution_graph,
     }
     observed = {}
+    persisted_events = []
+    derived_job_ids = []
+    derive_job_id = authority.derive_autoresearch_job_id_v2
+
+    def capture_job_id(**kwargs):
+        value = derive_job_id(**kwargs)
+        derived_job_ids.append(value)
+        return value
+
+    monkeypatch.setattr(
+        authority,
+        "derive_autoresearch_job_id_v2",
+        capture_job_id,
+    )
 
     monkeypatch.setattr(
         authority,
@@ -853,6 +867,26 @@ def test_authoritative_loop_binds_measured_provider_outcome_parent(
 
     async def execute(**kwargs):
         observed.update(kwargs)
+        event_doc = {
+            "event_type": "loop_failed",
+            "loop_status": "failed",
+            "elapsed_seconds": 1.0,
+            "node_id": None,
+            "candidate_artifact_hash": None,
+            "candidate_patch_hash": None,
+            "provider_usage": [],
+            "cost_ledger": {},
+            "event_doc": {"stop_reason": "no_eligible_tree_finalist"},
+        }
+        event_hash = sha256_json(event_doc)
+        await kwargs["host_operation_handlers"][authority.HOST_APPEND_EVENT](
+            {
+                "event": event_doc,
+                "event_hash": event_hash,
+                "event_sequence": 0,
+            },
+            {"expected_state_hash": "sha256:" + "c" * 64},
+        )
         policy = TreePolicy(mode="active")
         tree_id = derive_tree_id(
             run_id="run-1",
@@ -941,7 +975,10 @@ def test_authoritative_loop_binds_measured_provider_outcome_parent(
             component_registry_authority=component_authority,
             active_model_authority=active_authority,
             expected_event_state_hash="sha256:" + "c" * 64,
-            record_loop_event=lambda _event: {},
+            record_loop_event=lambda event, **kwargs: persisted_events.append(
+                {"event": event, **kwargs}
+            )
+            or {},
             code_builder=SimpleNamespace(
                 config=SimpleNamespace(code_edit_build_timeout_seconds=900)
             ),
@@ -956,6 +993,30 @@ def test_authoritative_loop_binds_measured_provider_outcome_parent(
     )
 
     assert result.loop_result.status == "failed"
+    assert len(derived_job_ids) == 1
+    assert len(persisted_events) == 1
+    assert persisted_events[0]["event_operation_id"] == sha256_json(
+        {
+            "schema_version": "research_lab.autoresearch_event_operation.v1",
+            "job_id": derived_job_ids[0],
+            "event_hash": sha256_json(
+                {
+                    "event_type": "loop_failed",
+                    "loop_status": "failed",
+                    "elapsed_seconds": 1.0,
+                    "node_id": None,
+                    "candidate_artifact_hash": None,
+                    "candidate_patch_hash": None,
+                    "provider_usage": [],
+                    "cost_ledger": {},
+                    "event_doc": {
+                        "stop_reason": "no_eligible_tree_finalist"
+                    },
+                }
+            ),
+            "event_sequence": 0,
+        }
+    )
     assert observed["payload"]["provider_outcome_digest"] == outcome_result[
         "provider_outcome_digest"
     ]

--- a/tests/test_loop_projection_transitions.py
+++ b/tests/test_loop_projection_transitions.py
@@ -45,6 +45,161 @@ async def test_append_event_with_seq_preserves_supplied_event_id(
     assert rows[0]["event_id"] == event_id
 
 
+@pytest.mark.parametrize("detail", ("unexpected_eof", "unexpected eof"))
+def test_loop_event_transport_eof_is_retryable(detail: str) -> None:
+    assert store_mod._is_transient_store_error(RuntimeError(detail))
+
+
+@pytest.mark.asyncio
+async def test_loop_event_recovers_committed_insert_after_response_loss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_id = "44444444-4444-4444-8444-444444444444"
+    inserted: dict[str, Any] | None = None
+    insert_calls = 0
+
+    async def fake_select_one(table: str, **kwargs: Any) -> dict[str, Any] | None:
+        assert table == "research_lab_auto_research_loop_events"
+        assert kwargs["filters"] == (("event_id", event_id),)
+        return dict(inserted) if inserted is not None else None
+
+    async def fake_create_loop_event(**kwargs: Any) -> dict[str, Any]:
+        nonlocal insert_calls, inserted
+        insert_calls += 1
+        inserted = {
+            **kwargs,
+            "schema_version": "1.0",
+            "seq": 8,
+        }
+        payload = {
+            key: value
+            for key, value in inserted.items()
+            if key not in {"event_id", "schema_version"}
+        }
+        inserted["anchored_hash"] = store_mod.canonical_hash(payload)
+        raise RuntimeError("unexpected_eof")
+
+    monkeypatch.setattr(store_mod, "select_one", fake_select_one)
+    monkeypatch.setattr(
+        store_mod, "create_auto_research_loop_event", fake_create_loop_event
+    )
+
+    result = await store_mod.ensure_auto_research_loop_event(
+        event_id=event_id,
+        run_id=RUN_ID,
+        ticket_id=TICKET_ID,
+        receipt_id=None,
+        event_type="loop_failed",
+        loop_status="failed",
+        worker_ref="worker-a",
+        elapsed_seconds=12.5,
+        provider_usage=[],
+        cost_ledger={"actual_openrouter_cost_microusd": 100},
+        event_doc={"stop_reason": "no_valid_image_build_finalists"},
+    )
+
+    assert insert_calls == 1
+    assert result == inserted
+
+
+@pytest.mark.asyncio
+async def test_loop_event_retries_transport_failure_before_insert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_id = "55555555-5555-4555-8555-555555555555"
+    insert_calls = 0
+
+    async def fake_select_one(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    async def fake_create_loop_event(**kwargs: Any) -> dict[str, Any]:
+        nonlocal insert_calls
+        insert_calls += 1
+        if insert_calls == 1:
+            raise RuntimeError("unexpected eof")
+        payload = {
+            "run_id": kwargs["run_id"],
+            "ticket_id": kwargs["ticket_id"],
+            "receipt_id": kwargs["receipt_id"],
+            "seq": 2,
+            "event_type": kwargs["event_type"],
+            "loop_status": kwargs["loop_status"],
+            "node_id": kwargs["node_id"],
+            "worker_ref": kwargs["worker_ref"],
+            "elapsed_seconds": kwargs["elapsed_seconds"],
+            "candidate_artifact_hash": kwargs["candidate_artifact_hash"],
+            "candidate_patch_hash": kwargs["candidate_patch_hash"],
+            "provider_usage": kwargs["provider_usage"] or [],
+            "cost_ledger": kwargs["cost_ledger"] or {},
+            "event_doc": kwargs["event_doc"] or {},
+        }
+        return {
+            "event_id": event_id,
+            "schema_version": "1.0",
+            **payload,
+            "anchored_hash": store_mod.canonical_hash(payload),
+        }
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(store_mod, "select_one", fake_select_one)
+    monkeypatch.setattr(
+        store_mod, "create_auto_research_loop_event", fake_create_loop_event
+    )
+    monkeypatch.setattr(store_mod.asyncio, "sleep", no_sleep)
+
+    result = await store_mod.ensure_auto_research_loop_event(
+        event_id=event_id,
+        run_id=RUN_ID,
+        ticket_id=TICKET_ID,
+        receipt_id=None,
+        event_type="checkpoint_saved",
+        loop_status="running",
+        worker_ref="worker-a",
+        event_doc={"checkpoint_hash": "sha256:" + "f" * 64},
+    )
+
+    assert insert_calls == 2
+    assert result["event_id"] == event_id
+
+
+@pytest.mark.asyncio
+async def test_loop_event_does_not_retry_permanent_store_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class PermanentStoreError(RuntimeError):
+        code = "23514"
+
+    insert_calls = 0
+
+    async def fake_select_one(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    async def fake_create_loop_event(**_kwargs: Any) -> dict[str, Any]:
+        nonlocal insert_calls
+        insert_calls += 1
+        raise PermanentStoreError("event_doc violates check constraint")
+
+    monkeypatch.setattr(store_mod, "select_one", fake_select_one)
+    monkeypatch.setattr(
+        store_mod, "create_auto_research_loop_event", fake_create_loop_event
+    )
+
+    with pytest.raises(PermanentStoreError, match="violates check constraint"):
+        await store_mod.ensure_auto_research_loop_event(
+            event_id="66666666-6666-4666-8666-666666666666",
+            run_id=RUN_ID,
+            ticket_id=TICKET_ID,
+            receipt_id=None,
+            event_type="loop_failed",
+            loop_status="failed",
+            worker_ref="worker-a",
+        )
+
+    assert insert_calls == 1
+
+
 def _queue_row(status: str, event_hash: str = QUEUE_HASH) -> dict[str, Any]:
     return {
         "run_id": RUN_ID,
@@ -422,6 +577,7 @@ async def test_resumed_loop_event_binds_to_heartbeat_after_claim(
         event=event,
         event_doc={"checkpoint_hash": "sha256:" + "f" * 64},
         event_provider_usage=[],
+        event_operation_id="sha256:" + "a" * 64,
     )
 
     assert result["event_type"] == "loop_resumed"


### PR DESCRIPTION
## Root cause
A V2 autoresearch host append used a random event ID and no reconciliation after an ambiguous Supabase/PostgREST response. The shared transient classifier also did not recognize `unexpected_eof`, so one lost response could terminate an otherwise durable loop.

## Fix
- Bind each measured append to a deterministic operation key derived from the exact V2 job, event hash, and event sequence.
- Persist with a stable event UUID, exact-row reconciliation, bounded retry for allowlisted transport failures, and immediate fail-closed behavior for permanent SQL/PostgREST errors.
- Refresh only the two changed protected trust identities.

## Verification
- 47 V2/event/protected-manifest tests
- 45 measured transport/framing tests
- 10 40-ICP rebenchmark/restart/publication tests
- 32 durable store/allocation/canonical primary-audit handoff tests
- 77 local SOURCE_ADD skill tests

No scoring, benchmark, allocation, settlement, or validator implementation was changed.