### PR TITLE
Retry incomplete exact-model budget outcomes

### DIFF
--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -1630,6 +1630,9 @@ _PROVIDER_COST_CAP_ERROR_MARKERS = (
     "provider cost cap",
     "budget_soft_stop",
 )
+_MODEL_RUNNER_RETRYABLE_INCOMPLETE_MARKERS = (
+    "model_runner_incomplete:run_budget_exhausted",
+)
 
 
 def _provider_cost_cap_error_text(error_text: str) -> bool:
@@ -1657,6 +1660,11 @@ def _baseline_error_is_retryable(error_text: str) -> bool:
     diagnostics = _runtime_error_diagnostics(error_text)
     status = int(diagnostics.get("status") or 0)
     provider = str(diagnostics.get("provider") or "unknown")
+    if any(
+        marker in lowered
+        for marker in _MODEL_RUNNER_RETRYABLE_INCOMPLETE_MARKERS
+    ):
+        return True
     if _provider_cost_cap_error_text(error_text):
         return False
     if status in (408, 429) or status >= 500:

--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -1660,13 +1660,13 @@ def _baseline_error_is_retryable(error_text: str) -> bool:
     diagnostics = _runtime_error_diagnostics(error_text)
     status = int(diagnostics.get("status") or 0)
     provider = str(diagnostics.get("provider") or "unknown")
+    if _provider_cost_cap_error_text(error_text):
+        return False
     if any(
         marker in lowered
         for marker in _MODEL_RUNNER_RETRYABLE_INCOMPLETE_MARKERS
     ):
         return True
-    if _provider_cost_cap_error_text(error_text):
-        return False
     if status in (408, 429) or status >= 500:
         return True
     # Scrapingdog's 400 "Something went wrong or profile not found" is

--- a/tests/test_official_baseline_model_runner.py
+++ b/tests/test_official_baseline_model_runner.py
@@ -34,7 +34,11 @@ from gateway.research_lab.official_baseline_model_runner import (
 )
 from research_lab.canonical import sha256_json
 from research_lab.common_model_runner_host import HostActionResult
-from research_lab.eval import DockerPrivateModelSpec, PrivateModelArtifactManifest
+from research_lab.eval import (
+    DockerPrivateModelSpec,
+    PrivateModelArtifactManifest,
+    PrivateModelRuntimeError,
+)
 from research_lab.model_runner_protocol import (
     ArtifactRunnerProtocolGeneration,
     ExactModelRunnerRegistration,
@@ -1073,6 +1077,59 @@ async def test_scoring_worker_accepts_exact_empty_on_retry_zero(monkeypatch):
     assert row["diagnostics"]["sourcing_failed"] is False
     assert row["diagnostics"]["empty_result_provider_evidence_validated"] is True
     assert scoring_worker_module._OFFICIAL_BASELINE_CHECKPOINT_FIELD in row
+
+
+@pytest.mark.asyncio
+async def test_scoring_worker_retries_exact_model_incomplete_budget(monkeypatch):
+    runner, _projector, _authority, _terminal = _exact_fixture()
+    worker = object.__new__(scoring_worker_module.ResearchLabGatewayScoringWorker)
+    worker.worker_ref = "test-worker"
+    worker.config = SimpleNamespace(private_baseline_provider_retry_rounds=2)
+    worker._active_baseline_context = {}
+
+    async def unchanged(**_values):
+        return None
+
+    async def no_traces(**_values):
+        return None
+
+    def incomplete_budget(*_args, **_kwargs):
+        raise PrivateModelRuntimeError(
+            "model_runner_incomplete:run_budget_exhausted"
+        )
+
+    worker._ensure_private_baseline_repo_head_unchanged = unchanged
+    worker._record_baseline_icp_traces = no_traces
+    monkeypatch.setattr(
+        ExactOfficialBaselineRunner,
+        "run_icp",
+        incomplete_budget,
+    )
+    item = {
+        "icp_ref": "icp-incomplete-budget",
+        "icp_hash": "sha256:" + "1" * 64,
+        "set_id": "set-1",
+        "day_index": 0,
+        "day_rank": 1,
+        "icp": {"outputs": [], "max_companies": 1},
+    }
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        row = await worker._run_baseline_icp(
+            runner=runner,
+            scorer=object(),
+            item=item,
+            item_index=1,
+            total_icps=1,
+            run_start=0.0,
+            executor=executor,
+            benchmark_date="2026-08-23",
+            retry_round=0,
+        )
+
+    assert row["_retryable"] is True
+    assert row["_nonempty"] is False
+    assert row["diagnostics"]["sourcing_failed"] is True
+    assert scoring_worker_module._OFFICIAL_BASELINE_CHECKPOINT_FIELD not in row
 
 
 def test_restart_reconstructs_and_does_not_duplicate_provider_call():

--- a/tests/test_scoring_worker_fixes.py
+++ b/tests/test_scoring_worker_fixes.py
@@ -1225,6 +1225,11 @@ def test_stale_claim_recovery_preserves_operator_shards_but_lease_owner_gets_all
             "model_runner_incomplete:run_budget_exhausted",
             True,
         ),
+        (
+            "model_runner_incomplete:run_budget_exhausted; "
+            "research_lab_provider_cost_cap_exceeded",
+            False,
+        ),
         # Genuine auth / request errors stay permanent.
         ("HTTPError: HTTP Error 401: Unauthorized openrouter", False),
         ("HTTPError: HTTP Error 403: Forbidden", False),

--- a/tests/test_scoring_worker_fixes.py
+++ b/tests/test_scoring_worker_fixes.py
@@ -1220,6 +1220,11 @@ def test_stale_claim_recovery_preserves_operator_shards_but_lease_owner_gets_all
             "V2 scoring failed closed: execution_providerclientv2error",
             False,
         ),
+        (
+            "PrivateModelRuntimeError: "
+            "model_runner_incomplete:run_budget_exhausted",
+            True,
+        ),
         # Genuine auth / request errors stay permanent.
         ("HTTPError: HTTP Error 401: Unauthorized openrouter", False),
         ("HTTPError: HTTP Error 403: Forbidden", False),


### PR DESCRIPTION
## Summary
- classify the model-owned `model_runner_incomplete:run_budget_exhausted` outcome as retryable rather than terminal
- preserve provider cost-cap exhaustion as terminal even if diagnostic markers are combined
- cover the exact official-baseline handoff so incomplete runs write no score or checkpoint

## Validation
- 25 focused scoring/exact-runner tests passed
- Python compile and diff checks passed

This is a narrow Research Lab compatibility guard for the company-first model candidate; it does not alter routing, scoring semantics, Supabase persistence, restart/resume custody, or weight submission.