### PR TITLE
Bootstrap parity pip after isolated venv creation

### DIFF
--- a/.github/workflows/physical-v2-staging.yml
+++ b/.github/workflows/physical-v2-staging.yml
@@ -567,7 +567,10 @@ jobs:
           host_bootstrap_step=venv-absence
           test ! -e "$host_venv"
           host_bootstrap_step=venv-create
-          /usr/bin/python3.11 -m venv "$host_venv"
+          # The production AMI may omit the distro pip bootstrap wheel. Build
+          # the isolated interpreter first so that omission cannot make venv
+          # creation fail before the candidate dependency lock is installed.
+          /usr/bin/python3.11 -I -m venv --without-pip "$host_venv"
           host_bootstrap_step=venv-identity
           test -d "$host_venv"
           test ! -L "$host_venv"
@@ -589,6 +592,9 @@ jobs:
           host_bootstrap_step=pip-bootstrap
           if ! PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1 \
               "$host_python" -m pip --version >/dev/null 2>&1; then
+            test -x /usr/bin/dnf
+            sudo -n /usr/bin/dnf -q -y install \
+              python3.11-pip-wheel >/dev/null 2>&1
             PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1 \
               "$host_python" -m ensurepip --upgrade >/dev/null 2>&1
           fi

--- a/tests/test_physical_v2_staging.py
+++ b/tests/test_physical_v2_staging.py
@@ -1010,7 +1010,11 @@ def test_full_workflow_fetches_exact_bundle_head_then_binds_canonical_main():
     assert 'PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1' in source
     assert 'host_python="$host_venv/bin/python3"' in source
     assert 'test ! -e "$host_venv"' in source
-    assert '/usr/bin/python3.11 -m venv "$host_venv"' in source
+    assert (
+        '/usr/bin/python3.11 -I -m venv --without-pip "$host_venv"'
+        in source
+    )
+    assert "python3.11-pip-wheel" in source
     assert "GIT_CONFIG_NOSYSTEM=1" in source
     assert "git clone" not in source
 

--- a/tests/test_production_parity_bootstrap_evidence.py
+++ b/tests/test_production_parity_bootstrap_evidence.py
@@ -657,6 +657,7 @@ def test_full_workflow_traps_and_uploads_every_bootstrap_stage() -> None:
     assert "scripts/run_production_parity_full_host.py --help" in execute
     assert "scripts/resolve_production_parity_controller_requirements.py" in execute
     assert 'PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1' in execute
+    assert "python3.11-pip-wheel" in execute
     assert '"$host_python" -m ensurepip --upgrade' in execute
     assert '"$host_python" -m pip check' in execute
     provisioner = (
@@ -664,7 +665,11 @@ def test_full_workflow_traps_and_uploads_every_bootstrap_stage() -> None:
     ).read_text(encoding="utf-8")
     assert "install -d -m 0700 /run/leadpoet-production-parity" in provisioner
     bootstrap = execute.index("failure_stage=host-python-bootstrap")
-    venv = execute.index('/usr/bin/python3.11 -m venv "$host_venv"', bootstrap)
+    venv = execute.index(
+        '/usr/bin/python3.11 -I -m venv --without-pip "$host_venv"',
+        bootstrap,
+    )
+    bootstrap_pip = execute.index("python3.11-pip-wheel", venv)
     install = execute.index('"$host_python" -m pip install', venv)
     import_stage = execute.index("failure_stage=host-python-import", install)
     verified_import = execute.index(
@@ -673,6 +678,7 @@ def test_full_workflow_traps_and_uploads_every_bootstrap_stage() -> None:
     assert (
         bootstrap
         < venv
+        < bootstrap_pip
         < install
         < import_stage
         < verified_import
@@ -1033,7 +1039,9 @@ else:
         'host_python="$host_venv/bin/python3"',
         f"host_python={shlex.quote(str(host_python))}",
     )
-    venv_command = f'{sys.executable} -m venv "$host_venv"'
+    venv_command = (
+        f'{sys.executable} -I -m venv --without-pip "$host_venv"'
+    )
     assert command.count(venv_command) == 1
     command = command.replace(
         venv_command, 'mkdir -m 0700 -- "$host_venv"', 1


### PR DESCRIPTION
Repairs the exact Production Parity Full failure at `host-python-bootstrap: venv-create`. The transient production-derived host now creates its run-scoped Python 3.11 environment with `--without-pip`, then installs Amazon Linux's supported `python3.11-pip-wheel` before `ensurepip` and the candidate-derived dependency lock.

This preserves a fresh isolated controller and does not reuse the AMI's shared venv, alter model/scoring semantics, or weaken exact-main/attestation/lineage gates.

Validation:
- 179 focused physical-staging/bootstrap tests passed
- 136 production-parity tests passed (1 existing skip)
- AL2023 reproduction with the pip wheel deliberately removed passed the exact repaired sequence
- workflow YAML and diff checks passed