### PR TITLE
Close official baseline custody streams

### DIFF
--- a/gateway/research_lab/official_baseline_custody.py
+++ b/gateway/research_lab/official_baseline_custody.py
@@ -177,11 +177,38 @@ class S3OfficialBaselineDocumentCustody:
             response.get("ServerSideEncryption") != "aws:kms"
             or not isinstance(metadata, Mapping)
             or not callable(getattr(body_reader, "read", None))
+            or not callable(getattr(body_reader, "close", None))
         ):
+            close = getattr(body_reader, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception as exc:  # noqa: BLE001 - cleanup is fail-closed
+                    raise OfficialBaselineCustodyError(
+                        "official baseline custody response cleanup failed"
+                    ) from exc
             raise OfficialBaselineCustodyError(
                 "official baseline custody object is not SSE-KMS protected"
             )
-        body = bytes(body_reader.read())
+        read_error: Exception | None = None
+        close_error: Exception | None = None
+        body = b""
+        try:
+            body = bytes(body_reader.read())
+        except Exception as exc:  # noqa: BLE001 - normalize SDK/body failures
+            read_error = exc
+        try:
+            body_reader.close()
+        except Exception as exc:  # noqa: BLE001 - cleanup is fail-closed
+            close_error = exc
+        if read_error is not None:
+            raise OfficialBaselineCustodyError(
+                "official baseline encrypted custody body read failed"
+            ) from read_error
+        if close_error is not None:
+            raise OfficialBaselineCustodyError(
+                "official baseline custody response cleanup failed"
+            ) from close_error
         expected = str(metadata.get("content-sha256") or "")
         expected_kms = str(metadata.get("kms-key-id-sha256") or "")
         if (

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1,5 +1,5 @@
 {
-  "baseline_commit": "322df215a9f9c3d4800ee864718d8bf5914c01ec",
+  "baseline_commit": "b5ea0b3836603db4a643bb4a89e5f3fd54cd1560",
   "entries": [
     {
       "ast_sha256": "sha256:9366486b15b75d5a2a299caacc86b70e706f1c9bccf99721d18fedc375824e55",
@@ -1082,7 +1082,7 @@
       "symbol": "OFFICIAL_BASELINE_TRANSITION_SCHEMA_VERSION"
     },
     {
-      "ast_sha256": "sha256:462ede266f669f90094fd988635db081a4883d9bd64665be24dc0b4c3781d04d",
+      "ast_sha256": "sha256:1d4888fe29814e5500e9552b6e92d9c053ed00e9ec2e0cf9f5cd09a1b956c200",
       "path": "gateway/research_lab/official_baseline_custody.py",
       "symbol": "S3OfficialBaselineDocumentCustody"
     },
@@ -8187,7 +8187,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:e5a5a4b4f250e73c9486c5c9e2835af2c727db3e341301a4ea866b6a3ad96a2b",
-  "protected_source_commit": "322df215a9f9c3d4800ee864718d8bf5914c01ec",
+  "manifest_hash": "sha256:8b173575e3231f228e12a147f82dd25291c252c0784d56844bf37344c2df0203",
+  "protected_source_commit": "b5ea0b3836603db4a643bb4a89e5f3fd54cd1560",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_official_baseline_authority.py
+++ b/tests/test_official_baseline_authority.py
@@ -61,14 +61,17 @@ class _S3:
     def __init__(self):
         self.values = {}
         self.puts = 0
+        self.readers = []
 
     def get_object(self, *, Bucket, Key):
         del Bucket
         if Key not in self.values:
             raise _Missing
         value = self.values[Key]
+        reader = BytesIO(value["Body"])
+        self.readers.append(reader)
         return {
-            "Body": BytesIO(value["Body"]),
+            "Body": reader,
             "Metadata": deepcopy(value["Metadata"]),
             "ServerSideEncryption": value["ServerSideEncryption"],
         }
@@ -83,6 +86,17 @@ class _S3:
             **deepcopy(value),
             "Body": bytes(value["Body"]),
         }
+
+
+class _FailingBody:
+    def __init__(self):
+        self.closed = False
+
+    def read(self):
+        raise RuntimeError("fixture read failure")
+
+    def close(self):
+        self.closed = True
 
 
 def _context(runner) -> OfficialBaselineDependencyContext:
@@ -105,6 +119,65 @@ def _context(runner) -> OfficialBaselineDependencyContext:
         evidence_proxy_capability_sha256="sha256:" + "a" * 64,
         evidence_proxy_ready_provider_ids=("or",),
     )
+
+
+def _custody_for_test(s3) -> S3OfficialBaselineDocumentCustody:
+    return S3OfficialBaselineDocumentCustody(
+        client=s3,
+        bucket="fixture-bucket",
+        prefix="official-baseline",
+        kms_key_id="alias/fixture-encryption",
+    )
+
+
+def test_custody_closes_every_successful_s3_response_body():
+    s3 = _S3()
+    custody = _custody_for_test(s3)
+
+    assert custody._append_document("fixture.json", {"value": "fixture"}) is True
+    assert s3.readers
+    assert all(reader.closed for reader in s3.readers)
+
+
+def test_custody_closes_s3_body_before_rejecting_invalid_encryption():
+    s3 = _S3()
+    body = b'{}'
+    s3.values["fixture.json"] = {
+        "Body": body,
+        "Metadata": {
+            "content-sha256": sha256_bytes(body).removeprefix("sha256:"),
+            "kms-key-id-sha256": sha256_bytes(
+                b"alias/fixture-encryption"
+            ).removeprefix("sha256:"),
+        },
+        "ServerSideEncryption": "AES256",
+    }
+    custody = _custody_for_test(s3)
+
+    with pytest.raises(OfficialBaselineCustodyError, match="SSE-KMS protected"):
+        custody._read_bytes("fixture.json")
+
+    assert s3.readers[-1].closed
+
+
+def test_custody_closes_s3_body_when_stream_read_fails():
+    body = _FailingBody()
+
+    class _ReadFailureS3(_S3):
+        def get_object(self, *, Bucket, Key):
+            del Bucket, Key
+            return {
+                "Body": body,
+                "Metadata": {},
+                "ServerSideEncryption": "aws:kms",
+            }
+
+    custody = _custody_for_test(_ReadFailureS3())
+
+    with pytest.raises(OfficialBaselineCustodyError, match="body read failed"):
+        custody._read_bytes("fixture.json")
+
+    assert body.closed is True
 
 
 def test_fresh_daily_attempt_zero_is_a_valid_frozen_context():


### PR DESCRIPTION
## Summary
- close every S3 official-baseline StreamingBody on success and failure paths
- reject malformed body readers and fail closed on cleanup errors
- add regression coverage for success, encryption rejection, and read failure cleanup

## Production defect
The active latest-model rebenchmark exhausted the scorer S3 custody connection pool after many successful model actions because response bodies were read but never closed.

## Verification
- deterministic combined gate: 161 passed in 14.37s
- official-baseline authority/release tests: 65 passed
- protected manifest/exact-commit tests: 19 passed
- focused custody tests: 9 passed
- py_compile, diff check, secret scan, and silent-sentinel scan passed