### PR TITLE
Honor model canonical provider dispatch hashes

### DIFF
--- a/gateway/research_lab/official_baseline_release_authorities.py
+++ b/gateway/research_lab/official_baseline_release_authorities.py
@@ -44,7 +44,11 @@ from gateway.research_lab.official_baseline_store import (
     official_baseline_action_replay_identity,
 )
 from research_lab.canonical import sha256_json
-from research_lab.common_model_runner_host import HostActionResult
+from research_lab.common_model_runner_host import (
+    HostActionResult,
+    HostCompiledProviderDispatch,
+    ModelRunnerHostError,
+)
 from research_lab.docker_model_runner_transport import DockerModelRunnerTransport
 from research_lab.eval.private_runtime import DockerPrivateModelRunner
 from research_lab.model_runner_protocol import (
@@ -955,11 +959,17 @@ class ArtifactPreparedActionExecutor:
                 "official baseline artifact provider dispatch is not closed"
             )
         value = dict(dispatch)
-        body = dict(value)
-        claimed = _bare_hash(
-            body.pop("dispatch_sha256"),
-            "official baseline provider dispatch hash",
-        )
+        # Reuse the consumer-neutral runner validator here. Its canonical JSON
+        # is the exact ASCII/no-NaN algorithm frozen by the signed runner role
+        # contract. The gateway's general-purpose canonical helper deliberately
+        # uses UTF-8 text instead, so it is not an authority for model-owned
+        # request or dispatch hashes when a prompt contains non-ASCII text.
+        try:
+            HostCompiledProviderDispatch.from_mapping(action, value)
+        except ModelRunnerHostError as exc:
+            raise OfficialBaselineProtectedAuthorityError(
+                "official baseline artifact provider dispatch identity differs"
+            ) from exc
         request = value.get("request")
         if (
             value.get("action_sha256") != action.get("action_sha256")
@@ -974,12 +984,6 @@ class ArtifactPreparedActionExecutor:
                 "official baseline action binding hash",
             )
             or not isinstance(request, Mapping)
-            or _bare_hash(
-                value.get("request_sha256"),
-                "official baseline provider request hash",
-            )
-            != sha256_json(dict(request)).removeprefix("sha256:")
-            or claimed != sha256_json(body).removeprefix("sha256:")
         ):
             raise OfficialBaselineProtectedAuthorityError(
                 "official baseline artifact provider dispatch identity differs"

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1,5 +1,5 @@
 {
-  "baseline_commit": "6f35f470d90ee2eec1f731e4f929be11944de952",
+  "baseline_commit": "1ffa3d3dcde700ee8b5db4fdef22175c452a9b02",
   "entries": [
     {
       "ast_sha256": "sha256:9366486b15b75d5a2a299caacc86b70e706f1c9bccf99721d18fedc375824e55",
@@ -1322,7 +1322,7 @@
       "symbol": "validate_official_baseline_provider_closure"
     },
     {
-      "ast_sha256": "sha256:792f2324ade77c9653ba9cef4c1cb766ab90f572840d26879ab7163394435ea6",
+      "ast_sha256": "sha256:2fa13883a00e395290cd3a3419acac5466b7a6142ee4924fc075ac69dbf15675",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "ArtifactPreparedActionExecutor"
     },
@@ -8187,7 +8187,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:734810e6e7c94343049a6270184a46a817e6ed6be75314917cc9a0fc45396d81",
-  "protected_source_commit": "6f35f470d90ee2eec1f731e4f929be11944de952",
+  "manifest_hash": "sha256:2c3b169ed66f366563e52e8d17738abd24f5573c8aeb53a960c388f36bb2b311",
+  "protected_source_commit": "1ffa3d3dcde700ee8b5db4fdef22175c452a9b02",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_official_baseline_release_authorities.py
+++ b/tests/test_official_baseline_release_authorities.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from io import BytesIO
 import json
 
@@ -73,6 +74,17 @@ def _custody() -> S3OfficialBaselineDocumentCustody:
 
 def _hash(value) -> str:
     return sha256_json(value).removeprefix("sha256:")
+
+
+def _runner_hash(value) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _catalog_row(
@@ -379,6 +391,76 @@ def _openrouter_provider_fixture():
         }
     )
     return action, dispatch, catalog, inventory
+
+
+def _unicode_openrouter_provider_fixture():
+    action, dispatch, catalog, inventory = _openrouter_provider_fixture()
+    dispatch_body = {
+        key: value for key, value in dispatch.items() if key != "dispatch_sha256"
+    }
+    request = dict(dispatch_body["request"])
+    request["body"] = {
+        **request["body"],
+        "messages": [{"role": "user", "content": "Société — München"}],
+    }
+    dispatch_body["request"] = request
+    dispatch_body["request_sha256"] = _runner_hash(request)
+    return (
+        action,
+        {
+            **dispatch_body,
+            "dispatch_sha256": _runner_hash(dispatch_body),
+        },
+        catalog,
+        inventory,
+    )
+
+
+def test_provider_dispatch_uses_signed_runner_canonical_json_for_unicode():
+    action, dispatch, catalog, inventory = _unicode_openrouter_provider_fixture()
+    executor = ArtifactPreparedActionExecutor(
+        registration=_registration(_Protocol(dispatch=dispatch)),
+        catalog=catalog,
+        inventory=inventory,
+        custody=_custody(),
+        proxy_url="http://127.0.0.1:8765",
+        proxy_client=_Proxy([]),
+    )
+
+    preparation = executor.prepare(
+        run_identity={"run": "unicode-provider-dispatch"},
+        unit_ref="baseline_icp:" + "f" * 64,
+        action=action,
+    )
+
+    assert preparation.request_body_sha256 == "sha256:" + dispatch["request_sha256"]
+    assert preparation.action_sha256 == "sha256:" + action["action_sha256"]
+    assert preparation.tool_id == action["tool_id"]
+
+
+def test_provider_dispatch_rejects_utf8_hash_for_signed_ascii_canonical_json():
+    action, dispatch, catalog, inventory = _unicode_openrouter_provider_fixture()
+    body = {key: value for key, value in dispatch.items() if key != "dispatch_sha256"}
+    body["request_sha256"] = _hash(body["request"])
+    invalid = {**body, "dispatch_sha256": _hash(body)}
+    executor = ArtifactPreparedActionExecutor(
+        registration=_registration(_Protocol(dispatch=invalid)),
+        catalog=catalog,
+        inventory=inventory,
+        custody=_custody(),
+        proxy_url="http://127.0.0.1:8765",
+        proxy_client=_Proxy([]),
+    )
+
+    with pytest.raises(
+        OfficialBaselineProtectedAuthorityError,
+        match="provider dispatch identity differs",
+    ):
+        executor.prepare(
+            run_identity={"run": "unicode-provider-dispatch-invalid"},
+            unit_ref="baseline_icp:" + "e" * 64,
+            action=action,
+        )
 
 
 def _batched_openrouter_provider_fixture():


### PR DESCRIPTION
Fix the production rebenchmark blocker where non-ASCII model-owned provider requests were rehashed with the Lab's generic UTF-8 canonicalizer instead of the signed runner protocol's ASCII canonicalizer. Reuse HostCompiledProviderDispatch for the exact request/dispatch identity check, retain all closed-schema and binding checks, and add positive/negative Unicode regressions.\n\nVerification: 212 directly affected tests passed in 13.14s; exact failed production dispatch replay confirmed model hashes valid and old Lab recomputation invalid.