### PR TITLE
Make parity Git bootstrap host-portable

### DIFF
--- a/.github/workflows/physical-v2-staging.yml
+++ b/.github/workflows/physical-v2-staging.yml
@@ -352,6 +352,7 @@ jobs:
           candidate_bundle_binding={q(root + "/candidate-bundle-binding.json")}
           candidate_repo={q(root + "/repo")}
           candidate_git_home={q(root + "/git-home")}
+          candidate_git_bin=
           candidate_bundle_sha256={q(candidate_bundle_sha256)}
           candidate_bundle_size_bytes={q(candidate_bundle_size_bytes)}
           candidate_bundle_binding_sha256={q(candidate_bundle_binding_sha256)}
@@ -363,27 +364,14 @@ jobs:
             esac
           }}
           candidate_git() {{
-            /usr/bin/env \
-              -u GIT_DIR \
-              -u GIT_WORK_TREE \
-              -u GIT_INDEX_FILE \
-              -u GIT_OBJECT_DIRECTORY \
-              -u GIT_ALTERNATE_OBJECT_DIRECTORIES \
-              -u GIT_COMMON_DIR \
-              -u GIT_CEILING_DIRECTORIES \
-              -u GIT_DISCOVERY_ACROSS_FILESYSTEM \
-              -u GIT_CONFIG_COUNT \
-              -u GIT_CONFIG_SYSTEM \
-              -u GIT_CONFIG_GLOBAL \
-              -u GIT_SSH \
-              -u GIT_SSH_COMMAND \
-              -u GIT_ASKPASS \
-              -u SSH_ASKPASS \
+            /usr/bin/env -i \
+              PATH=/usr/bin:/bin \
+              LC_ALL=C \
               HOME="$candidate_git_home" \
               XDG_CONFIG_HOME="$candidate_git_home/.config" \
               GIT_CONFIG_NOSYSTEM=1 \
               GIT_TERMINAL_PROMPT=0 \
-              /usr/bin/git -c init.templateDir= "$@"
+              "$candidate_git_bin" -c init.templateDir= "$@"
           }}
           retain_failure() {{
             evidence_parent="$(dirname -- "$evidence")" || return 1
@@ -491,8 +479,20 @@ jobs:
           test -d "$candidate_git_home"
           test ! -L "$candidate_git_home"
           failure_stage=candidate-git-runtime
-          test -x /usr/bin/git
-          candidate_git --version >/dev/null 2>&1
+          if [ -x /usr/bin/git ]; then
+            candidate_git_bin=/usr/bin/git
+          elif [ -x /usr/local/bin/git ]; then
+            candidate_git_bin=/usr/local/bin/git
+          else
+            test -x /usr/bin/dnf
+            sudo -n /usr/bin/dnf -q -y install git-core >/dev/null 2>&1
+            candidate_git_bin=/usr/bin/git
+          fi
+          case "$candidate_git_bin" in
+            /*) ;;
+            *) false ;;
+          esac
+          test -x "$candidate_git_bin"
           failure_stage=candidate-repository-init
           candidate_git -C "$candidate_repo" init >/dev/null 2>&1
           failure_stage=candidate-repository-structure

--- a/tests/test_physical_v2_staging.py
+++ b/tests/test_physical_v2_staging.py
@@ -1004,7 +1004,9 @@ def test_full_workflow_fetches_exact_bundle_head_then_binds_canonical_main():
         < exact_main
         < runner
     )
-    assert "/usr/bin/git -c init.templateDir=" in source
+    assert '"$candidate_git_bin" -c init.templateDir=' in source
+    assert "/usr/bin/env -i" in source
+    assert "sudo -n /usr/bin/dnf -q -y install git-core" in source
     assert "GIT_CONFIG_NOSYSTEM=1" in source
     assert "git clone" not in source
 

--- a/tests/test_production_parity_bootstrap_evidence.py
+++ b/tests/test_production_parity_bootstrap_evidence.py
@@ -743,7 +743,7 @@ def test_full_workflow_candidate_bundle_is_exact_and_metadata_bound() -> None:
     assert "git bundle list-heads" not in head_stage
     directory_stage = execute.split(
         "failure_stage=candidate-repository-directory", 1
-    )[1].split("failure_stage=candidate-git-runtime", 1)[0]
+    )[1].split("if [ -x /usr/bin/git ]", 1)[0]
     assert 'mkdir -m 0700 -- "$candidate_repo" "$candidate_git_home"' in (
         directory_stage
     )
@@ -754,8 +754,9 @@ def test_full_workflow_candidate_bundle_is_exact_and_metadata_bound() -> None:
     git_runtime_stage = execute.split(
         "failure_stage=candidate-git-runtime", 1
     )[1].split("failure_stage=candidate-repository-init", 1)[0]
-    assert "test -x /usr/bin/git" in git_runtime_stage
-    assert "candidate_git --version" in git_runtime_stage
+    assert 'test -x "$candidate_git_bin"' in git_runtime_stage
+    assert "candidate_git --version" not in git_runtime_stage
+    assert "sudo -n /usr/bin/dnf -q -y install git-core" in execute
     init_stage = execute.split(
         "failure_stage=candidate-repository-init", 1
     )[1].split("failure_stage=candidate-repository-structure", 1)[0]
@@ -767,11 +768,13 @@ def test_full_workflow_candidate_bundle_is_exact_and_metadata_bound() -> None:
     assert 'test ! -L "$candidate_repo/.git"' in structure_stage
     assert 'git init "$candidate_repo"' not in init_stage
     assert "candidate_git()" in execute
-    assert "-u GIT_DIR" in execute
+    assert "/usr/bin/env -i" in execute
+    assert "PATH=/usr/bin:/bin" in execute
+    assert "LC_ALL=C" in execute
     assert 'HOME="$candidate_git_home"' in execute
     assert "GIT_CONFIG_NOSYSTEM=1" in execute
     assert "GIT_TERMINAL_PROMPT=0" in execute
-    assert "/usr/bin/git -c init.templateDir=" in execute
+    assert '"$candidate_git_bin" -c init.templateDir=' in execute
     verify_stage = execute.split(
         "failure_stage=candidate-bundle-verify", 1
     )[1].split("failure_stage=candidate-bundle-fetch", 1)[0]
@@ -984,6 +987,7 @@ if "--help" not in sys.argv:
         "/home/ec2-user/venv311/bin/python3", str(host_python)
     )
     command = command.replace("/usr/bin/git", str(git_stub))
+    command = command.replace("/usr/bin/env -i", "/usr/bin/env")
     if stage is not None:
         assert category is not None
         if stage == "bootstrap-environment":
@@ -1138,7 +1142,6 @@ def test_rendered_ssm_uses_explicit_exact_candidate_git_sequence(
     assert all(call[:2] == ["-c", "init.templateDir="] for call in calls)
     normalized_calls = [call[2:] for call in calls]
     assert normalized_calls == [
-        ["--version"],
         ["-C", repo, "init"],
         ["-C", repo, "fetch", "--no-tags", bundle, "HEAD"],
         ["-C", repo, "rev-parse", "FETCH_HEAD"],


### PR DESCRIPTION
## Summary
- run candidate Git under a minimal allowlisted environment
- resolve the executable from supported host locations
- install the signed Amazon Linux git-core package only when the transient AMI lacks Git
- preserve exact bundle hash, candidate SHA, canonical-origin, and fail-closed checks

## Evidence
- Production Parity Full 32814129345 reached the transient host and failed at candidate-git-runtime before providers/scoring
- 173 focused parity bootstrap/workflow tests passed
- Python syntax and git diff checks passed

No production state, scoring semantics, Supabase behavior, or weight path is changed.