### PR TITLE
Identify exact Production Parity Full host bootstrap failure

### DIFF
--- a/.github/workflows/physical-v2-staging.yml
+++ b/.github/workflows/physical-v2-staging.yml
@@ -536,6 +536,7 @@ jobs:
           test "$("$host_python" -I -c \
             'import sys; print(f"{{sys.version_info.major}}.{{sys.version_info.minor}}")')" = \
             3.11
+          failure_stage=host-python-requirements
           host_requirements={q(root + "/host-controller-requirements.txt")}
           test ! -e "$host_requirements"
           /usr/bin/python3.11 \
@@ -544,17 +545,20 @@ jobs:
             --output "$host_requirements" >/dev/null 2>&1
           test -f "$host_requirements"
           test ! -L "$host_requirements"
+          failure_stage=host-python-pip-bootstrap
           if ! PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1 \
               "$host_python" -m pip --version >/dev/null 2>&1; then
             PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1 \
               "$host_python" -m ensurepip --upgrade >/dev/null 2>&1
           fi
+          failure_stage=host-python-dependency-install
           PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1 \
             "$host_python" -m pip install \
             --disable-pip-version-check \
             --no-input \
             --no-cache-dir \
             --requirement "$host_requirements" >/dev/null 2>&1
+          failure_stage=host-python-dependency-check
           PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1 \
             "$host_python" -m pip check >/dev/null 2>&1
           failure_stage=host-python-import

--- a/scripts/production_parity_bootstrap_evidence.py
+++ b/scripts/production_parity_bootstrap_evidence.py
@@ -35,6 +35,10 @@ BOOTSTRAP_STAGES = frozenset(
         "candidate-remote-rebind",
         "canonical-origin-fetch",
         "host-python-bootstrap",
+        "host-python-requirements",
+        "host-python-pip-bootstrap",
+        "host-python-dependency-install",
+        "host-python-dependency-check",
         "host-python-import",
         "host-entrypoint",
         "evidence-upload",
@@ -74,6 +78,10 @@ BOOTSTRAP_SSM_FAILURE_CODES = (
     (56, "candidate-repository-directory", "CommandFailed"),
     (57, "candidate-repository-structure", "CommandFailed"),
     (58, "host-python-bootstrap", "CommandFailed"),
+    (59, "host-python-requirements", "CommandFailed"),
+    (60, "host-python-pip-bootstrap", "CommandFailed"),
+    (61, "host-python-dependency-install", "CommandFailed"),
+    (62, "host-python-dependency-check", "CommandFailed"),
 )
 MAX_EVIDENCE_BYTES = 1_024
 

--- a/tests/test_production_parity_bootstrap_evidence.py
+++ b/tests/test_production_parity_bootstrap_evidence.py
@@ -58,6 +58,10 @@ def _output(tmp_path: Path) -> Path:
         ("candidate-remote-rebind", "CommandFailed"),
         ("canonical-origin-fetch", "CommandFailed"),
         ("host-python-bootstrap", "CommandFailed"),
+        ("host-python-requirements", "CommandFailed"),
+        ("host-python-pip-bootstrap", "CommandFailed"),
+        ("host-python-dependency-install", "CommandFailed"),
+        ("host-python-dependency-check", "CommandFailed"),
         ("host-python-import", "HostImportFailed"),
         ("host-entrypoint", "HostEntrypointFailed"),
         ("evidence-upload", "EvidenceUploadFailed"),
@@ -121,6 +125,10 @@ def test_bootstrap_ssm_failure_codes_are_unique_fixed_and_bounded() -> None:
         (56, "candidate-repository-directory", "CommandFailed"),
         (57, "candidate-repository-structure", "CommandFailed"),
         (58, "host-python-bootstrap", "CommandFailed"),
+        (59, "host-python-requirements", "CommandFailed"),
+        (60, "host-python-pip-bootstrap", "CommandFailed"),
+        (61, "host-python-dependency-install", "CommandFailed"),
+        (62, "host-python-dependency-check", "CommandFailed"),
     )
     codes = [code for code, _stage, _category in values]
     assert len(codes) == len(set(codes))
@@ -350,7 +358,7 @@ def test_terminal_poller_projects_authoritative_bootstrap_response_code(
 
 @pytest.mark.parametrize(
     "response_code",
-    [-1, 0, 1, 39, 59, 255, None, "40", True, 40.0, {}, []],
+    [-1, 0, 1, 39, 63, 255, None, "40", True, 40.0, {}, []],
 )
 def test_terminal_poller_falls_back_for_not_started_malformed_or_unknown_code(
     tmp_path: Path,
@@ -648,6 +656,10 @@ def test_full_workflow_traps_and_uploads_every_bootstrap_stage() -> None:
         "failure_stage=candidate-remote-rebind",
         "failure_stage=canonical-origin-fetch",
         "failure_stage=host-python-bootstrap",
+        "failure_stage=host-python-requirements",
+        "failure_stage=host-python-pip-bootstrap",
+        "failure_stage=host-python-dependency-install",
+        "failure_stage=host-python-dependency-check",
         "failure_stage=host-python-import",
         "failure_stage=host-entrypoint",
     ]
@@ -665,7 +677,15 @@ def test_full_workflow_traps_and_uploads_every_bootstrap_stage() -> None:
     assert "install -d -m 0700 /run/leadpoet-production-parity" in provisioner
     bootstrap = execute.index("failure_stage=host-python-bootstrap")
     venv = execute.index('/usr/bin/python3.11 -m venv "$host_venv"', bootstrap)
+    requirements = execute.index("failure_stage=host-python-requirements", venv)
+    pip_bootstrap = execute.index("failure_stage=host-python-pip-bootstrap", requirements)
+    dependency_install = execute.index(
+        "failure_stage=host-python-dependency-install", pip_bootstrap
+    )
     install = execute.index('"$host_python" -m pip install', venv)
+    dependency_check = execute.index(
+        "failure_stage=host-python-dependency-check", install
+    )
     import_stage = execute.index("failure_stage=host-python-import", install)
     verified_import = execute.index(
         "scripts/run_production_parity_full_host.py --help", import_stage
@@ -673,7 +693,11 @@ def test_full_workflow_traps_and_uploads_every_bootstrap_stage() -> None:
     assert (
         bootstrap
         < venv
+        < requirements
+        < pip_bootstrap
+        < dependency_install
         < install
+        < dependency_check
         < import_stage
         < verified_import
         < execute.index('evidence="$authoritative_evidence"')


### PR DESCRIPTION
Splits the already-bounded host Python bootstrap failure into requirements, pip bootstrap, dependency install, and dependency check stages. This preserves redaction and fail-closed behavior while making the repeated pre-scoring Full-lane failure actionable.\n\nValidation: 189 focused staging/bootstrap tests passed; py_compile and git diff checks passed.\n\nThis PR does not alter production scoring, transport, persistence, restart, or weight semantics.