### PR TITLE
Prioritize model runs over historical PCR0 warming

### DIFF
--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1,5 +1,5 @@
 {
-  "baseline_commit": "77d5273628e66f9dd626d125823ca7ca0cbfdc08",
+  "baseline_commit": "322df215a9f9c3d4800ee864718d8bf5914c01ec",
   "entries": [
     {
       "ast_sha256": "sha256:9366486b15b75d5a2a299caacc86b70e706f1c9bccf99721d18fedc375824e55",
@@ -5852,7 +5852,7 @@
       "symbol": "_docker_operation_admission_lock_file"
     },
     {
-      "ast_sha256": "sha256:e6cc1830904563437f36cccbd826bcac23b47e3e4b87aa8db1468ed6af07146b",
+      "ast_sha256": "sha256:6963029110d19b0eec8f84df6df9e71ae3d1f60074998d6557bb95670db7e742",
       "path": "gateway/utils/pcr0_builder.py",
       "symbol": "_docker_operation_lock_scope"
     },
@@ -8187,7 +8187,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:6566147393b860309629a8758b58019c7db40e85f4faafd156cc19750c904111",
-  "protected_source_commit": "77d5273628e66f9dd626d125823ca7ca0cbfdc08",
+  "manifest_hash": "sha256:e5a5a4b4f250e73c9486c5c9e2835af2c727db3e341301a4ea866b6a3ad96a2b",
+  "protected_source_commit": "322df215a9f9c3d4800ee864718d8bf5914c01ec",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/utils/pcr0_builder.py
+++ b/gateway/utils/pcr0_builder.py
@@ -252,8 +252,8 @@ _build_in_progress = False
 
 
 @asynccontextmanager
-async def _docker_operation_lock_scope():
-    """Coordinate background PCR0 builds with release and restart Docker work."""
+async def _docker_operation_lock_scope(*, opportunistic: bool = False):
+    """Coordinate PCR0 builds with release, restart, and model Docker work."""
 
     admission_lock_file = _docker_operation_admission_lock_file()
     resource_lock_file = os.path.realpath(DOCKER_OPERATION_LOCK_FILE)
@@ -277,38 +277,53 @@ async def _docker_operation_lock_scope():
     acquired = False
     deadline = time.monotonic() + DOCKER_OPERATION_LOCK_TIMEOUT_SECONDS
     try:
-        logger.info(
-            "[PCR0] Waiting for exclusive Docker maintenance admission: %s",
-            admission_lock_file,
-        )
-        while True:
-            try:
-                fcntl.flock(
-                    admission_fd,
-                    fcntl.LOCK_EX | fcntl.LOCK_NB,
-                )
-                admission_acquired = True
-                break
-            except BlockingIOError:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    raise TimeoutError(
-                        "timed out waiting for exclusive Docker "
-                        "maintenance admission"
+        admission_wait_logged = False
+        resource_wait_logged = False
+        while not acquired:
+            if not admission_acquired:
+                if not admission_wait_logged:
+                    logger.info(
+                        "[PCR0] Waiting for exclusive Docker maintenance "
+                        "admission: %s",
+                        admission_lock_file,
                     )
-                await asyncio.sleep(
-                    min(DOCKER_OPERATION_LOCK_POLL_SECONDS, remaining)
+                    admission_wait_logged = True
+                try:
+                    fcntl.flock(
+                        admission_fd,
+                        fcntl.LOCK_EX | fcntl.LOCK_NB,
+                    )
+                    admission_acquired = True
+                except BlockingIOError:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise TimeoutError(
+                            "timed out waiting for exclusive Docker "
+                            "maintenance admission"
+                        )
+                    await asyncio.sleep(
+                        min(DOCKER_OPERATION_LOCK_POLL_SECONDS, remaining)
+                    )
+                    continue
+
+            if not resource_wait_logged:
+                logger.info(
+                    "[PCR0] Waiting for exclusive Docker build/maintenance "
+                    "access: %s",
+                    resource_lock_file,
                 )
-        logger.info(
-            "[PCR0] Waiting for exclusive Docker build/maintenance access: %s",
-            resource_lock_file,
-        )
-        while True:
+                resource_wait_logged = True
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 acquired = True
-                break
             except BlockingIOError:
+                if opportunistic:
+                    # Optional historical warming must never hold the writer
+                    # turnstile while an active model lifecycle owns shared
+                    # Docker access. Required current/deployed PCR0 builds use
+                    # the strict default and retain writer priority.
+                    fcntl.flock(admission_fd, fcntl.LOCK_UN)
+                    admission_acquired = False
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     raise TimeoutError(
@@ -1850,7 +1865,9 @@ async def build_pcr0_for_recent_commits(num_commits: int = None):
                 logger.warning(f"[PCR0] Failed to compute content hash for {commit_hash[:8]}")
                 continue
 
-            async with _docker_operation_lock_scope():
+            async with _docker_operation_lock_scope(
+                opportunistic=commit_hash not in required_commit_hashes,
+            ):
                 if not await ensure_base_image_exists(repo_dir):
                     logger.warning(
                         f"[PCR0] Failed to prepare base image for {commit_hash[:8]}"

--- a/tests/test_pcr0_content_hash_covers_build_inputs.py
+++ b/tests/test_pcr0_content_hash_covers_build_inputs.py
@@ -588,6 +588,65 @@ async def test_queued_pcr0_writer_blocks_late_shared_reader(
 
 
 @pytest.mark.asyncio
+async def test_opportunistic_historical_writer_yields_to_shared_reader(
+    tmp_path,
+    monkeypatch,
+):
+    lock_path = tmp_path / "docker-operation.lock"
+    monkeypatch.setattr(
+        pcr0_builder,
+        "DOCKER_OPERATION_LOCK_FILE",
+        str(lock_path),
+    )
+    monkeypatch.setattr(
+        pcr0_builder,
+        "DOCKER_OPERATION_LOCK_TIMEOUT_SECONDS",
+        3,
+    )
+    monkeypatch.setattr(
+        pcr0_builder,
+        "DOCKER_OPERATION_LOCK_POLL_SECONDS",
+        0.01,
+    )
+    monkeypatch.setenv(
+        "LEADPOET_DOCKER_OPERATION_LOCK_FILE", str(lock_path)
+    )
+    monkeypatch.setenv("LEADPOET_DOCKER_OPERATION_LOCK_TIMEOUT_SECONDS", "3")
+
+    first_reader_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    fcntl.flock(first_reader_fd, fcntl.LOCK_SH | fcntl.LOCK_NB)
+    historical_entered = asyncio.Event()
+    late_reader_entered = threading.Event()
+
+    async def historical_writer() -> None:
+        async with pcr0_builder._docker_operation_lock_scope(
+            opportunistic=True,
+        ):
+            historical_entered.set()
+
+    def late_reader() -> None:
+        with docker_lock.shared_docker_operation_lock(
+            timeout_seconds=3,
+            require_daemon_ready=False,
+        ):
+            late_reader_entered.set()
+
+    historical_task = asyncio.create_task(historical_writer())
+    await asyncio.sleep(0.05)
+    assert historical_entered.is_set() is False
+
+    late_reader_task = asyncio.create_task(asyncio.to_thread(late_reader))
+    await asyncio.wait_for(late_reader_task, timeout=1)
+    assert late_reader_entered.is_set() is True
+    assert historical_entered.is_set() is False
+
+    fcntl.flock(first_reader_fd, fcntl.LOCK_UN)
+    os.close(first_reader_fd)
+    await asyncio.wait_for(historical_task, timeout=1)
+    assert historical_entered.is_set() is True
+
+
+@pytest.mark.asyncio
 async def test_pcr0_builder_releases_waiting_lock_on_cancellation(
     tmp_path,
     monkeypatch,

--- a/tests/test_restart_docker_coordination_v2.py
+++ b/tests/test_restart_docker_coordination_v2.py
@@ -150,4 +150,10 @@ def test_attestation_builds_share_the_same_host_docker_lock() -> None:
     )
     assert pcr0_builder.count(
         "async with _docker_operation_lock_scope()"
-    ) == 2
+    ) == 1
+    assert (
+        "async with _docker_operation_lock_scope(\n"
+        "                opportunistic=commit_hash not in required_commit_hashes,\n"
+        "            ):"
+        in pcr0_builder
+    )


### PR DESCRIPTION
Makes optional historical PCR0 cache warming yield admission whenever active model/scoring work owns shared Docker access. Current and deployed PCR0 builds retain the existing strict writer-priority path; exact PCR0 verification, attestation, restart, scoring, and weight semantics are unchanged.

Fast validation:
- 32 affected PCR0 and Docker lifecycle tests passed
- Python syntax passed
- protected-workflow manifest verification passed
- git diff check passed