### PR TITLE
Retry incomplete model provider waterfalls

### DIFF
--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -1632,6 +1632,7 @@ _PROVIDER_COST_CAP_ERROR_MARKERS = (
 )
 _MODEL_RUNNER_RETRYABLE_INCOMPLETE_MARKERS = (
     "model_runner_incomplete:run_budget_exhausted",
+    "model_runner_incomplete:required_provider_failure",
 )
 
 

--- a/tests/test_official_baseline_model_runner.py
+++ b/tests/test_official_baseline_model_runner.py
@@ -1079,8 +1079,18 @@ async def test_scoring_worker_accepts_exact_empty_on_retry_zero(monkeypatch):
     assert scoring_worker_module._OFFICIAL_BASELINE_CHECKPOINT_FIELD in row
 
 
+@pytest.mark.parametrize(
+    "incomplete_marker",
+    (
+        "model_runner_incomplete:run_budget_exhausted",
+        "model_runner_incomplete:required_provider_failure",
+    ),
+)
 @pytest.mark.asyncio
-async def test_scoring_worker_retries_exact_model_incomplete_budget(monkeypatch):
+async def test_scoring_worker_retries_exact_model_incomplete_outcome(
+    monkeypatch,
+    incomplete_marker: str,
+):
     runner, _projector, _authority, _terminal = _exact_fixture()
     worker = object.__new__(scoring_worker_module.ResearchLabGatewayScoringWorker)
     worker.worker_ref = "test-worker"
@@ -1093,17 +1103,15 @@ async def test_scoring_worker_retries_exact_model_incomplete_budget(monkeypatch)
     async def no_traces(**_values):
         return None
 
-    def incomplete_budget(*_args, **_kwargs):
-        raise PrivateModelRuntimeError(
-            "model_runner_incomplete:run_budget_exhausted"
-        )
+    def incomplete_outcome(*_args, **_kwargs):
+        raise PrivateModelRuntimeError(incomplete_marker)
 
     worker._ensure_private_baseline_repo_head_unchanged = unchanged
     worker._record_baseline_icp_traces = no_traces
     monkeypatch.setattr(
         ExactOfficialBaselineRunner,
         "run_icp",
-        incomplete_budget,
+        incomplete_outcome,
     )
     item = {
         "icp_ref": "icp-incomplete-budget",

--- a/tests/test_scoring_worker_fixes.py
+++ b/tests/test_scoring_worker_fixes.py
@@ -1226,6 +1226,11 @@ def test_stale_claim_recovery_preserves_operator_shards_but_lease_owner_gets_all
             True,
         ),
         (
+            "PrivateModelRuntimeError: "
+            "model_runner_incomplete:required_provider_failure",
+            True,
+        ),
+        (
             "model_runner_incomplete:run_budget_exhausted; "
             "research_lab_provider_cost_cap_exceeded",
             False,


### PR DESCRIPTION
## Problem

Sourcing_model PR417 makes the official benchmark projector fail closed when an under-target company, intent, or contact waterfall contains an explicit failed, timed-out, or unavailable provider attempt. The existing Research Lab retry classifier recognizes model budget incompleteness but not this new model-owned incompleteness marker.

## Fix

Recognize only `model_runner_incomplete:required_provider_failure` as a bounded retryable exact-model outcome, alongside the existing budget marker. No routing, provider, scoring, persistence, Supabase, restart, publication, or weight-submission behavior changes.

## Verification

- Retry classifier matrix: 23 passed.
- Exact official-baseline retry handoff plus classifier matrix: 25 passed.
- Protected workflow identity tests: 19 passed.
- Python compilation and diff checks: passed.

Depends on leadpoet/Sourcing_model#417 for the model-owned fail-closed signal. This host change is inert until an exact signed artifact emits that marker.