### PR TITLE
Recover exact provider responses after transport loss

### DIFF
--- a/gateway/research_lab/official_baseline_release_authorities.py
+++ b/gateway/research_lab/official_baseline_release_authorities.py
@@ -737,6 +737,7 @@ class _GatewayEvidenceProxyClient:
         timeout_seconds: float,
         max_response_bytes: int,
         cost_scope: str,
+        replay_only: bool = False,
     ) -> tuple[int, Mapping[str, Any], Mapping[str, str]]:
         normalized_method = str(method or "").upper()
         if normalized_method not in _HTTP_METHODS:
@@ -779,7 +780,11 @@ class _GatewayEvidenceProxyClient:
                 split._replace(query=urllib.parse.urlencode(existing + supplied))
             )
         encoded = None if body is None else _canonical_bytes(body)
-        headers = {str(key): str(value) for key, value in static_headers.items()}
+        headers = {
+            str(key): str(value)
+            for key, value in static_headers.items()
+            if str(key).casefold() != "x-research-lab-replay-only"
+        }
         headers.update(
             {
                 "Accept": headers.get("Accept", "application/json"),
@@ -787,6 +792,8 @@ class _GatewayEvidenceProxyClient:
                 "X-Research-Lab-Budget-Soft-Stop": "1",
             }
         )
+        if replay_only:
+            headers["X-Research-Lab-Replay-Only"] = "1"
         request = urllib.request.Request(
             target,
             data=encoded,
@@ -1266,20 +1273,21 @@ class ArtifactPreparedActionExecutor:
             )
         return expected
 
-    def _one_request(
+    def _proxy_request(
         self,
         *,
         preparation: OfficialBaselineProtectedPreparation,
         provider: str,
         request: Mapping[str, Any],
         timeout_seconds: float,
-    ) -> tuple[int, Mapping[str, Any]]:
+        replay_only: bool,
+    ) -> tuple[int, Mapping[str, Any], Mapping[str, str]]:
         method = str(request.get("method") or "")
         if method == "BATCH_GET":
             raise OfficialBaselineProtectedAuthorityError(
                 "official baseline nested batch request is invalid"
             )
-        status, body, _headers = self._proxy.request(
+        return self._proxy.request(
             provider=provider,
             method=method,
             upstream_url=str(request.get("url") or ""),
@@ -1307,8 +1315,60 @@ class ArtifactPreparedActionExecutor:
             cost_scope="official-baseline-" + preparation.unit_ref.split(":", 1)[-1][
                 :32
             ],
+            replay_only=replay_only,
+        )
+
+    def _one_request(
+        self,
+        *,
+        preparation: OfficialBaselineProtectedPreparation,
+        provider: str,
+        request: Mapping[str, Any],
+        timeout_seconds: float,
+    ) -> tuple[int, Mapping[str, Any]]:
+        status, body, _headers = self._proxy_request(
+            preparation=preparation,
+            provider=provider,
+            request=request,
+            timeout_seconds=timeout_seconds,
+            replay_only=False,
         )
         return status, body
+
+    def _replay_one_request(
+        self,
+        *,
+        preparation: OfficialBaselineProtectedPreparation,
+        provider: str,
+        request: Mapping[str, Any],
+        timeout_seconds: float,
+    ) -> tuple[int, Mapping[str, Any]] | None:
+        status, body, headers = self._proxy_request(
+            preparation=preparation,
+            provider=provider,
+            request=request,
+            timeout_seconds=timeout_seconds,
+            replay_only=True,
+        )
+        evidence = next(
+            (
+                str(value).strip().casefold()
+                for key, value in headers.items()
+                if str(key).casefold() == "x-research-lab-evidence"
+            ),
+            "",
+        )
+        if evidence == "hit":
+            return status, body
+        if (
+            status == 409
+            and evidence in {"", "replay_miss"}
+            and dict(body) == {"error": "replay_miss"}
+        ):
+            return None
+        raise OfficialBaselineProtectedAuthorityError(
+            "official baseline evidence proxy replay response is invalid"
+        )
 
     def _batch_request(
         self,
@@ -1317,7 +1377,8 @@ class ArtifactPreparedActionExecutor:
         provider: str,
         request: Mapping[str, Any],
         timeout_seconds: float,
-    ) -> tuple[int, Mapping[str, Any], int]:
+        replay_only: bool = False,
+    ) -> tuple[int, Mapping[str, Any], int] | None:
         rows = request.get("requests")
         if (
             request.get("method") != "BATCH_GET"
@@ -1340,17 +1401,30 @@ class ArtifactPreparedActionExecutor:
                 raise OfficialBaselineProtectedAuthorityError(
                     "official baseline artifact batch member is invalid"
                 )
-            status, body = self._one_request(
-                preparation=preparation,
-                provider=provider,
-                request={
-                    "method": row["method"],
-                    "url": row["url"],
-                    "query": row["query"],
-                    "static_headers": request.get("static_headers") or {},
-                },
-                timeout_seconds=timeout_seconds,
+            member_request = {
+                "method": row["method"],
+                "url": row["url"],
+                "query": row["query"],
+                "static_headers": request.get("static_headers") or {},
+            }
+            terminal = (
+                self._replay_one_request(
+                    preparation=preparation,
+                    provider=provider,
+                    request=member_request,
+                    timeout_seconds=timeout_seconds,
+                )
+                if replay_only
+                else self._one_request(
+                    preparation=preparation,
+                    provider=provider,
+                    request=member_request,
+                    timeout_seconds=timeout_seconds,
+                )
             )
+            if terminal is None:
+                return None
+            status, body = terminal
             responses.append(
                 {
                     "request_sha256": row["request_sha256"],
@@ -1504,22 +1578,36 @@ class ArtifactPreparedActionExecutor:
             if terminal is None:
                 return self._uncertain(request_ref)
             status, body = terminal
-        elif reconcile_only:
-            return self._uncertain(request_ref)
         elif request.get("method") == "BATCH_GET":
-            status, body, calls = self._batch_request(
+            terminal = self._batch_request(
                 preparation=preparation,
                 provider=provider,
                 request=request,
                 timeout_seconds=preparation.timeout_ms / 1000,
+                replay_only=reconcile_only,
             )
+            if terminal is None:
+                return self._uncertain(request_ref)
+            status, body, calls = terminal
         else:
-            status, body = self._one_request(
-                preparation=preparation,
-                provider=provider,
-                request=request,
-                timeout_seconds=preparation.timeout_ms / 1000,
+            terminal = (
+                self._replay_one_request(
+                    preparation=preparation,
+                    provider=provider,
+                    request=request,
+                    timeout_seconds=preparation.timeout_ms / 1000,
+                )
+                if reconcile_only
+                else self._one_request(
+                    preparation=preparation,
+                    provider=provider,
+                    request=request,
+                    timeout_seconds=preparation.timeout_ms / 1000,
+                )
             )
+            if terminal is None:
+                return self._uncertain(request_ref)
+            status, body = terminal
         return self._known_provider_terminal(
             preparation=preparation,
             dispatch=dispatch,

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1317,7 +1317,7 @@
       "symbol": "validate_official_baseline_provider_closure"
     },
     {
-      "ast_sha256": "sha256:3bd0aa4a42c4c9775941efa440df881fca708d01b2cb06d91934235bf6396823",
+      "ast_sha256": "sha256:4e1005c5480eb3799804be1f03d392f4572f3aa69e7c7eca39203ac6080e311f",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "ArtifactPreparedActionExecutor"
     },
@@ -1372,7 +1372,7 @@
       "symbol": "SITE_PROTECTED_ACTION_AUTHORITY_SOURCE_COMMIT"
     },
     {
-      "ast_sha256": "sha256:b42587d249053ed28e7bc44f20b93853384d73a3801043605280fb52cf3bcc01",
+      "ast_sha256": "sha256:3b93e54e1b23f9bc4df52445ffa3839ca58d2f6108c15a28e686345b4a5113ed",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "_GatewayEvidenceProxyClient"
     },
@@ -1382,7 +1382,7 @@
       "symbol": "_GatewayEvidenceProxyClient._proxied_url"
     },
     {
-      "ast_sha256": "sha256:a7056bc3726a2fb01a59f9ee7a4143f923944f3ba5dd0b2e93d115c3c03a5cd1",
+      "ast_sha256": "sha256:4a2446149b9fd091f924cd35aced4861f10f239c6e7dfe17c9c01ef90caab0a8",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "_GatewayEvidenceProxyClient.request"
     },
@@ -8147,7 +8147,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:1971a457a1374227b196b90c12579db64ac6a6a8c869929f35120f92e96b54bd",
-  "protected_source_commit": "5760d2a7f99e38a3c3d8865ef707d02e45ef255d",
+  "manifest_hash": "sha256:664c285561315fa32b9651938d3adb8019a3a9f3b9058b9f28bbda9d81b223fe",
+  "protected_source_commit": "bfd7d755f1a1072a6063cc7d2da3d534eb67de54",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_official_baseline_release_authorities.py
+++ b/tests/test_official_baseline_release_authorities.py
@@ -7,6 +7,7 @@ import pytest
 
 from gateway.research_lab.official_baseline_authority import (
     PROTECTED_ACTION_AUTHORITY_SHA256,
+    GatewayLocalProtectedActionBridge,
     OfficialBaselineProtectedAuthorityError,
 )
 from gateway.research_lab.official_baseline_custody import (
@@ -302,6 +303,263 @@ def _provider_fixture():
         }
     )
     return action, dispatch, catalog, inventory
+
+
+def _openrouter_provider_fixture():
+    binding = "d" * 64
+    tool_id = "candidate.company_evidence_search"
+    action = {
+        "sequence": 2,
+        "action_type": "execute_candidate_tool",
+        "tool_id": tool_id,
+        "binding_contract_sha256": binding,
+        "response_schema_version": "model-provider-response:v2",
+        "max_response_bytes": 200_000,
+        "idempotency_key": "7" * 64,
+        "action_sha256": "8" * 64,
+        "request_fingerprint_sha256": "9" * 64,
+    }
+    request = {
+        "method": "POST",
+        "url": "https://openrouter.ai/api/v1/chat/completions",
+        "static_headers": {"Content-Type": "application/json"},
+        "credential_binding": {
+            "location": "header",
+            "name": "Authorization",
+            "scheme": "Bearer",
+            "source": "OPENROUTER_API_KEY",
+            "persist": False,
+        },
+        "body": {
+            "model": "perplexity/sonar-pro",
+            "messages": [{"role": "user", "content": "fixture"}],
+        },
+    }
+    dispatch_body = {
+        "schema_version": "model-runner-provider-dispatch:v1",
+        "action_sha256": action["action_sha256"],
+        "action_type": action["action_type"],
+        "tool_id": action["tool_id"],
+        "compiler_id": "openrouter.company_evidence:v1",
+        "compiler_contract_sha256": binding,
+        "provider": "openrouter",
+        "request": request,
+        "request_sha256": _hash(request),
+        "response_contract": {
+            "schema_version": "provider-response-contract:v1"
+        },
+        "budgets": {
+            "call_cap": 1,
+            "credit_cap": 0.02,
+            "timeout_seconds": 120.0,
+            "max_results": 100,
+            "max_response_bytes": 200_000,
+        },
+        "idempotency_key": "model-action:" + action["action_sha256"],
+    }
+    dispatch = {**dispatch_body, "dispatch_sha256": _hash(dispatch_body)}
+    catalog = _catalog(
+        _catalog_row(
+            action_type=action["action_type"],
+            tool_id=tool_id,
+            binding=binding,
+            response_schema=action["response_schema_version"],
+        )
+    )
+    inventory = _inventory(
+        {
+            "action_type": action["action_type"],
+            "tool_id": tool_id,
+            "status": "supported",
+            "execution_mode": "invoke",
+            "compiler_id": dispatch["compiler_id"],
+            "provider": dispatch["provider"],
+            "compiler_contract_sha256": binding,
+            "timeout_seconds": 120.0,
+        }
+    )
+    return action, dispatch, catalog, inventory
+
+
+def _batched_openrouter_provider_fixture():
+    action, dispatch, catalog, inventory = _openrouter_provider_fixture()
+    members = [
+        {
+            "method": "GET",
+            "url": "https://openrouter.ai/api/v1/models",
+            "query": {"page": page},
+            "segment_id": f"segment-{page}",
+            "request_sha256": str(page) * 64,
+        }
+        for page in (1, 2)
+    ]
+    request = {
+        "method": "BATCH_GET",
+        "url": "https://openrouter.ai/api/v1/models",
+        "static_headers": {"Accept": "application/json"},
+        "credential_binding": dispatch["request"]["credential_binding"],
+        "requests": members,
+    }
+    dispatch_body = {
+        key: value for key, value in dispatch.items() if key != "dispatch_sha256"
+    }
+    dispatch_body["request"] = request
+    dispatch_body["request_sha256"] = _hash(request)
+    dispatch_body["budgets"] = {**dispatch_body["budgets"], "call_cap": 2}
+    return (
+        action,
+        {**dispatch_body, "dispatch_sha256": _hash(dispatch_body)},
+        catalog,
+        inventory,
+    )
+
+
+def test_non_deepline_lost_response_recovers_only_from_exact_proxy_replay():
+    action, dispatch, catalog, inventory = _openrouter_provider_fixture()
+    protocol = _Protocol(dispatch=dispatch, current=True)
+    custody = _custody()
+    proxy = _Proxy(
+        [
+            OfficialBaselineProtectedAuthorityError("response interrupted"),
+            (
+                200,
+                {"choices": [{"message": {"content": "[]"}}]},
+                {"X-Research-Lab-Evidence": "hit"},
+            ),
+        ]
+    )
+    executor = ArtifactPreparedActionExecutor(
+        registration=_registration(protocol),
+        catalog=catalog,
+        inventory=inventory,
+        custody=custody,
+        proxy_url="http://127.0.0.1:8765",
+        proxy_client=proxy,
+    )
+    bridge = GatewayLocalProtectedActionBridge(
+        custody=custody,
+        executor=executor,
+    )
+    preparation = bridge.prepare(
+        run_identity={"run": "openrouter-recovery"},
+        unit_ref="baseline_icp:" + "a" * 64,
+        action=action,
+    )
+
+    terminal = bridge.execute_prepared(preparation=preparation, action=action)
+
+    assert terminal.state == "known"
+    assert terminal.protected_action_result.host_result.outcome == "succeeded"
+    assert [call["replay_only"] for call in proxy.calls] == [False, True]
+    assert terminal.protected_action_result.provider_receipt.call_count == 1
+
+
+def test_non_deepline_replay_miss_remains_uncertain_without_redispatch():
+    action, dispatch, catalog, inventory = _openrouter_provider_fixture()
+    custody = _custody()
+    proxy = _Proxy(
+        [
+            OfficialBaselineProtectedAuthorityError("response interrupted"),
+            (409, {"error": "replay_miss"}, {}),
+        ]
+    )
+    executor = ArtifactPreparedActionExecutor(
+        registration=_registration(_Protocol(dispatch=dispatch)),
+        catalog=catalog,
+        inventory=inventory,
+        custody=custody,
+        proxy_url="http://127.0.0.1:8765",
+        proxy_client=proxy,
+    )
+    bridge = GatewayLocalProtectedActionBridge(
+        custody=custody,
+        executor=executor,
+    )
+    preparation = bridge.prepare(
+        run_identity={"run": "openrouter-replay-miss"},
+        unit_ref="baseline_icp:" + "b" * 64,
+        action=action,
+    )
+
+    terminal = bridge.execute_prepared(preparation=preparation, action=action)
+
+    assert terminal.state == "uncertain"
+    assert [call["replay_only"] for call in proxy.calls] == [False, True]
+
+
+def test_non_deepline_cached_provider_409_is_known_not_replay_miss():
+    action, dispatch, catalog, inventory = _openrouter_provider_fixture()
+    proxy = _Proxy(
+        [
+            (
+                409,
+                {"error": "replay_miss"},
+                {"X-Research-Lab-Evidence": "hit"},
+            )
+        ]
+    )
+    executor = ArtifactPreparedActionExecutor(
+        registration=_registration(_Protocol(dispatch=dispatch)),
+        catalog=catalog,
+        inventory=inventory,
+        custody=_custody(),
+        proxy_url="http://127.0.0.1:8765",
+        proxy_client=proxy,
+    )
+    preparation = executor.prepare(
+        run_identity={"run": "openrouter-cached-conflict"},
+        unit_ref="baseline_icp:" + "c" * 64,
+        action=action,
+    )
+
+    terminal = executor.reconcile(preparation=preparation, action=action)
+
+    assert terminal.state == "known"
+    assert terminal.protected_action_result.host_result.outcome == "failed"
+    assert proxy.calls[0]["replay_only"] is True
+
+
+def test_batched_lost_response_reconciles_all_members_without_live_calls():
+    action, dispatch, catalog, inventory = _batched_openrouter_provider_fixture()
+    protocol = _Protocol(dispatch=dispatch, current=True)
+    custody = _custody()
+    proxy = _Proxy(
+        [
+            (200, {"data": ["first"]}, {}),
+            OfficialBaselineProtectedAuthorityError("response interrupted"),
+            (200, {"data": ["first"]}, {"X-Research-Lab-Evidence": "hit"}),
+            (200, {"data": ["second"]}, {"X-Research-Lab-Evidence": "hit"}),
+        ]
+    )
+    executor = ArtifactPreparedActionExecutor(
+        registration=_registration(protocol),
+        catalog=catalog,
+        inventory=inventory,
+        custody=custody,
+        proxy_url="http://127.0.0.1:8765",
+        proxy_client=proxy,
+    )
+    bridge = GatewayLocalProtectedActionBridge(
+        custody=custody,
+        executor=executor,
+    )
+    preparation = bridge.prepare(
+        run_identity={"run": "openrouter-batch-recovery"},
+        unit_ref="baseline_icp:" + "d" * 64,
+        action=action,
+    )
+
+    terminal = bridge.execute_prepared(preparation=preparation, action=action)
+
+    assert terminal.state == "known"
+    assert terminal.protected_action_result.host_result.outcome == "succeeded"
+    assert [call["replay_only"] for call in proxy.calls] == [
+        False,
+        False,
+        True,
+        True,
+    ]
+    assert terminal.protected_action_result.provider_receipt.call_count == 2
 
 
 def test_deepline_progress_survives_interruption_and_restart_never_reposts():
@@ -817,3 +1075,48 @@ def test_exa_transport_uses_only_reviewed_evidence_proxy_route():
             max_response_bytes=10_000,
             cost_scope="official-baseline-fixture",
         )
+
+
+def test_official_proxy_replay_only_header_is_host_owned():
+    captured_headers = []
+
+    class _Response:
+        status = 200
+        headers = {"X-Research-Lab-Evidence": "hit"}
+
+        def read(self, _limit):
+            return b'{"results":[]}'
+
+        def close(self):
+            pass
+
+    def opener(request, *, timeout):
+        del timeout
+        captured_headers.append(
+            {key.casefold(): value for key, value in request.header_items()}
+        )
+        return _Response()
+
+    client = _GatewayEvidenceProxyClient(
+        proxy_url="http://127.0.0.1:8765", opener=opener
+    )
+    common = {
+        "provider": "exa",
+        "method": "POST",
+        "upstream_url": "https://api.exa.ai/search",
+        "static_headers": {
+            "Content-Type": "application/json",
+            "X-Research-Lab-Replay-Only": "1",
+        },
+        "body": {"query": "redacted fixture"},
+        "query": None,
+        "timeout_seconds": 10,
+        "max_response_bytes": 10_000,
+        "cost_scope": "official-baseline-fixture",
+    }
+
+    client.request(**common, replay_only=False)
+    client.request(**common, replay_only=True)
+
+    assert "x-research-lab-replay-only" not in captured_headers[0]
+    assert captured_headers[1]["x-research-lab-replay-only"] == "1"


### PR DESCRIPTION
Fixes the live official-baseline stop after successful company acquisition. When the loopback evidence-proxy response is lost after a provider result was recorded, reconciliation now requests the exact same fingerprint in replay-only mode. Cache hits recover the real response; misses remain terminal-uncertain with no redispatch or semantic fallback. Covers single and batched provider actions and keeps the replay header host-owned.

Fast validation: 216 directly affected checks passed; protected manifest verification passed. No model routing, scoring, Supabase schema, restart, or weight-submission logic changed.