### PR TITLE
Honor model-owned Deepline run pointers

### DIFF
--- a/gateway/research_lab/official_baseline_release_authorities.py
+++ b/gateway/research_lab/official_baseline_release_authorities.py
@@ -1150,6 +1150,37 @@ class ArtifactPreparedActionExecutor:
         return ""
 
     @staticmethod
+    def _deepline_run_id(
+        value: Mapping[str, Any],
+        reconciliation: Mapping[str, Any],
+    ) -> str:
+        """Resolve the provider run ID from the exact model-owned pointer."""
+
+        pointer = reconciliation.get("run_id_json_pointer")
+        if not isinstance(pointer, str) or not pointer.startswith("/"):
+            raise OfficialBaselineProtectedAuthorityError(
+                "official baseline Deepline run id pointer is invalid"
+            )
+        current: Any = value
+        for raw_segment in pointer[1:].split("/"):
+            if not raw_segment or re.search(r"~(?:[^01]|$)", raw_segment):
+                raise OfficialBaselineProtectedAuthorityError(
+                    "official baseline Deepline run id pointer is invalid"
+                )
+            segment = raw_segment.replace("~1", "/").replace("~0", "~")
+            if not isinstance(current, Mapping) or segment not in current:
+                raise OfficialBaselineProtectedAuthorityError(
+                    "official baseline Deepline run id is unavailable"
+                )
+            current = current[segment]
+        run_id = current.strip() if isinstance(current, str) else ""
+        if _SAFE_REF_RE.fullmatch(run_id) is None:
+            raise OfficialBaselineProtectedAuthorityError(
+                "official baseline Deepline run id is invalid"
+            )
+        return run_id
+
+    @staticmethod
     def _progress_document(
         *,
         preparation: OfficialBaselineProtectedPreparation,
@@ -1406,11 +1437,12 @@ class ArtifactPreparedActionExecutor:
                         calls=1,
                         started=started,
                     )
-                run_id = str(body.get("id") or "")
-                if _SAFE_REF_RE.fullmatch(run_id) is None:
+                reconciliation = request.get("reconciliation")
+                if not isinstance(reconciliation, Mapping):
                     raise OfficialBaselineProtectedAuthorityError(
-                        "official baseline Deepline run id is invalid"
+                        "official baseline Deepline reconciliation contract is missing"
                     )
+                run_id = self._deepline_run_id(body, reconciliation)
                 progress = self._progress_document(
                     preparation=preparation,
                     dispatch=dispatch,

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1317,7 +1317,7 @@
       "symbol": "validate_official_baseline_provider_closure"
     },
     {
-      "ast_sha256": "sha256:3a52ce9c5e2ea612a27f8e967aad456465355b2ecfe87e1c05b3246a8ddf001a",
+      "ast_sha256": "sha256:cde12fa586f98ca305fe592ec2b0612ca6324dd8600ed9e4c3dc64f136f90d9b",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "ArtifactPreparedActionExecutor"
     },
@@ -8147,7 +8147,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:fdab9f529923508756a0cb32fa20bdddacab1c5cf19fac2452ca943ba2760465",
-  "protected_source_commit": "36232929adb328385beefb2665c21261c67dcb57",
+  "manifest_hash": "sha256:28036e22c88ab4b90f818300627211a147771ccb863ec6f45e8e6b80aaf68e89",
+  "protected_source_commit": "ba67e44980a19656877bbb831234b314da416fca",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_official_baseline_release_authorities.py
+++ b/tests/test_official_baseline_release_authorities.py
@@ -244,7 +244,7 @@ def _provider_fixture():
         },
         "body": {"name": "fixture", "input": {"schema_version": 3}},
         "reconciliation": {
-            "run_id_json_pointer": "/id",
+            "run_id_json_pointer": "/run/id",
             "primary_poll": {
                 "method": "GET",
                 "url_template": "https://code.deepline.com/api/v2/runs/{run_id}?full=true",
@@ -309,7 +309,11 @@ def test_deepline_progress_survives_interruption_and_restart_never_reposts():
     custody = _custody()
     interrupted = _Proxy(
         [
-            (200, {"id": "run-fixture", "status": "running"}, {}),
+            (
+                200,
+                {"run": {"id": "run-fixture", "status": "running"}},
+                {},
+            ),
             OfficialBaselineProtectedAuthorityError("poll interrupted"),
         ]
     )
@@ -398,6 +402,39 @@ def test_deepline_progress_survives_interruption_and_restart_never_reposts():
         .model_provider_response_ingestion
         is None
     )
+
+
+def test_deepline_missing_model_owned_run_id_path_fails_closed_before_poll():
+    action, dispatch, catalog, inventory = _provider_fixture()
+    protocol = _Protocol(dispatch=dispatch, current=True)
+    custody = _custody()
+    proxy = _Proxy(
+        [(200, {"id": "legacy-top-level", "status": "running"}, {})]
+    )
+    executor = ArtifactPreparedActionExecutor(
+        registration=_registration(protocol),
+        catalog=catalog,
+        inventory=inventory,
+        custody=custody,
+        proxy_url="http://127.0.0.1:8765",
+        proxy_client=proxy,
+    )
+    preparation = executor.prepare(
+        run_identity={"run": "missing-nested-id"},
+        unit_ref="baseline_icp:" + "9" * 64,
+        action=action,
+    )
+
+    with pytest.raises(
+        OfficialBaselineProtectedAuthorityError,
+        match="run id is unavailable",
+    ):
+        executor.execute_prepared(preparation=preparation, action=action)
+
+    assert [call["method"] for call in proxy.calls] == ["POST"]
+    assert custody.load_protected_action_progress(
+        preparation_sha256=preparation.preparation_sha256
+    ) is None
 
 
 def test_deepline_tampered_progress_fails_closed_without_network():


### PR DESCRIPTION
## Summary
- resolve Deepline run IDs from the exact model-owned JSON pointer
- preserve persisted run custody and restart-without-repost behavior
- fail closed when the declared pointer is missing or malformed
- refresh the protected official-baseline authority identity

## Evidence
- live current-window ICP: Deepline completed and returned 100 candidates; accepted start envelope used `/run/id`
- `tests/test_official_baseline_release_authorities.py`: 16 passed
- Sourcing_model model-runner regression: 61 passed
- protected-workflow manifest verification passed

No routing, scoring, persistence, retry, Supabase, restart, or weight-submission policy is changed.