### PR TITLE
Retry terminal-uncertain baseline actions safely

### DIFF
--- a/gateway/research_lab/official_baseline_authority.py
+++ b/gateway/research_lab/official_baseline_authority.py
@@ -78,6 +78,10 @@ class OfficialBaselineProtectedAuthorityError(OfficialBaselineModelError):
     """The protected action state machine cannot prove one exact outcome."""
 
 
+class OfficialBaselineTerminalUncertainError(CommonModelExperimentRecoveryError):
+    """A bounded fresh attempt is required after an unresolved paid call."""
+
+
 def _prefixed_hash(value: Any, label: str) -> str:
     text = str(value or "").lower()
     normalized = text if text.startswith("sha256:") else "sha256:" + text
@@ -1000,7 +1004,7 @@ class _ReservedOfficialBaselineDispatcher:
             )
         replay = self._authority.store.load_replay(identity=identity)
         if replay.get("state") == "terminal_uncertain":
-            raise CommonModelExperimentRecoveryError(
+            raise OfficialBaselineTerminalUncertainError(
                 "official baseline protected call is terminal uncertain"
             )
         if replay.get("state") != "reserved":
@@ -1021,7 +1025,7 @@ class _ReservedOfficialBaselineDispatcher:
                 "uncertainty_sha256": validated.uncertainty_sha256,
             }
         )
-        raise CommonModelExperimentRecoveryError(
+        raise OfficialBaselineTerminalUncertainError(
             "official baseline protected call is terminal uncertain"
         )
 
@@ -1128,7 +1132,7 @@ class _ReservedOfficialBaselineDispatcher:
         replay = self._authority.store.load_replay(identity=identity)
         state = replay.get("state")
         if state == "terminal_uncertain":
-            raise CommonModelExperimentRecoveryError(
+            raise OfficialBaselineTerminalUncertainError(
                 "official baseline protected call is terminal uncertain"
             )
         if state == "terminal_known":
@@ -1188,7 +1192,7 @@ class _ReservedOfficialBaselineDispatcher:
                 allow_execute_after_absence=False,
             )
         if state == "terminal_uncertain":
-            raise CommonModelExperimentRecoveryError(
+            raise OfficialBaselineTerminalUncertainError(
                 "official baseline protected call is terminal uncertain"
             )
         raise OfficialBaselineProtectedAuthorityError(

--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -111,6 +111,7 @@ from gateway.research_lab.official_baseline_store import (
     SupabaseOfficialBaselineAttemptStore,
 )
 from gateway.research_lab.official_baseline_authority import (
+    OfficialBaselineTerminalUncertainError,
     build_production_official_baseline_exact_dependencies,
 )
 from gateway.research_lab.official_baseline_release_authorities import (
@@ -16141,7 +16142,10 @@ class ResearchLabGatewayScoringWorker:
                 and model_qualification_authority is None
             ):
                 retryable = True
-        except PrivateModelRuntimeError as exc:
+        except (
+            PrivateModelRuntimeError,
+            OfficialBaselineTerminalUncertainError,
+        ) as exc:
             outputs = []
             runtime_error = _short_error(exc)
             runtime_error_class = type(exc).__name__
@@ -16155,6 +16159,13 @@ class ResearchLabGatewayScoringWorker:
                 model_qualification_partial_count = len(
                     tuple(exc.partial_companies)
                 )
+            elif isinstance(exc, OfficialBaselineTerminalUncertainError):
+                # The append-only authority correctly forbids reopening the
+                # unresolved paid-call identity.  The existing bounded retry
+                # round supplies a fresh durable unit/attempt identity, while
+                # exact evidence-proxy replay can still recover the response
+                # without redispatching the physical provider request.
+                retryable = True
             else:
                 # Classify from the full exception text: _short_error
                 # truncates to 300 chars and can drop the status marker the

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -987,6 +987,11 @@
       "symbol": "OfficialBaselineReleaseComponents"
     },
     {
+      "ast_sha256": "sha256:c9179e190d89fbdc070a03019d2db97521bd1a95f1e47061b5822aa0582ac73d",
+      "path": "gateway/research_lab/official_baseline_authority.py",
+      "symbol": "OfficialBaselineTerminalUncertainError"
+    },
+    {
       "ast_sha256": "sha256:4590267f7b021782fde3aa86aec2b6b7cbe0cbb978f5a955431aa2f270371c4d",
       "path": "gateway/research_lab/official_baseline_authority.py",
       "symbol": "PROTECTED_ACTION_AUTHORITY_SCHEMA_VERSION"
@@ -997,7 +1002,7 @@
       "symbol": "PROTECTED_ACTION_AUTHORITY_SHA256"
     },
     {
-      "ast_sha256": "sha256:8a21396992758b995d732777a2ac38d2a6a82170f4c785cae0963578b56a0576",
+      "ast_sha256": "sha256:4213cf6d31d8736d84cdbebc6b7f49dd60f49e53eb023e00e31b0b7866e9e83b",
       "path": "gateway/research_lab/official_baseline_authority.py",
       "symbol": "_ReservedOfficialBaselineDispatcher"
     },
@@ -2557,7 +2562,7 @@
       "symbol": "ResearchLabGatewayScoringWorker._run_baseline_batch_inner"
     },
     {
-      "ast_sha256": "sha256:384d8820775cf75edef13404b267470fc94d143b9d97ca13f088997ac1f43c74",
+      "ast_sha256": "sha256:24e10af5084842a7c558f107bc65467f8e649a100c144eafcddc23d0b0333282",
       "path": "gateway/research_lab/scoring_worker.py",
       "symbol": "ResearchLabGatewayScoringWorker._run_baseline_icp"
     },
@@ -8147,7 +8152,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:664c285561315fa32b9651938d3adb8019a3a9f3b9058b9f28bbda9d81b223fe",
-  "protected_source_commit": "bfd7d755f1a1072a6063cc7d2da3d534eb67de54",
+  "manifest_hash": "sha256:773f849f5fe26f851b00b02fba2e01583a8aee3ecac017dd1da29523acbcf565",
+  "protected_source_commit": "461d81a86df9e22550ab7f4022fa979720ab4f85",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/protected_workflows.py
+++ b/gateway/tee/protected_workflows.py
@@ -1084,6 +1084,7 @@ PROTECTED_SYMBOLS = {
         "OFFICIAL_BASELINE_PROTECTED_RECONCILIATION_SCHEMA_VERSION",
         "PROTECTED_ACTION_AUTHORITY_SCHEMA_VERSION",
         "PROTECTED_ACTION_AUTHORITY_SHA256",
+        "OfficialBaselineTerminalUncertainError",
         "OfficialBaselineProtectedPreparation",
         "OfficialBaselineProtectedTerminal",
         "OfficialBaselineReleaseComponents",

--- a/tests/test_official_baseline_authority.py
+++ b/tests/test_official_baseline_authority.py
@@ -26,6 +26,7 @@ from gateway.research_lab.official_baseline_authority import (
     OfficialBaselineProtectedAuthorityError,
     OfficialBaselineProtectedTerminal,
     OfficialBaselineReleaseComponents,
+    OfficialBaselineTerminalUncertainError,
     _protected_result_document,
     build_production_official_baseline_exact_dependencies,
 )
@@ -624,11 +625,11 @@ def test_unknown_call_is_terminal_uncertain_and_never_redispatched():
         run_identity=run_identity, unit_ref=unit_ref
     )
 
-    with pytest.raises(CommonModelExperimentRecoveryError, match="terminal uncertain"):
+    with pytest.raises(OfficialBaselineTerminalUncertainError, match="terminal uncertain"):
         dispatcher.dispatch_provider_action(
             action=action, variant_id="official_baseline", unit_ref=unit_ref
         )
-    with pytest.raises(CommonModelExperimentRecoveryError, match="terminal uncertain"):
+    with pytest.raises(OfficialBaselineTerminalUncertainError, match="terminal uncertain"):
         dispatcher.dispatch_provider_action(
             action=action, variant_id="official_baseline", unit_ref=unit_ref
         )

--- a/tests/test_official_baseline_model_runner.py
+++ b/tests/test_official_baseline_model_runner.py
@@ -15,6 +15,9 @@ from gateway.research_lab.common_model_experiment import (
     _bind_durable_provider_result,
 )
 from gateway.research_lab import scoring_worker as scoring_worker_module
+from gateway.research_lab.official_baseline_authority import (
+    OfficialBaselineTerminalUncertainError,
+)
 from gateway.research_lab.official_baseline_model_runner import (
     ArtifactBenchmarkProjection,
     ArtifactProtocolBenchmarkProjector,
@@ -1146,6 +1149,160 @@ async def test_scoring_worker_retries_exact_model_incomplete_outcome(
     assert row["_nonempty"] is False
     assert row["diagnostics"]["sourcing_failed"] is True
     assert scoring_worker_module._OFFICIAL_BASELINE_CHECKPOINT_FIELD not in row
+
+
+@pytest.mark.asyncio
+async def test_scoring_worker_retries_terminal_uncertain_with_fresh_attempt(
+    monkeypatch,
+):
+    runner, _projector, _authority, _terminal = _exact_fixture()
+    worker = object.__new__(scoring_worker_module.ResearchLabGatewayScoringWorker)
+    worker.worker_ref = "test-worker"
+    worker.config = SimpleNamespace(private_baseline_provider_retry_rounds=2)
+    worker._active_baseline_context = {}
+
+    async def unchanged(**_values):
+        return None
+
+    async def no_traces(**_values):
+        return None
+
+    attempt_ordinals = []
+
+    def terminal_uncertain(*_args, **kwargs):
+        attempt_ordinals.append(kwargs.get("attempt_ordinal"))
+        raise OfficialBaselineTerminalUncertainError(
+            "official baseline protected call is terminal uncertain"
+        )
+
+    worker._ensure_private_baseline_repo_head_unchanged = unchanged
+    worker._record_baseline_icp_traces = no_traces
+    monkeypatch.setattr(
+        ExactOfficialBaselineRunner,
+        "run_icp",
+        terminal_uncertain,
+    )
+    item = {
+        "icp_ref": "icp-terminal-uncertain",
+        "icp_hash": "sha256:" + "2" * 64,
+        "set_id": "set-1",
+        "day_index": 0,
+        "day_rank": 1,
+        "icp": {"outputs": [], "max_companies": 1},
+    }
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        row = await worker._run_baseline_icp(
+            runner=runner,
+            scorer=object(),
+            item=item,
+            item_index=1,
+            total_icps=1,
+            run_start=0.0,
+            executor=executor,
+            benchmark_date="2026-08-27",
+            retry_round=0,
+        )
+
+    assert attempt_ordinals == [0]
+    assert row["_retryable"] is True
+    assert row["_nonempty"] is False
+    assert row["diagnostics"]["sourcing_failed"] is True
+    assert row["_runtime_error"].startswith(
+        "OfficialBaselineTerminalUncertainError:"
+    )
+    assert scoring_worker_module._OFFICIAL_BASELINE_CHECKPOINT_FIELD not in row
+
+
+@pytest.mark.asyncio
+async def test_terminal_uncertain_advances_to_fresh_bounded_attempt(
+    monkeypatch,
+):
+    runner, _projector, _authority, _terminal = _exact_fixture()
+    runner = runner.with_spec(
+        replace(
+            runner.spec,
+            extra_env={
+                scoring_worker_module.PROVIDER_COST_EVALUATION_SCOPE_ENV: (
+                    "sha256:" + "7" * 64
+                )
+            },
+        )
+    )
+    worker = object.__new__(scoring_worker_module.ResearchLabGatewayScoringWorker)
+    worker.worker_ref = "test-worker"
+    worker.config = SimpleNamespace(
+        private_baseline_concurrency=1,
+        private_baseline_retry_concurrency=1,
+        private_baseline_provider_retry_rounds=1,
+        scoring_worker_total_workers=1,
+    )
+    worker._active_baseline_context = {}
+
+    async def unchanged(**_values):
+        return None
+
+    async def no_traces(**_values):
+        return None
+
+    async def maintenance_state():
+        return {"paused": False}
+
+    original_run_icp = ExactOfficialBaselineRunner.run_icp
+    attempt_ordinals = []
+
+    def recover_on_fresh_attempt(self, *_args, **kwargs):
+        attempt_ordinal = kwargs.get("attempt_ordinal")
+        attempt_ordinals.append(attempt_ordinal)
+        if attempt_ordinal == 0:
+            raise OfficialBaselineTerminalUncertainError(
+                "official baseline protected call is terminal uncertain"
+            )
+        return original_run_icp(self, *_args, **kwargs)
+
+    worker._ensure_private_baseline_repo_head_unchanged = unchanged
+    worker._record_baseline_icp_traces = no_traces
+    monkeypatch.setattr(
+        ExactOfficialBaselineRunner,
+        "run_icp",
+        recover_on_fresh_attempt,
+    )
+    monkeypatch.setattr(
+        scoring_worker_module,
+        "get_scoring_maintenance_state",
+        maintenance_state,
+    )
+    monkeypatch.setattr(
+        scoring_worker_module,
+        "_apply_provider_cost_baseline_outcome",
+        lambda _row: None,
+    )
+    window = SimpleNamespace(
+        benchmark_items=[
+            {
+                "icp_ref": "icp-terminal-uncertain",
+                "icp_hash": "sha256:" + "2" * 64,
+                "set_id": "set-1",
+                "day_index": 0,
+                "day_rank": 1,
+                "icp": {"outputs": [], "max_companies": 1},
+            }
+        ]
+    )
+
+    rows, stats = await worker._run_baseline_batch_inner(
+        runner=runner,
+        retry_runner=runner,
+        scorer=object(),
+        window=window,
+        run_start=0.0,
+        benchmark_date="2026-08-27",
+    )
+
+    assert attempt_ordinals == [0, 1]
+    assert stats == {"retried": 1, "recovered": 1, "unresolved": 0}
+    assert rows[0]["_retryable"] is False
+    assert rows[0]["diagnostics"]["sourcing_failed"] is False
+    assert scoring_worker_module._OFFICIAL_BASELINE_CHECKPOINT_FIELD in rows[0]
 
 
 def test_restart_reconstructs_and_does_not_duplicate_provider_call():


### PR DESCRIPTION
## Summary
- classify persisted official-baseline terminal uncertainty with a typed recovery error
- hand only that condition into the existing bounded scoring retry path
- retain append-only round-zero ambiguity while giving the retry a fresh durable attempt identity
- refresh protected workflow identity for the exact source commit

## Verification
- 285 relevant tests passed, 1 skipped
- touched Python compiled successfully
- git diff --check passed
- exact synthetic transition covers uncertain round zero through successful bounded retry

## Production reason
Current f611 release cannot complete the official rebenchmark when a prior append-only terminal-uncertain action is encountered. This is a narrow production-critical recovery fix.