### PR TITLE
Honor model-owned provider path encoding

### DIFF
--- a/gateway/research_lab/official_baseline_release_authorities.py
+++ b/gateway/research_lab/official_baseline_release_authorities.py
@@ -1181,6 +1181,27 @@ class ArtifactPreparedActionExecutor:
         return run_id
 
     @staticmethod
+    def _deepline_poll_path_component(
+        progress: Mapping[str, Any],
+    ) -> str:
+        """Encode the run ID exactly as declared by the model artifact."""
+
+        reconciliation = progress.get("reconciliation")
+        if not isinstance(reconciliation, Mapping):
+            raise OfficialBaselineProtectedAuthorityError(
+                "official baseline Deepline poll contract is invalid"
+            )
+        layers = reconciliation.get("run_id_path_encoding_layers", 1)
+        if type(layers) is not int or not 1 <= layers <= 4:
+            raise OfficialBaselineProtectedAuthorityError(
+                "official baseline Deepline run id path encoding is invalid"
+            )
+        encoded = str(progress.get("run_id") or "")
+        for _ in range(layers):
+            encoded = urllib.parse.quote(encoded, safe="")
+        return encoded
+
+    @staticmethod
     def _progress_document(
         *,
         preparation: OfficialBaselineProtectedPreparation,
@@ -1351,7 +1372,7 @@ class ArtifactPreparedActionExecutor:
         started: float,
     ) -> tuple[int, Mapping[str, Any]] | None:
         reconciliation = progress["reconciliation"]
-        run_id = urllib.parse.quote(str(progress["run_id"]), safe="")
+        run_id = self._deepline_poll_path_component(progress)
         deadline = started + preparation.timeout_ms / 1000
         first = True
         while first or self._clock() < deadline:

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1317,7 +1317,7 @@
       "symbol": "validate_official_baseline_provider_closure"
     },
     {
-      "ast_sha256": "sha256:cde12fa586f98ca305fe592ec2b0612ca6324dd8600ed9e4c3dc64f136f90d9b",
+      "ast_sha256": "sha256:3bd0aa4a42c4c9775941efa440df881fca708d01b2cb06d91934235bf6396823",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "ArtifactPreparedActionExecutor"
     },
@@ -8147,7 +8147,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:837a92fc9715561bd3b1e198e3caf7753de2bec3ad9378a1d10c714ac6544a1f",
-  "protected_source_commit": "157569d756585393f319a1ba822186b5efbeb025",
+  "manifest_hash": "sha256:5a69611a31c8224994b296cc30b52f4698e73c410125e4dd0d42456171e4c8d5",
+  "protected_source_commit": "6d2e3f950c9b0b2fcf48e4dd3e1a5f9216d462dd",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_official_baseline_release_authorities.py
+++ b/tests/test_official_baseline_release_authorities.py
@@ -245,6 +245,7 @@ def _provider_fixture():
         "body": {"name": "fixture", "input": {"schema_version": 3}},
         "reconciliation": {
             "run_id_json_pointer": "/run/id",
+            "run_id_path_encoding_layers": 2,
             "primary_poll": {
                 "method": "GET",
                 "url_template": "https://code.deepline.com/api/v2/runs/{run_id}?full=true",
@@ -402,6 +403,81 @@ def test_deepline_progress_survives_interruption_and_restart_never_reposts():
         .model_provider_response_ingestion
         is None
     )
+
+
+def test_deepline_model_owned_run_id_path_encoding_is_applied_exactly():
+    action, dispatch, catalog, inventory = _provider_fixture()
+    protocol = _Protocol(dispatch=dispatch, current=True)
+    custody = _custody()
+    run_id = "play/leadpoet-firmographic-company-discovery/run-fixture"
+    proxy = _Proxy(
+        [
+            (200, {"run": {"id": run_id, "status": "running"}}, {}),
+            (
+                200,
+                {
+                    "run": {"id": run_id, "status": "completed"},
+                    "output": {
+                        "schema_version": 3,
+                        "segment_id": "aggregate-fixture",
+                        "rows": [],
+                    },
+                },
+                {},
+            ),
+        ]
+    )
+    executor = ArtifactPreparedActionExecutor(
+        registration=_registration(protocol),
+        catalog=catalog,
+        inventory=inventory,
+        custody=custody,
+        proxy_url="http://127.0.0.1:8765",
+        proxy_client=proxy,
+        sleep=lambda _seconds: None,
+    )
+    preparation = executor.prepare(
+        run_identity={"run": "double-encoded"},
+        unit_ref="baseline_icp:" + "6" * 64,
+        action=action,
+    )
+
+    terminal = executor.execute_prepared(
+        preparation=preparation,
+        action=action,
+    )
+
+    assert terminal.state == "known"
+    assert proxy.calls[1]["upstream_url"] == (
+        "https://code.deepline.com/api/v2/runs/"
+        "play%252Fleadpoet-firmographic-company-discovery%252Frun-fixture"
+        "?full=true"
+    )
+
+
+def test_deepline_legacy_artifact_defaults_to_single_path_encoding_layer():
+    assert ArtifactPreparedActionExecutor._deepline_poll_path_component(
+        {
+            "run_id": "play/fixture",
+            "reconciliation": {},
+        }
+    ) == "play%2Ffixture"
+
+
+@pytest.mark.parametrize("layers", [True, 0, 5, "2"])
+def test_deepline_run_id_path_encoding_layers_fail_closed(layers):
+    with pytest.raises(
+        OfficialBaselineProtectedAuthorityError,
+        match="run id path encoding is invalid",
+    ):
+        ArtifactPreparedActionExecutor._deepline_poll_path_component(
+            {
+                "run_id": "play/fixture",
+                "reconciliation": {
+                    "run_id_path_encoding_layers": layers,
+                },
+            }
+        )
 
 
 def test_deepline_missing_model_owned_run_id_path_fails_closed_before_poll():


### PR DESCRIPTION
Production rebenchmark blocker: Deepline returns slash-bearing run IDs whose live detail route requires two URL-component encoding layers.

This keeps transport semantics model-owned and backward compatible:
- the model artifact may declare a bounded run_id_path_encoding_layers value;
- old artifacts retain the existing one-layer default;
- malformed or out-of-range declarations fail closed;
- no model commit, workflow ID, or provider response is hard-coded.

Verification:
- 41 focused Lab and protected-workflow tests passed;
- Python compilation and diff checks passed;
- exact live probe established one layer returns 404 and two layers returns the canonical completed run.

Merging this changes the protected runtime identity and is expected to require exact-SHA attestation/restart before the latest model rebenchmark can resume.