### PR TITLE
Use model wire canonical hashes in official baseline

### DIFF
--- a/gateway/research_lab/official_baseline_release_authorities.py
+++ b/gateway/research_lab/official_baseline_release_authorities.py
@@ -386,6 +386,12 @@ def _canonical_bytes(value: Any) -> bytes:
         ) from exc
 
 
+def _artifact_wire_sha256(value: Any) -> str:
+    """Hash one model-owned wire document with the signed artifact contract."""
+
+    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
 def _load_json_object(value: bytes) -> Mapping[str, Any]:
     def _closed_pairs(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
         output: dict[str, Any] = {}
@@ -523,12 +529,12 @@ def _catalog_bindings(catalog: Mapping[str, Any]) -> list[dict[str, Any]]:
             catalog.get("binding_contracts_sha256"),
             "official baseline binding catalog hash",
         )
-        != sha256_json(normalized).removeprefix("sha256:")
+        != _artifact_wire_sha256(normalized)
         or _bare_hash(
             catalog.get("catalog_sha256"),
             "official baseline catalog identity",
         )
-        != sha256_json(
+        != _artifact_wire_sha256(
             {
                 "schema_version": OFFICIAL_BINDING_CATALOG_SCHEMA_VERSION,
                 "bindings": normalized,
@@ -555,12 +561,12 @@ def _validate_inventory_catalog(
             inventory.get("entries_sha256"),
             "official baseline compiler entries hash",
         )
-        != sha256_json(entries).removeprefix("sha256:")
+        != _artifact_wire_sha256(entries)
         or _bare_hash(
             inventory.get("inventory_sha256"),
             "official baseline compiler inventory hash",
         )
-        != sha256_json(
+        != _artifact_wire_sha256(
             {
                 key: item
                 for key, item in inventory.items()
@@ -978,8 +984,8 @@ class ArtifactPreparedActionExecutor:
                 value.get("request_sha256"),
                 "official baseline provider request hash",
             )
-            != sha256_json(dict(request)).removeprefix("sha256:")
-            or claimed != sha256_json(body).removeprefix("sha256:")
+            != _artifact_wire_sha256(dict(request))
+            or claimed != _artifact_wire_sha256(body)
         ):
             raise OfficialBaselineProtectedAuthorityError(
                 "official baseline artifact provider dispatch identity differs"
@@ -1909,8 +1915,8 @@ class ArtifactPreparedActionExecutor:
                 execution.get("result_sha256"),
                 "official baseline verifier result hash",
             )
-            != sha256_json(dict(result)).removeprefix("sha256:")
-            or claimed != sha256_json(body).removeprefix("sha256:")
+            != _artifact_wire_sha256(dict(result))
+            or claimed != _artifact_wire_sha256(body)
         ):
             raise OfficialBaselineProtectedAuthorityError(
                 "official baseline artifact verifier identity differs"
@@ -2190,7 +2196,7 @@ def load_official_baseline_release_components(
             compiler_preflight.get("preflight_sha256"),
             "official baseline compiler preflight hash",
         )
-        != sha256_json(preflight_payload).removeprefix("sha256:")
+        != _artifact_wire_sha256(preflight_payload)
     ):
         raise OfficialBaselineAuthorityUnavailable(
             "official baseline artifact compiler preflight failed"

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1,5 +1,5 @@
 {
-  "baseline_commit": "6f35f470d90ee2eec1f731e4f929be11944de952",
+  "baseline_commit": "0baa2d8dc80287bd42ee3c8ebaa403480ced7532",
   "entries": [
     {
       "ast_sha256": "sha256:9366486b15b75d5a2a299caacc86b70e706f1c9bccf99721d18fedc375824e55",
@@ -1322,7 +1322,7 @@
       "symbol": "validate_official_baseline_provider_closure"
     },
     {
-      "ast_sha256": "sha256:792f2324ade77c9653ba9cef4c1cb766ab90f572840d26879ab7163394435ea6",
+      "ast_sha256": "sha256:636d5c24bfa4797e30edfb0ed9d56ff51464c4f62175bfaf4496fe8fbb6d87c9",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "ArtifactPreparedActionExecutor"
     },
@@ -1392,7 +1392,17 @@
       "symbol": "_GatewayEvidenceProxyClient.request"
     },
     {
-      "ast_sha256": "sha256:bbfe69d1f0b978a04e8f3444b117cff1058a129dbf512d9235b6f9041e91f267",
+      "ast_sha256": "sha256:94b72df538fd6e8c14084a3e58f0b230089b18b12bb3256ea5ea851c4350e12c",
+      "path": "gateway/research_lab/official_baseline_release_authorities.py",
+      "symbol": "_artifact_wire_sha256"
+    },
+    {
+      "ast_sha256": "sha256:b73d269a0e72cd709b2f8236817ab38bef68b0b0d781b20c8939262f8720bf6e",
+      "path": "gateway/research_lab/official_baseline_release_authorities.py",
+      "symbol": "_canonical_bytes"
+    },
+    {
+      "ast_sha256": "sha256:8add45417a6927f76f3c327852f9091d1231f8cb674cf141a36cd6c7fde383c3",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "_catalog_bindings"
     },
@@ -1412,7 +1422,7 @@
       "symbol": "_reviewed_provider_transport_available"
     },
     {
-      "ast_sha256": "sha256:dfa293ee66040f143e10adc9b219be2993ef7f91a14df717e75d4a878381686b",
+      "ast_sha256": "sha256:297c4606ab0607fd9ee574a1752aa555016aba9277df646e50c530bc4003247c",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "_validate_inventory_catalog"
     },
@@ -1422,7 +1432,7 @@
       "symbol": "_validated_protected_action_authority_sha256"
     },
     {
-      "ast_sha256": "sha256:da83569d5708f42bfe5622533b2c2a0cd7a308d0b920a71d1ff6310d54ae813a",
+      "ast_sha256": "sha256:1f8d66a478cf4548e1f1ea4af361833b2c0caa89f4f511d70eb421020522c41b",
       "path": "gateway/research_lab/official_baseline_release_authorities.py",
       "symbol": "load_official_baseline_release_components"
     },
@@ -8187,7 +8197,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:734810e6e7c94343049a6270184a46a817e6ed6be75314917cc9a0fc45396d81",
-  "protected_source_commit": "6f35f470d90ee2eec1f731e4f929be11944de952",
+  "manifest_hash": "sha256:3a62d7fbe21a2489970450dd314cc94e70382d7eb3846d58f42d87b8f59a99e0",
+  "protected_source_commit": "0baa2d8dc80287bd42ee3c8ebaa403480ced7532",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/protected_workflows.py
+++ b/gateway/tee/protected_workflows.py
@@ -1124,6 +1124,8 @@ PROTECTED_SYMBOLS = {
         "SITE_PROTECTED_ACTION_AUTHORITY_SOURCE_CALLABLE",
         "protected_action_authority_contract_identity",
         "_validated_protected_action_authority_sha256",
+        "_canonical_bytes",
+        "_artifact_wire_sha256",
         "preflight_official_baseline_artifact_protocol",
         "_catalog_bindings",
         "_validate_inventory_catalog",

--- a/tests/test_official_baseline_release_authorities.py
+++ b/tests/test_official_baseline_release_authorities.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from io import BytesIO
 import json
 
@@ -73,6 +74,17 @@ def _custody() -> S3OfficialBaselineDocumentCustody:
 
 def _hash(value) -> str:
     return sha256_json(value).removeprefix("sha256:")
+
+
+def _model_hash(value) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _catalog_row(
@@ -379,6 +391,37 @@ def _openrouter_provider_fixture():
         }
     )
     return action, dispatch, catalog, inventory
+
+
+def test_unicode_provider_dispatch_uses_model_wire_canonicalization():
+    action, dispatch, catalog, inventory = _openrouter_provider_fixture()
+    request = json.loads(json.dumps(dispatch["request"]))
+    request["body"]["messages"][0]["content"] = "M\u00fcnchen"
+    dispatch_body = {
+        key: value for key, value in dispatch.items() if key != "dispatch_sha256"
+    }
+    dispatch_body["request"] = request
+    dispatch_body["request_sha256"] = _model_hash(request)
+    unicode_dispatch = {
+        **dispatch_body,
+        "dispatch_sha256": _model_hash(dispatch_body),
+    }
+    executor = ArtifactPreparedActionExecutor(
+        registration=_registration(_Protocol(dispatch=unicode_dispatch)),
+        catalog=catalog,
+        inventory=inventory,
+        custody=_custody(),
+        proxy_url="http://127.0.0.1:8765",
+        proxy_client=_Proxy([]),
+    )
+
+    preparation = executor.prepare(
+        run_identity={"run": "unicode-provider-request"},
+        unit_ref="baseline_icp:" + "f" * 64,
+        action=action,
+    )
+
+    assert preparation.request_body_sha256 == "sha256:" + _model_hash(request)
 
 
 def _batched_openrouter_provider_fixture():
@@ -829,6 +872,7 @@ def test_artifact_verifier_result_is_zero_call_known_terminal(
         "schema_version": response_schema,
         "accepted": False,
         "reason_code": "company_constraints_not_proven",
+        "evidence_summary": "M\u00fcnchen",
     }
     execution_body = {
         "schema_version": "model-runner-verifier-execution:v1",
@@ -838,11 +882,11 @@ def test_artifact_verifier_result_is_zero_call_known_terminal(
         "cost_credits": 0.0,
         "provider_receipt_allowed": False,
         "result": result,
-        "result_sha256": _hash(result),
+        "result_sha256": _model_hash(result),
     }
     execution = {
         **execution_body,
-        "execution_sha256": _hash(execution_body),
+        "execution_sha256": _model_hash(execution_body),
     }
     protocol = _Protocol(verifier=execution)
     catalog = _catalog(


### PR DESCRIPTION
Fix the confirmed production rebenchmark failure where artifact-owned provider dispatches containing non-ASCII text were re-hashed with the Lab host canonicalizer instead of the signed model wire contract. This keeps all host-owned durable identities unchanged, applies the model canonicalizer to provider dispatch, verifier, catalog, inventory, and preflight checks, and refreshes the protected-workflow identity. Focused evidence: 32/32 official baseline release-authority tests passed; protected manifest reproduction passed.