### PR TITLE
Retain bounded Production Parity initialization failures

### DIFF
--- a/scripts/run_production_parity_full_host.py
+++ b/scripts/run_production_parity_full_host.py
@@ -139,6 +139,13 @@ CLONE_PREFIX_ADAPTER_METHODS = frozenset(
 FULL_FAILURE_STAGES = frozenset(
     {
         "initialization",
+        "public-origin",
+        "checkout-identity",
+        "early-boot-isolation",
+        "gateway-key-identity",
+        "arweave-key-identity",
+        "private-model-ssh-identity",
+        "work-root",
         "runtime-config-capture",
         "parity-contract",
         "production-dsn",
@@ -2516,32 +2523,13 @@ def run_full(
         or not ARTIFACT_BUCKET_RE.fullmatch(artifact_bucket)
     ):
         raise FullParityError("full parity inputs are invalid")
-    supabase_origin = _validated_public_origin(supabase_origin)
-    _checkout_identity(candidate_sha)
-    try:
-        boot_state = EARLY_BOOT_MARKER.read_text(encoding="utf-8").strip()
-    except OSError as exc:
-        raise FullParityError(
-            "transient host did not prove early production-service isolation"
-        ) from exc
-    if boot_state != "isolated":
-        raise FullParityError(
-            "transient host early production-service isolation differs"
-        )
-    gateway_private_key_path = _validated_baked_gateway_private_key_path()
-    arweave_keyfile_path = _validated_baked_arweave_keyfile_path()
-    private_model_git_ssh_command = (
-        _validated_baked_private_model_ssh_command()
-    )
     started = time.monotonic()
     deadline = _full_deadline(
         started=started,
         timeout_seconds=timeout_seconds,
     )
     work = FULL_WORK_ROOT / run_id / "runtime"
-    work.mkdir(parents=True, mode=0o700, exist_ok=False)
     scoring_cache = work / "scoring-cache"
-    scoring_cache.mkdir(mode=0o700)
     runtime_config = work / "runtime-config.json"
     contract_path = work / "contract.json"
     archive_path = work / "production.dump"
@@ -2563,6 +2551,34 @@ def run_full(
         "started_at": datetime.now(timezone.utc).isoformat(),
     }
     try:
+        failure_stage = "public-origin"
+        supabase_origin = _validated_public_origin(supabase_origin)
+        failure_stage = "checkout-identity"
+        _checkout_identity(candidate_sha)
+        failure_stage = "early-boot-isolation"
+        try:
+            boot_state = EARLY_BOOT_MARKER.read_text(
+                encoding="utf-8"
+            ).strip()
+        except OSError as exc:
+            raise FullParityError(
+                "transient host did not prove early production-service isolation"
+            ) from exc
+        if boot_state != "isolated":
+            raise FullParityError(
+                "transient host early production-service isolation differs"
+            )
+        failure_stage = "gateway-key-identity"
+        gateway_private_key_path = _validated_baked_gateway_private_key_path()
+        failure_stage = "arweave-key-identity"
+        arweave_keyfile_path = _validated_baked_arweave_keyfile_path()
+        failure_stage = "private-model-ssh-identity"
+        private_model_git_ssh_command = (
+            _validated_baked_private_model_ssh_command()
+        )
+        failure_stage = "work-root"
+        work.mkdir(parents=True, mode=0o700, exist_ok=False)
+        scoring_cache.mkdir(mode=0o700)
         secrets_client = boto3.client("secretsmanager", region_name=region)
         database = _DockerDatabase(
             candidate_sha=candidate_sha,

--- a/tests/test_production_parity.py
+++ b/tests/test_production_parity.py
@@ -1799,6 +1799,61 @@ def test_full_runner_forwards_remaining_clone_budget_and_cleans_runtime(
         assert cleanup["database"] == {"status": "removed"}
 
 
+def test_full_runner_retains_exact_bounded_initialization_stage(
+    monkeypatch,
+    tmp_path: Path,
+):
+    marker = tmp_path / "early-boot-isolated"
+    marker.write_text("isolated\n", encoding="utf-8")
+    work_root = tmp_path / "encrypted-root-volume"
+    output = tmp_path / "evidence" / "full.json"
+    secret = "must-not-escape-initialization-failure"
+
+    monkeypatch.setattr(full_host, "EARLY_BOOT_MARKER", marker)
+    monkeypatch.setattr(full_host, "FULL_WORK_ROOT", work_root)
+    monkeypatch.setattr(full_host, "_checkout_identity", lambda _sha: None)
+    monkeypatch.setattr(
+        full_host,
+        "_validated_baked_gateway_private_key_path",
+        lambda: "/home/ec2-user/gateway/secrets/gateway_private_key.pem",
+    )
+    monkeypatch.setattr(
+        full_host,
+        "_validated_baked_arweave_keyfile_path",
+        lambda: "/home/ec2-user/gateway/secrets/arweave_keyfile.json",
+    )
+    monkeypatch.setattr(
+        full_host,
+        "_validated_baked_private_model_ssh_command",
+        lambda: (_ for _ in ()).throw(FullParityError(secret)),
+    )
+
+    with pytest.raises(FullParityError, match=secret):
+        full_host.run_full(
+            region="us-east-1",
+            run_id="pp-test-1",
+            base_sha="a" * 40,
+            candidate_sha="b" * 40,
+            production_gateway_secret_id="gateway-secret",
+            readonly_dsn_secret_id="readonly-secret",
+            miner_intake_secret_id="miner-secret",
+            supabase_origin=ORIGIN,
+            artifact_bucket="parity-artifacts",
+            postgres_image="postgres@sha256:" + "c" * 64,
+            postgrest_image="postgrest@sha256:" + "d" * 64,
+            output=output,
+            timeout_seconds=1_000,
+        )
+
+    encoded = output.read_text(encoding="utf-8")
+    evidence = json.loads(encoded)
+    assert evidence["status"] == "failed"
+    assert evidence["failure_stage"] == "private-model-ssh-identity"
+    assert evidence["error_type"] == "FullParityError"
+    assert evidence["cleanup"] == {"work": "already_absent"}
+    assert secret not in encoded
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [


### PR DESCRIPTION
## Why

Production Parity Full run 33078994779 reached the exact candidate host and corrected Python bootstrap, then failed during initialization before runtime configuration, secrets, Supabase, model loading, or provider execution. Existing retained evidence collapsed that failure to a generic initialization error, preventing an evidence-based fix.

## Change

- retain a fixed, redacted initialization substage in Full-lane evidence
- keep raw exception text, paths, and secret material out of retained artifacts
- preserve exact cleanup reporting
- add a regression proving bounded stage retention and redaction

This does not change model semantics, routing, scoring, persistence, retries, transport, activation, or production runtime behavior.

## Validation

- focused regression: 10 passed
- direct parity/full test files: 261 passed, 1 skipped
- Python compilation and diff checks passed