### PR TITLE
Retry model activation infrastructure contention

### DIFF
--- a/gateway/research_lab/promotion.py
+++ b/gateway/research_lab/promotion.py
@@ -23,6 +23,7 @@ from gateway.research_lab.attested_scoring import (
 from gateway.research_lab.chain import resolve_research_lab_evaluation_epoch
 from gateway.research_lab.code_build import (
     CodeEditBuildError,
+    CodeEditInfraFailureError,
     validate_private_code_edit_diff_artifact,
 )
 from gateway.research_lab.config import (
@@ -1898,6 +1899,22 @@ async def sync_active_model_to_repo_head(
         )
         current_artifact = admitted.artifact
         compatibility_receipt = admitted.compatibility_receipt
+    except CodeEditInfraFailureError as exc:
+        return {
+            "ok": False,
+            "action": action,
+            "dry_run": dry_run,
+            "status": "model_compatibility_infrastructure_unavailable",
+            "repo_branch": branch_name,
+            "repo_main_sha": repo_main_sha,
+            "current_json_git_sha": current_artifact.git_commit_sha,
+            "active_is_repo_head": False,
+            "benchmark_blocked_reason": (
+                "model_compatibility_infrastructure_unavailable"
+            ),
+            "retryable": True,
+            "error": _safe_text(str(exc))[:200],
+        }
     except Exception as exc:
         return {
             "ok": False,

--- a/tests/test_promotion_fixes.py
+++ b/tests/test_promotion_fixes.py
@@ -2498,6 +2498,74 @@ async def test_repo_head_sync_registers_current_json_with_db_safe_doc(store, mon
 
 
 @pytest.mark.parametrize(
+    ("preflight_error", "expected_status", "expected_retryable"),
+    [
+        (
+            promotion.CodeEditInfraFailureError(
+                "shared Docker lifecycle access timed out"
+            ),
+            "model_compatibility_infrastructure_unavailable",
+            True,
+        ),
+        (
+            RuntimeError("measured model compatibility differs"),
+            "model_compatibility_quarantined",
+            None,
+        ),
+    ],
+)
+async def test_repo_head_sync_distinguishes_retryable_preflight_infrastructure(
+    store,
+    monkeypatch,
+    preflight_error,
+    expected_status,
+    expected_retryable,
+):
+    current_artifact = _valid_fake_artifact(
+        model_artifact_hash="sha256:" + "9" * 64,
+        git_commit_sha="e" * 40,
+    )
+    monkeypatch.setattr(
+        promotion,
+        "_resolve_private_repo_head_sha",
+        lambda **_kwargs: current_artifact.git_commit_sha,
+    )
+
+    async def _manifest(*_args: Any, **_kwargs: Any):
+        return current_artifact, {"status": "manifest_ready"}
+
+    async def _failed_preflight(*_args: Any, **_kwargs: Any):
+        raise preflight_error
+
+    monkeypatch.setattr(promotion, "_load_repo_head_current_manifest", _manifest)
+    monkeypatch.setattr(
+        promotion,
+        "_preflight_private_model_activation",
+        _failed_preflight,
+    )
+
+    result = await sync_active_model_to_repo_head(
+        _controller_config(
+            private_repo_url="git@example.invalid/private.git",
+            private_repo_branch=DEFAULT_PRIVATE_REPO_BRANCH,
+        ),
+        actor_ref="test",
+        dry_run=False,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == expected_status
+    assert result["benchmark_blocked_reason"] == expected_status
+    assert result.get("retryable") is expected_retryable
+    if expected_retryable:
+        assert result["current_json_git_sha"] == current_artifact.git_commit_sha
+    else:
+        assert "current_json_git_sha" not in result
+    assert store.version_event_writes == []
+    assert store.version_writes == []
+
+
+@pytest.mark.parametrize(
     ("commit_status", "has_commit_sha", "event_doc"),
     [
         ("pushed", True, {}),


### PR DESCRIPTION
## Confirmed production failure

A real latest-model activation waited 912 seconds behind exact attestation Docker work. The existing retryable `CodeEditInfraFailureError` was caught by the generic compatibility handler and reported as `model_compatibility_quarantined`, even though model compatibility was never reached.

## Narrow permanent fix

- Classify the existing infrastructure exception before the generic compatibility quarantine.
- Return explicit retryable infrastructure status and current signed model SHA.
- Keep all genuine compatibility errors quarantined exactly as before.
- Perform zero lineage writes on either failure path.

## Focused gate

`2 passed, 114 deselected in 0.67s`

No model semantics, scoring, transport, Supabase, persistence, restart, candidate evaluation, or weight-submission logic changes.