### PR TITLE
Give exact baseline retries durable attempt identities

### DIFF
--- a/gateway/research_lab/official_baseline_model_runner.py
+++ b/gateway/research_lab/official_baseline_model_runner.py
@@ -947,16 +947,31 @@ class ExactOfficialBaselineRunner:
         raw_icp: Mapping[str, Any],
         icp_ref: str,
         target_count: int,
+        attempt_ordinal: int = 0,
         expected_checkpoint: Mapping[str, Any] | None = None,
     ) -> OfficialBaselineModelOutput:
         registration = self.dependencies.registration
         generation_sha256 = registration.protocol_generation.protocol_generation_sha256
+        if (
+            not isinstance(attempt_ordinal, int)
+            or isinstance(attempt_ordinal, bool)
+            or attempt_ordinal < 0
+        ):
+            raise OfficialBaselineModelError(
+                "official baseline attempt ordinal is invalid"
+            )
+        unit_identity: dict[str, Any] = {
+            "run_sha256": self.run_sha256,
+            "icp_ref": str(icp_ref),
+            "raw_icp_sha256": sha256_json(dict(raw_icp)),
+        }
+        # Preserve every existing first-attempt unit identity. A later scoring
+        # round is a new paid provider attempt, while replaying the same round
+        # must remain exactly idempotent across gateway restarts.
+        if attempt_ordinal:
+            unit_identity["attempt_ordinal"] = attempt_ordinal
         unit_ref = "baseline_icp:" + sha256_json(
-            {
-                "run_sha256": self.run_sha256,
-                "icp_ref": str(icp_ref),
-                "raw_icp_sha256": sha256_json(dict(raw_icp)),
-            }
+            unit_identity
         ).removeprefix("sha256:")
         model_input = registration.protocol.build_raw_input(
             raw_icp,

--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -14156,6 +14156,11 @@ class ResearchLabGatewayScoringWorker:
                 latest_result = (
                     attempts[-1].get("result_row") if attempts else None
                 )
+                latest_retry_round = (
+                    int(attempts[-1].get("retry_round") or 0)
+                    if attempts
+                    else 0
+                )
                 checkpoint = (
                     latest_result.get(_OFFICIAL_BASELINE_CHECKPOINT_FIELD)
                     if isinstance(latest_result, Mapping)
@@ -14170,6 +14175,7 @@ class ResearchLabGatewayScoringWorker:
                     raw_icp=item["icp"],
                     icp_ref=resumed_ref,
                     target_count=_icp_company_goal(item["icp"]) or 1,
+                    attempt_ordinal=latest_retry_round,
                     expected_checkpoint=checkpoint,
                 )
 
@@ -16084,6 +16090,7 @@ class ResearchLabGatewayScoringWorker:
                     raw_icp=item["icp"],
                     icp_ref=label,
                     target_count=_icp_company_goal(item["icp"]) or 1,
+                    attempt_ordinal=retry_round,
                 )
                 exact_call = functools.partial(
                     contextvars.copy_context().run,

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1172,7 +1172,7 @@
       "symbol": "EXACT_MODEL_RUNNER_FAMILY"
     },
     {
-      "ast_sha256": "sha256:41680edbecd4a528ef441d77da0f7b2dcbdaa5a80ef4bb9047b569b1c014640d",
+      "ast_sha256": "sha256:672c83eff8fd41e8c588c4c6603da2f1804ec40766a1f2498eff0fc1051277a5",
       "path": "gateway/research_lab/official_baseline_model_runner.py",
       "symbol": "ExactOfficialBaselineRunner"
     },
@@ -2542,7 +2542,7 @@
       "symbol": "ResearchLabGatewayScoringWorker._maybe_run_private_baseline"
     },
     {
-      "ast_sha256": "sha256:39645d41864e3b38826e22a424c23c6770142c5d4497983115fd7d86af924272",
+      "ast_sha256": "sha256:9c952fe4d604be4f7c2b0cd45defa702d03b32a6af47a2286ec42f302751f2ec",
       "path": "gateway/research_lab/scoring_worker.py",
       "symbol": "ResearchLabGatewayScoringWorker._maybe_run_private_baseline_impl"
     },
@@ -2557,7 +2557,7 @@
       "symbol": "ResearchLabGatewayScoringWorker._run_baseline_batch_inner"
     },
     {
-      "ast_sha256": "sha256:25b1e5dbf36ea0db7deaf70eae74515a0c9ce58bf5806830502344ce4efe5dcf",
+      "ast_sha256": "sha256:384d8820775cf75edef13404b267470fc94d143b9d97ca13f088997ac1f43c74",
       "path": "gateway/research_lab/scoring_worker.py",
       "symbol": "ResearchLabGatewayScoringWorker._run_baseline_icp"
     },
@@ -8147,7 +8147,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:b8ba798f232fdd352c20c7476e0e77b9ebdd828fa2d1c652c9ba0c2bb4327635",
-  "protected_source_commit": "2e0dac10487ab81b143966c3c2d075f571482cd7",
+  "manifest_hash": "sha256:837a92fc9715561bd3b1e198e3caf7753de2bec3ad9378a1d10c714ac6544a1f",
+  "protected_source_commit": "157569d756585393f319a1ba822186b5efbeb025",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_official_baseline_model_runner.py
+++ b/tests/test_official_baseline_model_runner.py
@@ -1159,6 +1159,14 @@ def test_restart_reconstructs_and_does_not_duplicate_provider_call():
         expected_checkpoint=first.checkpoint,
     )
 
+    expected_round_zero_ref = "baseline_icp:" + sha256_json(
+        {
+            "run_sha256": runner.run_sha256,
+            "icp_ref": "icp-restart",
+            "raw_icp_sha256": sha256_json(raw),
+        }
+    ).removeprefix("sha256:")
+    assert first.checkpoint["unit_ref"] == expected_round_zero_ref
     assert second.checkpoint == first.checkpoint
     assert second.replayed_transition_count == 1
     assert authority.dispatcher.provider_calls == 1

--- a/tests/test_official_baseline_model_runner.py
+++ b/tests/test_official_baseline_model_runner.py
@@ -747,10 +747,12 @@ class _Transitions:
         return self.generation
 
     def load_model_transition(self, **identity):
-        return self.values.get(identity["idempotency_key"])
+        return self.values.get(
+            (identity["unit_ref"], identity["idempotency_key"])
+        )
 
     def append_model_transition(self, **value):
-        self.values[value["action"]["idempotency_key"]] = {
+        self.values[(value["unit_ref"], value["action"]["idempotency_key"])] = {
             "action": deepcopy(value["action"]),
             "continuation": deepcopy(value["continuation"]),
             "completion": deepcopy(value["completion"]),
@@ -878,7 +880,9 @@ class _ProtectedAuthority:
     def close_unit(self, *, completion):
         ordered_keys = []
         ordered_hashes = []
-        for stored in self.transitions.values.values():
+        for (unit_ref, _idempotency_key), stored in self.transitions.values.items():
+            if unit_ref != completion["unit_ref"]:
+                continue
             action = stored["action"]
             attempt_key = sha256_json(
                 {
@@ -1103,7 +1107,10 @@ async def test_scoring_worker_retries_exact_model_incomplete_outcome(
     async def no_traces(**_values):
         return None
 
-    def incomplete_outcome(*_args, **_kwargs):
+    attempt_ordinals = []
+
+    def incomplete_outcome(*_args, **kwargs):
+        attempt_ordinals.append(kwargs.get("attempt_ordinal"))
         raise PrivateModelRuntimeError(incomplete_marker)
 
     worker._ensure_private_baseline_repo_head_unchanged = unchanged
@@ -1131,9 +1138,10 @@ async def test_scoring_worker_retries_exact_model_incomplete_outcome(
             run_start=0.0,
             executor=executor,
             benchmark_date="2026-08-23",
-            retry_round=0,
+            retry_round=1,
         )
 
+    assert attempt_ordinals == [1]
     assert row["_retryable"] is True
     assert row["_nonempty"] is False
     assert row["diagnostics"]["sourcing_failed"] is True
@@ -1155,6 +1163,42 @@ def test_restart_reconstructs_and_does_not_duplicate_provider_call():
     assert second.replayed_transition_count == 1
     assert authority.dispatcher.provider_calls == 1
     assert len(terminal.records) == 1
+
+    retry = runner.run_icp(
+        raw_icp=raw,
+        icp_ref="icp-restart",
+        target_count=1,
+        attempt_ordinal=1,
+    )
+    retry_after_restart = runner.run_icp(
+        raw_icp=raw,
+        icp_ref="icp-restart",
+        target_count=1,
+        attempt_ordinal=1,
+        expected_checkpoint=retry.checkpoint,
+    )
+
+    assert retry.checkpoint != first.checkpoint
+    assert retry_after_restart.checkpoint == retry.checkpoint
+    assert retry_after_restart.replayed_transition_count == 1
+    assert authority.dispatcher.provider_calls == 2
+    assert len(terminal.records) == 2
+
+
+@pytest.mark.parametrize("attempt_ordinal", (-1, True, 1.0, "1"))
+def test_exact_official_baseline_rejects_invalid_attempt_ordinal(attempt_ordinal):
+    runner, _projector, _authority, _terminal = _exact_fixture()
+
+    with pytest.raises(
+        OfficialBaselineModelError,
+        match="attempt ordinal is invalid",
+    ):
+        runner.run_icp(
+            raw_icp={"outputs": []},
+            icp_ref="icp-invalid-attempt",
+            target_count=1,
+            attempt_ordinal=attempt_ordinal,
+        )
 
 
 def test_current_official_baseline_uses_compiled_dispatch_and_v4_custody():


### PR DESCRIPTION
## Why

An exact-model provider terminal is durably replayed by unit identity. The scoring scheduler advanced retry_round, but the runner reused the round-0 unit, so a retry could replay the same failed provider terminal forever.

## Change

- Preserve the existing round-0 unit identity byte-for-byte.
- Bind rounds 1+ to deterministic attempt ordinals, giving each authorized retry a fresh provider/cost-custody unit.
- Replay the same retry ordinal idempotently after restart.
- Reconstruct completed retry checkpoints with their persisted ordinal.
- Refresh the protected workflow identity.

No model routing, provider ordering, scoring, persistence schema, retry count, or weight behavior changes.

## Validation

- 55 exact official-baseline runner tests passed.
- 64 protected authority/store/release tests passed.
- 30 protected-workflow/exact-commit tests passed.
- Final combined focused gate: 120 passed.
- Python compile and diff checks passed.