### PR TITLE
Bootstrap parity host Python before venv creation

### DIFF
--- a/.github/workflows/physical-v2-staging.yml
+++ b/.github/workflows/physical-v2-staging.yml
@@ -427,7 +427,7 @@ jobs:
             if [ "$final_status" -ne 0 ] && \
                [ "$failure_stage" = host-python-bootstrap ]; then
               case "$host_bootstrap_step" in
-                venv-absence|venv-create|venv-identity|python-version|requirements-resolve|pip-bootstrap|pip-install|pip-check)
+                venv-absence|runtime-package|venv-create|venv-identity|python-version|requirements-resolve|pip-bootstrap|pip-install|pip-check)
                   printf 'LEADPOET_BOOTSTRAP_STEP=%s\n' \
                     "$host_bootstrap_step" >&2
                   ;;
@@ -566,11 +566,15 @@ jobs:
           failure_category=CommandFailed
           host_bootstrap_step=venv-absence
           test ! -e "$host_venv"
+          host_bootstrap_step=runtime-package
+          test -x /usr/bin/dnf
+          # Amazon Linux publishes the complete Python 3.11 venv bootstrap as
+          # the namespaced pip package. Install it before creating the venv so
+          # the base AMI's optional package set cannot make venv fail first.
+          sudo -n /usr/bin/dnf -q -y install \
+            python3.11-pip >/dev/null 2>&1
           host_bootstrap_step=venv-create
-          # The production AMI may omit the distro pip bootstrap wheel. Build
-          # the isolated interpreter first so that omission cannot make venv
-          # creation fail before the candidate dependency lock is installed.
-          /usr/bin/python3.11 -I -m venv --without-pip "$host_venv"
+          /usr/bin/python3.11 -I -m venv "$host_venv"
           host_bootstrap_step=venv-identity
           test -d "$host_venv"
           test ! -L "$host_venv"
@@ -590,14 +594,8 @@ jobs:
           test -f "$host_requirements"
           test ! -L "$host_requirements"
           host_bootstrap_step=pip-bootstrap
-          if ! PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1 \
-              "$host_python" -m pip --version >/dev/null 2>&1; then
-            test -x /usr/bin/dnf
-            sudo -n /usr/bin/dnf -q -y install \
-              python3.11-pip-wheel >/dev/null 2>&1
-            PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1 \
-              "$host_python" -m ensurepip --upgrade >/dev/null 2>&1
-          fi
+          PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1 \
+            "$host_python" -m pip --version >/dev/null 2>&1
           host_bootstrap_step=pip-install
           PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1 \
             "$host_python" -m pip install \
@@ -699,6 +697,7 @@ jobs:
 
           allowed = {
               "venv-absence",
+              "runtime-package",
               "venv-create",
               "venv-identity",
               "python-version",

--- a/tests/test_physical_v2_staging.py
+++ b/tests/test_physical_v2_staging.py
@@ -1011,10 +1011,18 @@ def test_full_workflow_fetches_exact_bundle_head_then_binds_canonical_main():
     assert 'host_python="$host_venv/bin/python3"' in source
     assert 'test ! -e "$host_venv"' in source
     assert (
-        '/usr/bin/python3.11 -I -m venv --without-pip "$host_venv"'
+        'sudo -n /usr/bin/dnf -q -y install \\\n'
+        '            python3.11-pip >/dev/null 2>&1'
         in source
     )
-    assert "python3.11-pip-wheel" in source
+    assert (
+        '/usr/bin/python3.11 -I -m venv "$host_venv"'
+        in source
+    )
+    runtime_package = source.index("host_bootstrap_step=runtime-package")
+    venv_create = source.index("host_bootstrap_step=venv-create")
+    assert runtime_package < venv_create
+    assert "python3.11-pip-wheel" not in source
     assert "GIT_CONFIG_NOSYSTEM=1" in source
     assert "git clone" not in source
 
@@ -1078,6 +1086,7 @@ def test_full_bootstrap_diagnostic_exposes_only_a_bounded_substage():
     ).read_text(encoding="utf-8")
     allowed = {
         "venv-absence",
+        "runtime-package",
         "venv-create",
         "venv-identity",
         "python-version",

--- a/tests/test_production_parity_bootstrap_evidence.py
+++ b/tests/test_production_parity_bootstrap_evidence.py
@@ -657,19 +657,25 @@ def test_full_workflow_traps_and_uploads_every_bootstrap_stage() -> None:
     assert "scripts/run_production_parity_full_host.py --help" in execute
     assert "scripts/resolve_production_parity_controller_requirements.py" in execute
     assert 'PIP_CONFIG_FILE=/dev/null PYTHONNOUSERSITE=1' in execute
-    assert "python3.11-pip-wheel" in execute
-    assert '"$host_python" -m ensurepip --upgrade' in execute
+    assert "python3.11-pip" in execute
+    assert "python3.11-pip-wheel" not in execute
+    assert '"$host_python" -m ensurepip --upgrade' not in execute
     assert '"$host_python" -m pip check' in execute
     provisioner = (
         Path(__file__).parents[1] / "scripts/provision_production_parity_staging.py"
     ).read_text(encoding="utf-8")
     assert "install -d -m 0700 /run/leadpoet-production-parity" in provisioner
     bootstrap = execute.index("failure_stage=host-python-bootstrap")
-    venv = execute.index(
-        '/usr/bin/python3.11 -I -m venv --without-pip "$host_venv"',
+    runtime_package = execute.index(
+        "host_bootstrap_step=runtime-package",
         bootstrap,
     )
-    bootstrap_pip = execute.index("python3.11-pip-wheel", venv)
+    package_install = execute.index("python3.11-pip", runtime_package)
+    venv = execute.index(
+        '/usr/bin/python3.11 -I -m venv "$host_venv"',
+        package_install,
+    )
+    bootstrap_pip = execute.index('"$host_python" -m pip --version', venv)
     install = execute.index('"$host_python" -m pip install', venv)
     import_stage = execute.index("failure_stage=host-python-import", install)
     verified_import = execute.index(
@@ -677,6 +683,8 @@ def test_full_workflow_traps_and_uploads_every_bootstrap_stage() -> None:
     )
     assert (
         bootstrap
+        < runtime_package
+        < package_install
         < venv
         < bootstrap_pip
         < install
@@ -961,16 +969,22 @@ else:
     sudo_stub.write_text(
         """#!/bin/sh
 set -eu
+if [ "${1:-}" = "-n" ]; then
+  shift
+fi
 operation="$1"
 shift
 case "$operation" in
   mkdir) exec mkdir "$@" ;;
   chown) exit 0 ;;
+  */dnf) exec "$operation" "$@" ;;
   *) exit 2 ;;
 esac
 """,
         encoding="utf-8",
     )
+    dnf_stub = fake_bin / "dnf"
+    dnf_stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     stat_stub = fake_bin / "stat"
     stat_stub.write_text(
         """#!/usr/bin/env python3
@@ -1020,6 +1034,7 @@ else:
         aws_stub,
         git_stub,
         sudo_stub,
+        dnf_stub,
         stat_stub,
         sha256sum_stub,
         host_python,
@@ -1040,7 +1055,7 @@ else:
         f"host_python={shlex.quote(str(host_python))}",
     )
     venv_command = (
-        f'{sys.executable} -I -m venv --without-pip "$host_venv"'
+        f'{sys.executable} -I -m venv "$host_venv"'
     )
     assert command.count(venv_command) == 1
     command = command.replace(
@@ -1051,6 +1066,7 @@ else:
         f'test "$(readlink -f -- "$host_python")" = {host_python.resolve()}',
     )
     command = command.replace("/usr/bin/git", str(git_stub))
+    command = command.replace("/usr/bin/dnf", str(dnf_stub))
     command = command.replace("/usr/bin/env -i", "/usr/bin/env")
     if stage is not None:
         assert category is not None


### PR DESCRIPTION
Production Parity Full reaches the disposable Nitro host but fails at host-python-bootstrap / venv-create before candidate code runs. The prior fallback installed a pip wheel only after venv creation, so it could not repair that failure.\n\nThis narrow change installs Amazon Linux's namespaced python3.11-pip package before creating the isolated venv, verifies pip inside that venv, and adds only the bounded runtime-package diagnostic marker. It does not touch production runtime, model, scoring, Supabase, retry/recovery, persistence, restart, or weight logic.\n\nValidation:\n- 55 tests passed in tests/test_physical_v2_staging.py\n- workflow YAML parsed successfully\n- exact linux/amd64 Amazon Linux package -> venv -> pip sequence passed\n- Python compile and git diff checks passed