### PR TITLE
Refresh private ECR auth for model pulls

### DIFF
--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -6887,7 +6887,7 @@
       "symbol": "score_private_model_pair_items"
     },
     {
-      "ast_sha256": "sha256:0895f96accd1152bee5c36bd94a086f3d8619d3ac1a603f919b9d7740afecb35",
+      "ast_sha256": "sha256:b7f97b1edbd874ac6074011c996a5d6572da4070dc5e7806c7a798bc6e332803",
       "path": "research_lab/eval/private_runtime.py",
       "symbol": "DockerPrivateModelRunner._pull_image"
     },
@@ -8147,7 +8147,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:5a69611a31c8224994b296cc30b52f4698e73c410125e4dd0d42456171e4c8d5",
-  "protected_source_commit": "6d2e3f950c9b0b2fcf48e4dd3e1a5f9216d462dd",
+  "manifest_hash": "sha256:1971a457a1374227b196b90c12579db64ac6a6a8c869929f35120f92e96b54bd",
+  "protected_source_commit": "5760d2a7f99e38a3c3d8865ef707d02e45ef255d",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/research_lab/eval/private_runtime.py
+++ b/research_lab/eval/private_runtime.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from typing import Any, Iterator, Mapping, Sequence
@@ -108,6 +109,15 @@ PROVIDER_COST_ENV_PASSTHROUGH = (
 )
 PROVIDER_COST_EVALUATION_SCOPE_ENV = "RESEARCH_LAB_PROVIDER_COST_EVALUATION_SCOPE"
 DEFAULT_DOCKER_PLATFORM = "linux/amd64"
+_PRIVATE_ECR_REGISTRY_RE = re.compile(
+    r"^(?P<registry>[0-9]+\.dkr\.ecr\.(?P<region>[a-z0-9-]+)\.amazonaws\.com(?:\.cn)?)/"
+)
+_PRIVATE_ECR_AUTH_FAILURE_MARKERS = (
+    "authorization token has expired",
+    "no basic auth credentials",
+    "pull access denied",
+    "requested access to the resource is denied",
+)
 SOURCING_MODEL_MAX_RUNTIME_CAP_SECONDS = 1500.0
 SOURCING_MODEL_MAX_AGENT_TIMEOUT_SECONDS = 900
 # Match the adapter's result/receipt finalization window before sandbox kill.
@@ -1673,6 +1683,101 @@ def _docker_lifecycle_remaining_seconds(deadline_monotonic: float) -> float:
     return max(0.1, remaining)
 
 
+def _private_ecr_registry(image_digest: str) -> tuple[str, str] | None:
+    match = _PRIVATE_ECR_REGISTRY_RE.match(str(image_digest or "").strip())
+    if match is None:
+        return None
+    return match.group("registry"), match.group("region")
+
+
+def _private_ecr_auth_failure(
+    completed: subprocess.CompletedProcess[str],
+) -> bool:
+    text = " ".join(
+        (
+            str(completed.stderr or ""),
+            str(completed.stdout or ""),
+        )
+    ).lower()
+    return any(marker in text for marker in _PRIVATE_ECR_AUTH_FAILURE_MARKERS)
+
+
+def _pull_private_ecr_image_with_refreshed_auth(
+    spec: DockerPrivateModelSpec,
+    *,
+    registry: str,
+    region: str,
+    deadline_monotonic: float,
+    environment: Mapping[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Refresh private-ECR auth in memory and one ephemeral Docker config."""
+
+    try:
+        password_result = subprocess.run(
+            ["aws", "ecr", "get-login-password", "--region", region],
+            text=True,
+            capture_output=True,
+            timeout=_docker_lifecycle_remaining_seconds(deadline_monotonic),
+            env=dict(environment),
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise PrivateModelRuntimeError(
+            "private ECR authentication refresh failed"
+        ) from exc
+    password = str(password_result.stdout or "").strip()
+    if password_result.returncode != 0 or not password:
+        raise PrivateModelRuntimeError(
+            "private ECR authentication refresh failed"
+        )
+
+    with tempfile.TemporaryDirectory(
+        prefix="research-lab-private-model-docker-auth-"
+    ) as config_dir:
+        try:
+            login_result = subprocess.run(
+                [
+                    spec.docker_executable,
+                    "--config",
+                    config_dir,
+                    "login",
+                    "--username",
+                    "AWS",
+                    "--password-stdin",
+                    registry,
+                ],
+                input=password + "\n",
+                text=True,
+                capture_output=True,
+                timeout=_docker_lifecycle_remaining_seconds(deadline_monotonic),
+                env=dict(environment),
+                check=False,
+            )
+            if login_result.returncode != 0:
+                raise PrivateModelRuntimeError(
+                    "private ECR Docker login failed"
+                )
+            return subprocess.run(
+                [
+                    spec.docker_executable,
+                    "--config",
+                    config_dir,
+                    "pull",
+                    *_docker_platform_args(spec),
+                    spec.image_digest,
+                ],
+                text=True,
+                capture_output=True,
+                timeout=_docker_lifecycle_remaining_seconds(deadline_monotonic),
+                env=dict(environment),
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise PrivateModelRuntimeError(
+                "private ECR authenticated pull failed"
+            ) from exc
+
+
 def _remove_private_model_container(
     spec: DockerPrivateModelSpec,
     *,
@@ -1771,15 +1876,29 @@ class DockerPrivateModelRunner:
         return validate_sourcing_adapter_metadata(decoded)
 
     def _pull_image(self) -> None:
+        environment = _build_docker_process_env(self.spec)
         with _docker_private_model_lifecycle(self.spec) as deadline:
             completed = subprocess.run(
                 [self.spec.docker_executable, "pull", *_docker_platform_args(self.spec), self.spec.image_digest],
                 text=True,
                 capture_output=True,
                 timeout=_docker_lifecycle_remaining_seconds(deadline),
-                env=_build_docker_process_env(self.spec),
+                env=environment,
                 check=False,
             )
+            registry = _private_ecr_registry(self.spec.image_digest)
+            if (
+                completed.returncode != 0
+                and registry is not None
+                and _private_ecr_auth_failure(completed)
+            ):
+                completed = _pull_private_ecr_image_with_refreshed_auth(
+                    self.spec,
+                    registry=registry[0],
+                    region=registry[1],
+                    deadline_monotonic=deadline,
+                    environment=environment,
+                )
         if completed.returncode != 0:
             stderr = _sanitize_text(completed.stderr)[-1200:]
             raise PrivateModelRuntimeError(f"docker pull failed with code {completed.returncode}: {stderr}")

--- a/tests/test_docker_operation_shared_lifecycle_v2.py
+++ b/tests/test_docker_operation_shared_lifecycle_v2.py
@@ -15,6 +15,10 @@ from research_lab.eval import private_runtime
 
 
 IMAGE_REF = "example.invalid/model@sha256:" + ("a" * 64)
+ECR_IMAGE_REF = (
+    "493765492819.dkr.ecr.us-east-1.amazonaws.com/leadpoet/sourcing-model"
+    "@sha256:" + ("b" * 64)
+)
 
 
 @pytest.mark.parametrize("timeout_seconds", (0, -1, float("nan"), float("inf")))
@@ -243,6 +247,111 @@ def test_private_model_daemon_readiness_failure_is_bounded_and_retryable(
             stdin_payload={"icp": {}, "context": {}},
         )
     assert time.monotonic() - started < 2
+
+
+def test_private_model_pull_refreshes_expired_ecr_auth_ephemerally(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "LEADPOET_DOCKER_OPERATION_LOCK_FILE",
+        str(tmp_path / "docker-operation.lock"),
+    )
+    calls: list[tuple[list[str], dict[str, object]]] = []
+    auth_config_dirs: list[Path] = []
+
+    def run(
+        command: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append((list(command), dict(kwargs)))
+        if command[-1:] == ["info"]:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        if command[:2] == ["docker", "pull"]:
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                stdout="",
+                stderr="denied: Your authorization token has expired",
+            )
+        if command[:4] == ["aws", "ecr", "get-login-password", "--region"]:
+            assert command[4] == "us-east-1"
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout="ephemeral-password\n",
+                stderr="",
+            )
+        if command[0:2] == ["docker", "--config"]:
+            config_dir = Path(command[2])
+            auth_config_dirs.append(config_dir)
+            assert config_dir.is_dir()
+            if command[3] == "login":
+                assert kwargs.get("input") == "ephemeral-password\n"
+                return subprocess.CompletedProcess(
+                    command, 0, stdout="Login Succeeded", stderr=""
+                )
+            assert command[3] == "pull"
+            assert command[-1] == ECR_IMAGE_REF
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        raise AssertionError(command)
+
+    monkeypatch.setattr(private_runtime.subprocess, "run", run)
+    private_runtime.DockerPrivateModelRunner(
+        private_runtime.DockerPrivateModelSpec(
+            image_digest=ECR_IMAGE_REF,
+            timeout_seconds=5,
+        )
+    )
+
+    assert [call[0][0] for call in calls] == [
+        "docker",
+        "docker",
+        "aws",
+        "docker",
+        "docker",
+    ]
+    assert len(set(auth_config_dirs)) == 1
+    assert auth_config_dirs[0].exists() is False
+    assert all("ephemeral-password" not in " ".join(call[0]) for call in calls)
+
+
+def test_private_model_pull_does_not_refresh_unrecognized_or_non_ecr_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "LEADPOET_DOCKER_OPERATION_LOCK_FILE",
+        str(tmp_path / "docker-operation.lock"),
+    )
+    calls: list[list[str]] = []
+
+    def run(
+        command: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(list(command))
+        if command[-1:] == ["info"]:
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            stdout="",
+            stderr="manifest digest mismatch",
+        )
+
+    monkeypatch.setattr(private_runtime.subprocess, "run", run)
+    with pytest.raises(
+        private_runtime.PrivateModelRuntimeError,
+        match="docker pull failed with code 1",
+    ):
+        private_runtime.DockerPrivateModelRunner(
+            private_runtime.DockerPrivateModelSpec(
+                image_digest=ECR_IMAGE_REF,
+                timeout_seconds=5,
+            )
+        )
+    assert [command[0] for command in calls] == ["docker", "docker"]
 
 
 def test_private_model_timeout_removes_named_container_before_unlock(


### PR DESCRIPTION
## Summary
- retry only recognized private-ECR authentication failures for immutable model pulls
- obtain a fresh ECR password from the instance role and use it only through password-stdin in an ephemeral Docker config
- preserve the existing digest, platform, lifecycle lock, timeout, and fail-closed behavior for every unrecognized failure

## Production blocker
The newly signed `leadpoet-lab` model artifact is valid, but exact consumer admission cannot pull its immutable image because the gateway Docker token expired. This recurs as ECR tokens age and blocks the current official rebenchmark.

## Verification
- 104 focused Docker lifecycle, signed-artifact admission, private-runtime compatibility, host transport, and protected-workflow tests passed
- Python compile and `git diff --check` passed
- positive regression proves ephemeral refresh and cleanup; negative regression proves unknown failures do not refresh
- protected workflow identity refreshed only for `DockerPrivateModelRunner._pull_image`

No scoring, assignment, provider, model semantics, persistence, Supabase, reward, weight, or trust policy changes.