### PR TITLE
Bound protected provider request deadlines

### DIFF
--- a/gateway/research_lab/official_baseline_release_authorities.py
+++ b/gateway/research_lab/official_baseline_release_authorities.py
@@ -118,6 +118,9 @@ _ARTIFACT_CREDENTIAL_BINDING_BY_PROVIDER = {
 }
 _HTTP_METHODS = frozenset({"GET", "POST"})
 _MAX_HTTP_RESPONSE_BYTES = 8 * 1024 * 1024
+_PROXY_REQUEST_TIMEOUT_MS_HEADER = "X-Research-Lab-Request-Timeout-Ms"
+_PROXY_REQUEST_PENDING_EVIDENCE = "request_pending"
+_PROXY_RESPONSE_RESERVE_SECONDS = 5.0
 _DEEPLINE_TERMINAL_STATUSES = frozenset(
     {"completed", "failed", "cancelled"}
 )
@@ -783,13 +786,26 @@ class _GatewayEvidenceProxyClient:
         headers = {
             str(key): str(value)
             for key, value in static_headers.items()
-            if str(key).casefold() != "x-research-lab-replay-only"
+            if str(key).casefold()
+            not in {
+                "x-research-lab-replay-only",
+                _PROXY_REQUEST_TIMEOUT_MS_HEADER.casefold(),
+            }
         }
+        proxy_reserve_seconds = min(
+            _PROXY_RESPONSE_RESERVE_SECONDS,
+            max(0.05, float(timeout_seconds) * 0.05),
+        )
+        proxy_timeout_ms = max(
+            1,
+            int((float(timeout_seconds) - proxy_reserve_seconds) * 1000),
+        )
         headers.update(
             {
                 "Accept": headers.get("Accept", "application/json"),
                 "X-Research-Lab-Cost-Scope": cost_scope,
                 "X-Research-Lab-Budget-Soft-Stop": "1",
+                _PROXY_REQUEST_TIMEOUT_MS_HEADER: str(proxy_timeout_ms),
             }
         )
         if replay_only:
@@ -830,7 +846,24 @@ class _GatewayEvidenceProxyClient:
             raise OfficialBaselineProtectedAuthorityError(
                 "official baseline provider response exceeds artifact bound"
             )
-        return status, _load_json_object(raw), response_headers
+        parsed_body = _load_json_object(raw)
+        evidence = next(
+            (
+                str(value).strip().casefold()
+                for key, value in response_headers.items()
+                if str(key).casefold() == "x-research-lab-evidence"
+            ),
+            "",
+        )
+        if evidence == _PROXY_REQUEST_PENDING_EVIDENCE:
+            if status != 409 or parsed_body != {"error": "request_pending"}:
+                raise OfficialBaselineProtectedAuthorityError(
+                    "official baseline evidence proxy pending response is invalid"
+                )
+            raise OfficialBaselineProtectedAuthorityError(
+                "official baseline provider request remains pending reconciliation"
+            )
+        return status, parsed_body, response_headers
 
 
 class ArtifactPreparedActionExecutor:

--- a/gateway/research_lab/provider_evidence_proxy.py
+++ b/gateway/research_lab/provider_evidence_proxy.py
@@ -94,6 +94,12 @@ CALLER_TOKEN_HEADER = "X-Research-Lab-Caller-Token"
 REPLAY_ONLY_HEADER = "X-Research-Lab-Replay-Only"
 BUDGET_SOFT_STOP_HEADER = "X-Research-Lab-Budget-Soft-Stop"
 BUDGET_SOFT_STOP_RESPONSE_HEADER = "X-Research-Lab-Budget-Soft-Stopped"
+REQUEST_TIMEOUT_MS_HEADER = "X-Research-Lab-Request-Timeout-Ms"
+REQUEST_PENDING_EVIDENCE = "request_pending"
+_DEFAULT_REQUEST_TIMEOUT_SECONDS = 180.0
+_MAX_REQUEST_TIMEOUT_MILLISECONDS = 900_000
+_SINGLE_FLIGHT_WAIT_SECONDS = 175.0
+_PROXY_RESPONSE_RESERVE_SECONDS = 0.25
 OPENROUTER_MANAGEMENT_CREDENTIAL_REFS = (
     "RESEARCH_LAB_OPENROUTER_MANAGEMENT_KEY",
     "OPENROUTER_MANAGEMENT_KEY",
@@ -355,6 +361,7 @@ def _reconcile_openrouter_generation_cost(
     credential: str,
     management_credential: str = "",
     estimate: ProviderCostEstimate,
+    deadline: float | None = None,
 ) -> ProviderCostEstimate:
     generation_id = str(estimate.generation_id or "").strip()
     if not generation_id:
@@ -370,12 +377,22 @@ def _reconcile_openrouter_generation_cost(
     last_error: Exception | None = None
     for attempt, delay in enumerate((0.0, 2.0, 5.0, 10.0, 20.0)):
         if delay:
+            if deadline is not None:
+                remaining = deadline - time.monotonic() - _PROXY_RESPONSE_RESERVE_SECONDS
+                if remaining <= delay:
+                    return estimate
             time.sleep(delay)
         for token in credentials:
+            request_timeout = 30.0
+            if deadline is not None:
+                remaining = deadline - time.monotonic() - _PROXY_RESPONSE_RESERVE_SECONDS
+                if remaining <= 0:
+                    return estimate
+                request_timeout = min(request_timeout, remaining)
             gen_headers = {"Authorization": "Bearer " + token}
             gen_req = urllib.request.Request(gen_url, headers=gen_headers, method="GET")
             try:
-                with urllib.request.urlopen(gen_req, timeout=30) as gen_response:
+                with urllib.request.urlopen(gen_req, timeout=request_timeout) as gen_response:
                     if int(getattr(gen_response, "status", None) or getattr(gen_response, "code", 0) or 0) >= 400:
                         continue
                     generation_body = gen_response.read()
@@ -651,17 +668,27 @@ class ExaConcurrencyGate:
                 target=_cancel_abandoned_exa_run, args=(rid,), daemon=True
             ).start()
 
-    def acquire(self, provider: str, method: str, path: str) -> tuple[str, bool]:
+    def acquire(
+        self,
+        provider: str,
+        method: str,
+        path: str,
+        *,
+        timeout_seconds: float | None = None,
+    ) -> tuple[str, bool]:
         """Returns (kind, acquired). kind '' means this request is not gated."""
         if provider != "exa":
             return "", True
         self._reap_expired_runs()
+        wait_seconds = self._wait_seconds
+        if timeout_seconds is not None:
+            wait_seconds = min(wait_seconds, max(0.0, float(timeout_seconds)))
         clean = (path or "").split("?")[0].rstrip("/")
         if method.upper() == "POST" and clean == "/agent/runs":
-            return "agent_run", self._agent_sem.acquire(timeout=self._wait_seconds)
+            return "agent_run", self._agent_sem.acquire(timeout=wait_seconds)
         if clean.startswith("/agent/runs/"):
             return "", True  # status polls are cheap and must never queue
-        return "search", self._search_sem.acquire(timeout=self._wait_seconds)
+        return "search", self._search_sem.acquire(timeout=wait_seconds)
 
     def release_on_failure(self, kind: str) -> None:
         if kind == "search":
@@ -733,11 +760,20 @@ class SdConcurrencyGate:
         self._sem = threading.BoundedSemaphore(self.request_limit)
         self._wait_seconds = float(os.getenv("SD_GATE_WAIT_SECONDS", "20"))
 
-    def acquire(self, provider: str, path: str) -> tuple[str, bool]:
+    def acquire(
+        self,
+        provider: str,
+        path: str,
+        *,
+        timeout_seconds: float | None = None,
+    ) -> tuple[str, bool]:
         """Returns (kind, acquired). kind '' means this request is not gated."""
         if provider != "sd":
             return "", True
-        return "sd_request", self._sem.acquire(timeout=self._wait_seconds)
+        wait_seconds = self._wait_seconds
+        if timeout_seconds is not None:
+            wait_seconds = min(wait_seconds, max(0.0, float(timeout_seconds)))
+        return "sd_request", self._sem.acquire(timeout=wait_seconds)
 
     def release(self, kind: str) -> None:
         if kind == "sd_request":
@@ -1053,16 +1089,20 @@ class EvidenceStore:
             self._rollover_if_needed_locked()
             return self._cached_locked(fingerprint)
 
-    def acquire_or_wait(self, fingerprint: str, timeout: float = 175.0) -> tuple[dict[str, Any] | None, bool]:
+    def acquire_or_wait(
+        self,
+        fingerprint: str,
+        timeout: float = _SINGLE_FLIGHT_WAIT_SECONDS,
+    ) -> tuple[dict[str, Any] | None, bool]:
         """Single-flight gate.
 
         Returns (record, is_leader):
         - (record, False): already recorded — replay it, do not call live.
         - (None, True): you are the leader — make the live call, then call
           record() (or release_lead() on failure).
-        - (None, False): timed out waiting for the leader — fall back to a
-          live call without leadership (rare; keeps a stuck leader from
-          blocking forever).
+        - (None, False): timed out waiting for the leader — the caller must
+          return a reconciliation-pending result and must not make a duplicate
+          live call without leadership.
         """
         with self._cond:
             deadline = time.monotonic() + max(0.0, float(timeout))
@@ -1331,7 +1371,33 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             sidecar_spend_kind=sidecar_spend_kind,
         )
 
+    def _request_deadline(self, *, started: float) -> float:
+        raw = str(self.headers.get(REQUEST_TIMEOUT_MS_HEADER) or "").strip()
+        if not raw:
+            timeout_seconds = _DEFAULT_REQUEST_TIMEOUT_SECONDS
+        elif (
+            not raw.isascii()
+            or not raw.isdigit()
+            or raw.startswith("0")
+            or not 1 <= int(raw) <= _MAX_REQUEST_TIMEOUT_MILLISECONDS
+        ):
+            raise ValueError("invalid request timeout")
+        else:
+            timeout_seconds = min(
+                _DEFAULT_REQUEST_TIMEOUT_SECONDS,
+                int(raw) / 1000.0,
+            )
+        return started + timeout_seconds
+
+    @staticmethod
+    def _remaining_request_seconds(deadline: float) -> float:
+        return max(
+            0.0,
+            deadline - time.monotonic() - _PROXY_RESPONSE_RESERVE_SECONDS,
+        )
+
     def _handle(self) -> None:
+        request_started = time.monotonic()
         routed = self._provider()
         if routed is None:
             self._respond(404, b'{"error":"unknown provider route"}')
@@ -1417,6 +1483,23 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             DEFAULT_SCRAPINGDOG_COST_PER_CREDIT_USD,
         )
         cost_ledger = self.store.cost_ledger(scope, cap_usd)
+        try:
+            request_deadline = self._request_deadline(started=request_started)
+        except ValueError:
+            self._ledger_row(
+                entry,
+                rest,
+                fingerprint,
+                evidence="blocked",
+                status=400,
+                live_cost=False,
+            )
+            self._respond(
+                400,
+                b'{"error":"invalid research lab request timeout"}',
+                evidence="blocked",
+            )
+            return
         # Global read-through with single-flight: the first run of the day to
         # make a request calls the provider live while every concurrent
         # identical request (e.g. another candidate on the same ICP) waits and
@@ -1434,7 +1517,13 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         cached, is_leader = (
             (self.store.lookup(fingerprint), False)
             if replay_only
-            else self.store.acquire_or_wait(fingerprint)
+            else self.store.acquire_or_wait(
+                fingerprint,
+                timeout=min(
+                    _SINGLE_FLIGHT_WAIT_SECONDS,
+                    self._remaining_request_seconds(request_deadline),
+                ),
+            )
         )
         if cached is not None:
             try:
@@ -1454,6 +1543,21 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         if replay_only:
             self._ledger_row(entry, rest, fingerprint, evidence="replay_miss", status=409, live_cost=False)
             self._respond(409, b'{"error":"replay_miss"}')
+            return
+        if not is_leader:
+            self._ledger_row(
+                entry,
+                rest,
+                fingerprint,
+                evidence=REQUEST_PENDING_EVIDENCE,
+                status=409,
+                live_cost=False,
+            )
+            self._respond(
+                409,
+                b'{"error":"request_pending"}',
+                evidence=REQUEST_PENDING_EVIDENCE,
+            )
             return
         endpoint = redacted_endpoint(entry.id, upstream_url)
         if cost_ledger.should_block_paid_call():
@@ -1548,7 +1652,12 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             method=self.command,
         )
         response_headers: dict[str, str] = {}
-        gate_kind, gate_ok = _EXA_GATE.acquire(entry.id, self.command, rest)
+        gate_kind, gate_ok = _EXA_GATE.acquire(
+            entry.id,
+            self.command,
+            rest,
+            timeout_seconds=self._remaining_request_seconds(request_deadline),
+        )
         if not gate_ok:
             # Queue-wait timed out: surface a transient 429 so the model's
             # bounded retry ladder backs off — never a fake bad score.
@@ -1560,7 +1669,11 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                             "transient": True}).encode("utf-8"),
             )
             return
-        sd_gate_kind, sd_gate_ok = _SD_GATE.acquire(entry.id, rest)
+        sd_gate_kind, sd_gate_ok = _SD_GATE.acquire(
+            entry.id,
+            rest,
+            timeout_seconds=self._remaining_request_seconds(request_deadline),
+        )
         if not sd_gate_ok:
             if is_leader:
                 self.store.release_lead(fingerprint)
@@ -1570,8 +1683,27 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                             "transient": True}).encode("utf-8"),
             )
             return
+        upstream_timeout = self._remaining_request_seconds(request_deadline)
+        if upstream_timeout <= 0:
+            _EXA_GATE.release_on_failure(gate_kind)
+            _SD_GATE.release(sd_gate_kind)
+            self.store.release_lead(fingerprint)
+            self._ledger_row(
+                entry,
+                rest,
+                fingerprint,
+                evidence=REQUEST_PENDING_EVIDENCE,
+                status=409,
+                live_cost=False,
+            )
+            self._respond(
+                409,
+                b'{"error":"request_pending"}',
+                evidence=REQUEST_PENDING_EVIDENCE,
+            )
+            return
         try:
-            with urllib.request.urlopen(request, timeout=180) as response:
+            with urllib.request.urlopen(request, timeout=upstream_timeout) as response:
                 status = int(getattr(response, "status", None) or getattr(response, "code", 0) or 0)
                 response_headers = _headers_to_dict(getattr(response, "headers", None))
                 body = response.read()
@@ -1653,6 +1785,7 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 credential=credential,
                 management_credential=management_credential,
                 estimate=estimate,
+                deadline=request_deadline,
             )
         event = cost_ledger.record_live_event(
             provider=entry.id,

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1,5 +1,5 @@
 {
-  "baseline_commit": "55b0bc2c09dfa6e0ee4f056d89c83533221209e5",
+  "baseline_commit": "77d5273628e66f9dd626d125823ca7ca0cbfdc08",
   "entries": [
     {
       "ast_sha256": "sha256:9366486b15b75d5a2a299caacc86b70e706f1c9bccf99721d18fedc375824e55",
@@ -1377,7 +1377,7 @@
       "symbol": "SITE_PROTECTED_ACTION_AUTHORITY_SOURCE_COMMIT"
     },
     {
-      "ast_sha256": "sha256:3b93e54e1b23f9bc4df52445ffa3839ca58d2f6108c15a28e686345b4a5113ed",
+      "ast_sha256": "sha256:a33eda85fd768291f56c85da33c4b872e0f7b964a4b8386dccb9ce90654ac77e",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "_GatewayEvidenceProxyClient"
     },
@@ -1387,7 +1387,7 @@
       "symbol": "_GatewayEvidenceProxyClient._proxied_url"
     },
     {
-      "ast_sha256": "sha256:4a2446149b9fd091f924cd35aced4861f10f239c6e7dfe17c9c01ef90caab0a8",
+      "ast_sha256": "sha256:7046f2001ccd426266c7bef56268d1530cbcb486b1693859a0c5894d153daff5",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "_GatewayEvidenceProxyClient.request"
     },
@@ -1942,7 +1942,7 @@
       "symbol": "validate_source_add_registration_diff"
     },
     {
-      "ast_sha256": "sha256:d77384bbfad2b7fe682ba8703f242555363899f6a17fcd6bb2bb24fed7ada9a4",
+      "ast_sha256": "sha256:f8eb06ff4d31210b3e57c5c708498b91275a6e27dded868846c576bb6016a7f1",
       "path": "gateway/research_lab/provider_evidence_proxy.py",
       "symbol": "EvidenceStore.acquire_or_wait"
     },
@@ -8187,7 +8187,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:cc647e1d03241422985cac5c91607d92bf0d14b05ac03617607c7cc64705c673",
-  "protected_source_commit": "55b0bc2c09dfa6e0ee4f056d89c83533221209e5",
+  "manifest_hash": "sha256:6566147393b860309629a8758b58019c7db40e85f4faafd156cc19750c904111",
+  "protected_source_commit": "77d5273628e66f9dd626d125823ca7ca0cbfdc08",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_official_baseline_release_authorities.py
+++ b/tests/test_official_baseline_release_authorities.py
@@ -1112,7 +1112,10 @@ def test_exa_transport_uses_only_reviewed_evidence_proxy_route():
         provider="exa",
         method="POST",
         upstream_url="https://api.exa.ai/search",
-        static_headers={"Content-Type": "application/json"},
+        static_headers={
+            "Content-Type": "application/json",
+            "X-Research-Lab-Request-Timeout-Ms": "999999",
+        },
         body={"query": "redacted fixture"},
         query=None,
         timeout_seconds=10,
@@ -1127,6 +1130,7 @@ def test_exa_transport_uses_only_reviewed_evidence_proxy_route():
     lowered_headers = {key.casefold(): value for key, value in captured["headers"].items()}
     assert "authorization" not in lowered_headers
     assert "x-api-key" not in lowered_headers
+    assert lowered_headers["x-research-lab-request-timeout-ms"] == "9500"
     assert captured["closed"] is True
 
     with pytest.raises(
@@ -1189,3 +1193,49 @@ def test_official_proxy_replay_only_header_is_host_owned():
 
     assert "x-research-lab-replay-only" not in captured_headers[0]
     assert captured_headers[1]["x-research-lab-replay-only"] == "1"
+
+
+def test_official_proxy_pending_response_enters_protected_reconciliation():
+    captured = {}
+
+    class _Response:
+        status = 409
+        headers = {"X-Research-Lab-Evidence": "request_pending"}
+
+        def read(self, _limit):
+            return b'{"error":"request_pending"}'
+
+        def close(self):
+            captured["closed"] = True
+
+    def opener(request, *, timeout):
+        captured["headers"] = {
+            key.casefold(): value for key, value in request.header_items()
+        }
+        captured["timeout"] = timeout
+        return _Response()
+
+    client = _GatewayEvidenceProxyClient(
+        proxy_url="http://127.0.0.1:8765",
+        opener=opener,
+    )
+
+    with pytest.raises(
+        OfficialBaselineProtectedAuthorityError,
+        match="remains pending reconciliation",
+    ):
+        client.request(
+            provider="exa",
+            method="POST",
+            upstream_url="https://api.exa.ai/search",
+            static_headers={},
+            body={"query": "redacted fixture"},
+            query=None,
+            timeout_seconds=120,
+            max_response_bytes=10_000,
+            cost_scope="official-baseline-fixture",
+        )
+
+    assert captured["headers"]["x-research-lab-request-timeout-ms"] == "115000"
+    assert captured["timeout"] == 120
+    assert captured["closed"] is True

--- a/tests/test_provider_cost_tracking.py
+++ b/tests/test_provider_cost_tracking.py
@@ -460,6 +460,53 @@ def test_openrouter_missing_cost_for_perplexity_without_usage_is_zero_until_reco
     assert estimate.generation_id == "gen-sonar-no-usage"
 
 
+def test_openrouter_generation_cost_reconciliation_honors_request_deadline(
+    monkeypatch,
+):
+    estimate = ProviderCostEstimate(
+        provider="or",
+        endpoint="/api/v1/chat/completions",
+        model="perplexity/sonar",
+        generation_id="gen-bounded-reconciliation",
+        cost_source="openrouter_missing_cost_zero_cost",
+        tracking_reason="missing_openrouter_cost",
+    )
+    entry = provider_evidence_proxy.ProviderRegistryEntry(
+        id="or",
+        base_url="https://openrouter.ai",
+        auth_kind="bearer",
+    )
+    now = [100.0]
+    observed_timeouts = []
+
+    monkeypatch.setattr(
+        provider_evidence_proxy.time,
+        "monotonic",
+        lambda: now[0],
+    )
+
+    def unavailable(_request, *, timeout):
+        observed_timeouts.append(timeout)
+        now[0] += timeout
+        raise TimeoutError("bounded fixture timeout")
+
+    monkeypatch.setattr(
+        provider_evidence_proxy.urllib.request,
+        "urlopen",
+        unavailable,
+    )
+
+    result = provider_evidence_proxy._reconcile_openrouter_generation_cost(
+        entry=entry,
+        credential="redacted-fixture-key",
+        estimate=estimate,
+        deadline=101.0,
+    )
+
+    assert result == estimate
+    assert observed_timeouts == pytest.approx([0.75])
+
+
 def test_exa_agent_running_poll_is_not_billable_until_completed():
     running = estimate_provider_cost(
         provider="exa",
@@ -1496,6 +1543,55 @@ def test_evidence_store_single_flight_timeout_is_one_absolute_deadline(
 
     assert store.acquire_or_wait(fingerprint, timeout=0.1) == (None, False)
     assert condition.waits == pytest.approx([0.1, 0.06, 0.02])
+
+
+def test_live_single_flight_timeout_returns_pending_without_duplicate_call(
+    monkeypatch,
+):
+    registry = [
+        provider_evidence_proxy.ProviderRegistryEntry(
+            id="exa",
+            base_url="http://127.0.0.1:9",
+            auth_kind="none",
+        )
+    ]
+    proxy = None
+    try:
+        proxy, store, _proxy_thread = provider_evidence_proxy.serve_evidence_proxy(
+            host="127.0.0.1",
+            port=0,
+            registry=registry,
+        )
+        acquire_calls = []
+
+        def acquire_or_wait(*args, **kwargs):
+            acquire_calls.append((args, kwargs))
+            return None, False
+
+        monkeypatch.setattr(store, "acquire_or_wait", acquire_or_wait)
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{proxy.server_address[1]}/exa/search",
+            headers={provider_evidence_proxy.REQUEST_TIMEOUT_MS_HEADER: "2500"},
+            method="GET",
+        )
+
+        with pytest.raises(urllib.error.HTTPError) as raised:
+            urllib.request.urlopen(request, timeout=3)
+
+        assert raised.value.code == 409
+        assert raised.value.headers.get("X-Research-Lab-Evidence") == (
+            provider_evidence_proxy.REQUEST_PENDING_EVIDENCE
+        )
+        assert json.loads(raised.value.read().decode("utf-8")) == {
+            "error": "request_pending"
+        }
+        assert len(acquire_calls) == 1
+        assert acquire_calls[0][0]
+        assert 0 < acquire_calls[0][1]["timeout"] <= 2.25
+    finally:
+        if proxy is not None:
+            proxy.shutdown()
+            proxy.server_close()
 
 
 def test_replay_only_miss_does_not_wait_for_live_single_flight(monkeypatch):


### PR DESCRIPTION
Production rebenchmark recovery fix.

- propagate one host-owned deadline through singleflight, provider gates, upstream transport, and OpenRouter cost reconciliation
- return typed reconciliation-pending instead of issuing a duplicate live call after singleflight timeout
- preserve exact protected replay and refresh the protected workflow identity

Fast gate: 228 passed in 21.8s. Focused provider/authority gate: 92 passed.