### PR TITLE
Stream exact parity bundle binding

### DIFF
--- a/.github/workflows/physical-v2-staging.yml
+++ b/.github/workflows/physical-v2-staging.yml
@@ -319,8 +319,6 @@ jobs:
               "exec",
           )
           candidate_bundle_binding_validator = r'''import json
-          import os
-          import stat
           import sys
 
           MAX_BINDING_BYTES = 4096
@@ -334,25 +332,9 @@ jobs:
               return value
 
           try:
-              if len(sys.argv) != 5:
+              if len(sys.argv) != 4:
                   raise ValueError("binding arguments are invalid")
-              descriptor = os.open(
-                  sys.argv[1],
-                  os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
-              )
-              try:
-                  metadata = os.fstat(descriptor)
-                  if (
-                      not stat.S_ISREG(metadata.st_mode)
-                      or metadata.st_size <= 0
-                      or metadata.st_size > MAX_BINDING_BYTES
-                  ):
-                      raise ValueError("binding file is outside its bound")
-                  raw = os.read(descriptor, MAX_BINDING_BYTES + 1)
-                  if len(raw) != metadata.st_size:
-                      raise ValueError("binding file changed during read")
-              finally:
-                  os.close(descriptor)
+              raw = sys.stdin.buffer.read(MAX_BINDING_BYTES + 1)
               if not raw or len(raw) > MAX_BINDING_BYTES:
                   raise ValueError("binding input is outside its bound")
               actual = json.loads(
@@ -362,9 +344,9 @@ jobs:
           except (OSError, UnicodeDecodeError, ValueError):
               raise SystemExit(1) from None
           expected = {
-              "candidate-sha": sys.argv[2],
-              "bundle-sha256": sys.argv[3],
-              "bundle-size-bytes": sys.argv[4],
+              "candidate-sha": sys.argv[1],
+              "bundle-sha256": sys.argv[2],
+              "bundle-size-bytes": sys.argv[3],
           }
           if (
               type(actual) is not dict
@@ -391,7 +373,6 @@ jobs:
           evidence=/run/leadpoet-production-parity/full-evidence.json
           authoritative_evidence={q(root + "/full-evidence.json")}
           candidate_bundle={q(root + "/candidate.bundle")}
-          candidate_bundle_binding=""
           candidate_bundle_verifier={q(root + "/candidate-bundle-verifier.git")}
           candidate_repo={q(root + "/repo")}
           candidate_bundle_sha256={q(candidate_bundle_sha256)}
@@ -454,8 +435,7 @@ jobs:
             elif [ "$final_status" -ne 0 ]; then
               final_status="$(failure_response_code)" || final_status=1
             fi
-            rm -f "$candidate_bundle" "$candidate_bundle_binding" \
-              >/dev/null 2>&1 || true
+            rm -f "$candidate_bundle" >/dev/null 2>&1 || true
             exit "$final_status"
           }}
           trap finalize_bootstrap EXIT
@@ -469,30 +449,22 @@ jobs:
           failure_stage=bootstrap-workspace
           sudo mkdir -p {q(root)}
           sudo chown ec2-user:ec2-user {q(root)}
-          candidate_bundle_binding="$(
-            mktemp {q(root + "/candidate-bundle-binding.XXXXXX")}
-          )"
-          test -f "$candidate_bundle_binding"
-          test ! -L "$candidate_bundle_binding"
           failure_stage=candidate-bundle-download
           aws s3api get-object \
             --bucket {q(artifact_bucket)} \
             --key {q(prefix + "/candidate.bundle")} \
             --region {q(required['AWS_REGION'])} \
             "$candidate_bundle" >/dev/null 2>&1
-          aws s3api get-object \
-            --bucket {q(artifact_bucket)} \
-            --key {q(prefix + "/candidate-bundle-binding.json")} \
-            --region {q(required['AWS_REGION'])} \
-            "$candidate_bundle_binding" >/dev/null 2>&1
           failure_stage=candidate-bundle-metadata
+          aws s3 cp \
+            {q("s3://" + artifact_bucket + "/" + prefix + "/candidate-bundle-binding.json")} \
+            - \
+            --only-show-errors \
+            --region {q(required['AWS_REGION'])} | \
           /usr/bin/python3.11 -c {q(candidate_bundle_binding_validator)} \
-            "$candidate_bundle_binding" \
             {q(required['CANDIDATE_SHA'])} \
             "$candidate_bundle_sha256" \
             "$candidate_bundle_size_bytes"
-          rm -f "$candidate_bundle_binding"
-          candidate_bundle_binding=""
           failure_stage=candidate-bundle-file-integrity
           test -f "$candidate_bundle"
           test ! -L "$candidate_bundle"

--- a/tests/test_production_parity_bootstrap_evidence.py
+++ b/tests/test_production_parity_bootstrap_evidence.py
@@ -673,17 +673,17 @@ def test_full_workflow_candidate_bundle_is_exact_and_metadata_bound() -> None:
     download_stage = execute.split(
         "failure_stage=candidate-bundle-download", 1
     )[1].split("failure_stage=candidate-bundle-metadata", 1)[0]
-    assert download_stage.count("aws s3api get-object") == 2
-    assert "candidate-bundle-binding.json" in download_stage
+    assert download_stage.count("aws s3api get-object") == 1
+    assert "candidate-bundle-binding.json" not in download_stage
     assert '"$candidate_bundle"' in download_stage
-    assert '"$candidate_bundle_binding"' in download_stage
     assert "--query Metadata" not in download_stage
     assert "head-object" not in execute
-    assert '"$candidate_bundle_binding"' in metadata_stage
-    assert "os.O_NOFOLLOW" in execute
-    assert "stat.S_ISREG(metadata.st_mode)" in execute
+    assert "aws s3 cp" in metadata_stage
+    assert "candidate-bundle-binding.json" in metadata_stage
+    assert "sys.stdin.buffer.read(MAX_BINDING_BYTES + 1)" in execute
+    assert "candidate_bundle_binding=" not in execute
     assert "--output text" not in metadata_stage
-    assert 'rm -f "$candidate_bundle_binding"' in metadata_stage
+    assert "--only-show-errors" in metadata_stage
 
 
 def test_rendered_ssm_bootstrap_is_valid_and_bounded(tmp_path: Path) -> None:
@@ -747,10 +747,16 @@ if arguments[:2] == ["s3api", "get-object"]:
             destination.symlink_to(symlink_target)
         else:
             destination.write_bytes(payload)
-    elif key.endswith("/candidate-bundle-binding.json"):
-        destination.write_text(os.environ["METADATA_RAW_JSON"], encoding="utf-8")
     else:
         raise SystemExit(2)
+elif arguments[:2] == ["s3", "cp"]:
+    if (
+        len(arguments) < 4
+        or not arguments[2].endswith("/candidate-bundle-binding.json")
+        or arguments[3] != "-"
+    ):
+        raise SystemExit(2)
+    sys.stdout.buffer.write(os.environ["METADATA_RAW_JSON"].encode("utf-8"))
 elif arguments[:2] == ["s3api", "put-object"]:
     if os.environ.get("FAIL_EVIDENCE_UPLOAD") == "1":
         raise SystemExit(73)
@@ -967,7 +973,7 @@ def test_rendered_ssm_preserves_success_and_uploads_host_evidence(
     assert result.stderr == ""
 
 
-def test_rendered_ssm_downloads_bundle_and_exact_binding(
+def test_rendered_ssm_downloads_bundle_and_streams_exact_binding(
     tmp_path: Path,
 ) -> None:
     result, _capture = _run_rendered_ssm(tmp_path)
@@ -980,17 +986,19 @@ def test_rendered_ssm_downloads_bundle_and_exact_binding(
         ).splitlines()
     ]
     reads = [call for call in calls if call[:2] == ["s3api", "get-object"]]
-    assert len(reads) == 2
+    assert len(reads) == 1
     assert reads[0][reads[0].index("--key") + 1].endswith(
         "/candidate.bundle"
     )
     assert reads[0][-1] == str(tmp_path / "work" / "candidate.bundle")
-    assert reads[1][reads[1].index("--key") + 1].endswith(
+    binding_streams = [call for call in calls if call[:2] == ["s3", "cp"]]
+    assert len(binding_streams) == 1
+    assert binding_streams[0][2].endswith(
         "/candidate-bundle-binding.json"
     )
-    assert reads[1][-1].startswith(
-        str(tmp_path / "work" / "candidate-bundle-binding.")
-    )
+    assert binding_streams[0][3] == "-"
+    assert "--only-show-errors" in binding_streams[0]
+    assert "--region" in binding_streams[0]
     assert all("--query" not in call for call in reads)
     assert not any(call[:2] == ["s3api", "head-object"] for call in calls)
 


### PR DESCRIPTION
## Summary
- stream the exact candidate bundle binding sidecar from its immutable S3 key into the bounded validator
- preserve exact candidate SHA, bundle SHA256/size, strict JSON shape, duplicate-key rejection, Git bundle verification, and canonical origin checks
- remove only the transient local sidecar file surface that blocked Production Parity Full before scoring

## Evidence
- prior retained sidecar, bundle size, and streaming bundle SHA exactly matched controller outputs
- `python3 -m pytest -q tests/test_production_parity_bootstrap_evidence.py` — 111 passed
- Python compilation and `git diff --check` passed

No production restart, scoring-state mutation, lineage bypass, or verification weakening is included.