### PR TITLE
Preserve miner maintenance restart arguments

### DIFF
--- a/scripts/restart_attested_release_local.sh
+++ b/scripts/restart_attested_release_local.sh
@@ -1435,7 +1435,7 @@ build_gateway_restart_command() {
   fi
   if [ "$disable_miner_submissions_before_restart" = "1" ]; then
     bootstrap_prefix="gateway-miner-maintenance-bootstrap"
-    miner_bootstrap_arguments="
+    miner_bootstrap_arguments=" \\
           --miner-maintenance-bootstrap-plan \"\$bootstrap_root/plan.json\" \\
           --miner-maintenance-bootstrap-root \"\$bootstrap_root\" \\
           --miner-maintenance-handoff-file '$gateway_handoff_file' \\

--- a/tests/test_attested_release_restart_operator.py
+++ b/tests/test_attested_release_restart_operator.py
@@ -281,6 +281,13 @@ printf '%s\\0' "${{gateway_restart_command[@]}}"
     assert "cmp -s '/home/ec2-user/gw_restart.sh' \"$controller_release/gw_restart.sh\"" in bootstrap_command
     assert 'bash "$authority_root/gw_restart.sh"' in bootstrap_command
     assert "--commit '" + commit + "'" in bootstrap_command
+    assert (
+        "--commit '"
+        + commit
+        + "' \\\n"
+        + '          --miner-maintenance-bootstrap-plan "$bootstrap_root/plan.json" \\'
+        in bootstrap_command
+    )
     syntax = subprocess.run(
         ["bash", "-n", "-c", bootstrap_command],
         check=False,


### PR DESCRIPTION
Fix the canonical paired restart command so the four candidate-bound miner-maintenance arguments remain part of the gateway invocation. Adds an exact rendered-command regression assertion. Focused restart/operator suite: 33 passed.