### PR TITLE
Record rejected provider responses as known failures

### DIFF
--- a/gateway/research_lab/official_baseline_release_authorities.py
+++ b/gateway/research_lab/official_baseline_release_authorities.py
@@ -1679,6 +1679,31 @@ class ArtifactPreparedActionExecutor:
             raise OfficialBaselineProtectedAuthorityError(
                 "official baseline provider response exceeds artifact bound"
             )
+        ingestion: Mapping[str, Any] | None = None
+        response_rejected = False
+        if response is not None:
+            try:
+                ingestion = self._protocol.ingest_provider_response(
+                    action,
+                    response,
+                )
+            except Exception:
+                # The provider has returned a known terminal response. A
+                # model-contract rejection is therefore a known adapter
+                # failure, not an unknown paid-call outcome. Retain only the
+                # response hash in the receipt and let the model-owned
+                # waterfall handle the failed completion.
+                response = None
+                succeeded = False
+                response_rejected = True
+            else:
+                if not isinstance(ingestion, Mapping):
+                    response = None
+                    succeeded = False
+                    response_rejected = True
+                    ingestion = None
+                else:
+                    ingestion = dict(ingestion)
         outcome = (
             ProviderOutcome.VERIFIED.value
             if succeeded
@@ -1733,7 +1758,11 @@ class ArtifactPreparedActionExecutor:
             reason_code=(
                 "protected_provider_verified"
                 if succeeded
-                else "protected_provider_adapter_failure"
+                else (
+                    "protected_provider_response_rejected"
+                    if response_rejected
+                    else "protected_provider_adapter_failure"
+                )
             ),
             provider_response=response,
             calls=calls,
@@ -1743,22 +1772,6 @@ class ArtifactPreparedActionExecutor:
             provider_receipt_ref=receipt.receipt_ref,
             provider_identity_sha256=provider_identity,
         )
-        ingestion: Mapping[str, Any] | None = None
-        if response is not None:
-            try:
-                ingestion = self._protocol.ingest_provider_response(
-                    action,
-                    response,
-                )
-            except Exception as exc:
-                raise OfficialBaselineProtectedAuthorityError(
-                    "official baseline artifact provider response ingestion failed"
-                ) from exc
-            if not isinstance(ingestion, Mapping):
-                raise OfficialBaselineProtectedAuthorityError(
-                    "official baseline artifact provider response ingestion is invalid"
-                )
-            ingestion = dict(ingestion)
         binding_host = (
             replace(
                 host,

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1322,7 +1322,7 @@
       "symbol": "validate_official_baseline_provider_closure"
     },
     {
-      "ast_sha256": "sha256:4e1005c5480eb3799804be1f03d392f4572f3aa69e7c7eca39203ac6080e311f",
+      "ast_sha256": "sha256:daced534bd1a91966e62027cd9dffc03fff15104d79e4b0726b3836048f4fa0c",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "ArtifactPreparedActionExecutor"
     },
@@ -8152,7 +8152,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:773f849f5fe26f851b00b02fba2e01583a8aee3ecac017dd1da29523acbcf565",
-  "protected_source_commit": "461d81a86df9e22550ab7f4022fa979720ab4f85",
+  "manifest_hash": "sha256:c00e52ff4fe2cc18be9c5b562d213acdb5f6a34ee43d2c1485fd21db83cc22b5",
+  "protected_source_commit": "f590b1348b1686841b18f3dce65ba02805255035",
   "schema_version": "leadpoet.protected_workflows.v2"
 }


### PR DESCRIPTION
A successful provider HTTP response that the exact model contract rejects is a known adapter failure, but the protected executor raised and converted it into terminal uncertainty. Record the known failed completion instead, retain only the response hash, preserve paid-call accounting and exact receipts, and let the model-owned waterfall decide recovery. No route, provider, score, Supabase, restart, publication, or weight policy changes. Protected-workflow identity is refreshed against the exact code commit. Local suites were intentionally skipped per operator request; required GitHub checks remain authoritative before merge.