### PR TITLE
Harden rebenchmark restart and concurrency recovery

### DIFF
--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -5752,24 +5752,44 @@
       "symbol": "vsock_rpc_transport_health_lock"
     },
     {
+      "ast_sha256": "sha256:992453cca7209352c9020a1ff94d1b297d33bb3d14752ca2bd1654f9c77785c0",
+      "path": "gateway/tee/update_gateway_rebenchmark_retry_secret.py",
+      "symbol": "_FIRST_PASS_CONCURRENCY_ENV"
+    },
+    {
+      "ast_sha256": "sha256:4c21743ad594f6c0e6103470c89ef6e3a9a1ff79fa8df7d9aa22aece719f6cb2",
+      "path": "gateway/tee/update_gateway_rebenchmark_retry_secret.py",
+      "symbol": "_MAX_FIRST_PASS_CONCURRENCY"
+    },
+    {
+      "ast_sha256": "sha256:1e88a8c89d285ff142f07a5ed791d8ae6101127c2152e8204b98de0cfc7d4b04",
+      "path": "gateway/tee/update_gateway_rebenchmark_retry_secret.py",
+      "symbol": "_bounded_first_pass_concurrency"
+    },
+    {
       "ast_sha256": "sha256:3fb69b53608890f5ccfe1791a72447118a8193dbf3708701ab0b2840e8d34e22",
       "path": "gateway/tee/update_gateway_rebenchmark_retry_secret.py",
       "symbol": "_json_object_without_duplicates"
     },
     {
-      "ast_sha256": "sha256:754feaee3d4c470aa8310357ac5e82cab87aa195c96c7da7beecac84e38d8bea",
+      "ast_sha256": "sha256:4fdfb1b70cac96fc96f57e56ad4b886f98068c0423724402d6105e4e68dc05e5",
       "path": "gateway/tee/update_gateway_rebenchmark_retry_secret.py",
       "symbol": "_parse_environment"
     },
     {
-      "ast_sha256": "sha256:1c4e81131331e539dcce605b3a82a67cadb19cae729652fc593a0f8a203f473e",
+      "ast_sha256": "sha256:070c0b870a678bc574224dac18b5e8aaaf9df24422b55564c47cdaa7b3518012",
       "path": "gateway/tee/update_gateway_rebenchmark_retry_secret.py",
       "symbol": "_parse_shell_environment"
     },
     {
-      "ast_sha256": "sha256:8352cc3946b967db7551e201bcca127d4c40d89de50afe09d5beefef9a7d8b23",
+      "ast_sha256": "sha256:29bcbc4adcbfaa59c4a0706e6783b2381dd4c0aa02abe17d1029329e2ad990b8",
       "path": "gateway/tee/update_gateway_rebenchmark_retry_secret.py",
       "symbol": "_render_environment"
+    },
+    {
+      "ast_sha256": "sha256:e0bd2ad6dea348372245a203dc4cc6d4f2122f9f751b47346ca51bf0e208b8b4",
+      "path": "gateway/tee/update_gateway_rebenchmark_retry_secret.py",
+      "symbol": "update_gateway_rebenchmark_concurrency_secret"
     },
     {
       "ast_sha256": "sha256:2b1a8074a1b313094036519d84707890273df78569b69ec805a8e07f7ed17921",
@@ -8197,7 +8217,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:3a62d7fbe21a2489970450dd314cc94e70382d7eb3846d58f42d87b8f59a99e0",
+  "manifest_hash": "sha256:28bcc2d0569f09d771ef63de7e918eec5fb2381f48147e2d4efed868459739c3",
   "protected_source_commit": "0baa2d8dc80287bd42ee3c8ebaa403480ced7532",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -8217,7 +8217,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:28bcc2d0569f09d771ef63de7e918eec5fb2381f48147e2d4efed868459739c3",
-  "protected_source_commit": "0baa2d8dc80287bd42ee3c8ebaa403480ced7532",
+  "manifest_hash": "sha256:3e4be955af8d32311a17823ef5df585ddb9b4d2d2779f1b31c069974c39eec1b",
+  "protected_source_commit": "d93b1a17b970547c4318d2c3ec6c94f23c68e046",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/protected_workflows.py
+++ b/gateway/tee/protected_workflows.py
@@ -1212,11 +1212,15 @@ PROTECTED_SYMBOLS = {
         "ExactModelRunnerRegistration",
     ),
     "gateway/tee/update_gateway_rebenchmark_retry_secret.py": (
+        "_FIRST_PASS_CONCURRENCY_ENV",
+        "_MAX_FIRST_PASS_CONCURRENCY",
         "_json_object_without_duplicates",
         "_parse_shell_environment",
         "_parse_environment",
         "_render_environment",
+        "_bounded_first_pass_concurrency",
         "update_gateway_rebenchmark_retry_secret",
+        "update_gateway_rebenchmark_concurrency_secret",
     ),
     "gateway/tee/disable_gateway_miner_submissions_secret.py": (
         "__module__",

--- a/gateway/tee/update_gateway_rebenchmark_retry_secret.py
+++ b/gateway/tee/update_gateway_rebenchmark_retry_secret.py
@@ -1,10 +1,12 @@
-"""Apply the one authorized production rebenchmark retry-budget extension.
+"""Apply narrow production rebenchmark runtime configuration changes.
 
-The operation is intentionally fixed: it can only move provider retry rounds
-from its default 1 (absent) or explicit 1 to explicit 2, and retry concurrency
-from its default 2 (absent) or explicit 2 to explicit 1.  It preserves every
-unrelated secret field, verifies the exact persisted version, and restores the
-prior version if readback fails.
+The retry operation remains intentionally fixed: it can only move provider
+retry rounds from its default 1 (absent) or explicit 1 to explicit 2, and retry
+concurrency from its default 2 (absent) or explicit 2 to explicit 1.  The
+first-pass concurrency operation accepts an exact expected old value and a
+bounded new value.  Both operations preserve every unrelated secret field,
+verify the exact persisted version, and restore the prior version if readback
+fails.
 """
 
 from __future__ import annotations
@@ -36,6 +38,8 @@ _TARGET_VALUES = {
     _RETRY_CONCURRENCY_ENV: "1",
 }
 _TARGET_NAMES = frozenset(_TARGET_VALUES)
+_FIRST_PASS_CONCURRENCY_ENV = "RESEARCH_LAB_BENCHMARK_CONCURRENCY"
+_MAX_FIRST_PASS_CONCURRENCY = 64
 _ENVIRONMENT_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
@@ -58,7 +62,11 @@ def _json_object_without_duplicates(
     return decoded
 
 
-def _parse_shell_environment(raw: str) -> dict[str, str]:
+def _parse_shell_environment(
+    raw: str,
+    *,
+    target_names: frozenset[str] = _TARGET_NAMES,
+) -> dict[str, str]:
     """Parse restart-hydrated KEY=VALUE records as data, never shell code."""
 
     parsed: dict[str, str] = {}
@@ -83,22 +91,29 @@ def _parse_shell_environment(raw: str) -> dict[str, str]:
             raise GatewayRebenchmarkRetryUpdateError(
                 "gateway secret environment contains an invalid name"
             )
-        if name in _TARGET_NAMES and name in parsed:
+        if name in target_names and name in parsed:
             raise GatewayRebenchmarkRetryUpdateError(
-                "gateway secret environment contains a duplicate retry setting"
+                "gateway secret environment contains a duplicate target setting"
             )
         parsed[name] = value
     return parsed
 
 
-def _parse_environment(raw: str) -> tuple[dict[str, str], str]:
+def _parse_environment(
+    raw: str,
+    *,
+    target_names: frozenset[str] = _TARGET_NAMES,
+) -> tuple[dict[str, str], str]:
     try:
         decoded = json.loads(
             raw,
             object_pairs_hook=_json_object_without_duplicates,
         )
     except json.JSONDecodeError:
-        return _parse_shell_environment(raw), "shell"
+        return _parse_shell_environment(
+            raw,
+            target_names=target_names,
+        ), "shell"
     if not isinstance(decoded, Mapping):
         raise GatewayRebenchmarkRetryUpdateError(
             "gateway secret JSON must contain an object"
@@ -111,6 +126,7 @@ def _render_environment(
     *,
     document_format: str,
     values: Mapping[str, str],
+    target_names: frozenset[str] = _TARGET_NAMES,
 ) -> str:
     if document_format == "json":
         decoded = json.loads(
@@ -133,7 +149,7 @@ def _render_environment(
             if "=" in candidate
             else ""
         )
-        if name not in _TARGET_NAMES:
+        if name not in target_names:
             kept_records.append(raw_line + separator)
     rendered = "".join(kept_records)
     if rendered and not rendered.endswith(("\n", "\r", "\x00")):
@@ -159,14 +175,15 @@ def _write_backup(
     *,
     backup_directory: Path,
     now: datetime,
+    operation_label: str = "rebenchmark-retry-extension",
 ) -> Path:
     backup_directory = Path(backup_directory)
     backup_directory.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(backup_directory, 0o700)
     timestamp = now.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     path = backup_directory / (
-        "gateway-secret.before-rebenchmark-retry-extension.%s.%s.env"
-        % (timestamp, uuid.uuid4().hex[:12])
+        "gateway-secret.before-%s.%s.%s.env"
+        % (operation_label, timestamp, uuid.uuid4().hex[:12])
     )
     descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
@@ -367,6 +384,206 @@ def update_gateway_rebenchmark_retry_secret(
     }
 
 
+def _bounded_first_pass_concurrency(value: Any, *, label: str) -> int:
+    if isinstance(value, bool):
+        raise GatewayRebenchmarkRetryUpdateError(f"{label} is invalid")
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise GatewayRebenchmarkRetryUpdateError(f"{label} is invalid") from exc
+    if not 1 <= normalized <= _MAX_FIRST_PASS_CONCURRENCY:
+        raise GatewayRebenchmarkRetryUpdateError(
+            f"{label} must be between 1 and {_MAX_FIRST_PASS_CONCURRENCY}"
+        )
+    return normalized
+
+
+def update_gateway_rebenchmark_concurrency_secret(
+    *,
+    secrets_client: Any,
+    expected_prior_scoring_configuration_hash: str,
+    expected_current_concurrency: int,
+    target_concurrency: int,
+    apply: bool = False,
+    secret_id: str = DEFAULT_SECRET_ID,
+    backup_directory: Path = DEFAULT_BACKUP_DIRECTORY,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Verify or apply one exact, bounded first-pass concurrency change."""
+
+    expected_prior_hash = str(
+        expected_prior_scoring_configuration_hash or ""
+    ).strip().lower()
+    if not _SHA256_RE.fullmatch(expected_prior_hash):
+        raise GatewayRebenchmarkRetryUpdateError(
+            "expected prior scoring configuration hash is invalid"
+        )
+    expected_concurrency = _bounded_first_pass_concurrency(
+        expected_current_concurrency,
+        label="expected current first-pass concurrency",
+    )
+    target = _bounded_first_pass_concurrency(
+        target_concurrency,
+        label="target first-pass concurrency",
+    )
+    target_names = frozenset({_FIRST_PASS_CONCURRENCY_ENV})
+
+    initial_response = secrets_client.get_secret_value(SecretId=secret_id)
+    initial_version = str(initial_response.get("VersionId") or "")
+    if not initial_version:
+        raise GatewayRebenchmarkRetryUpdateError(
+            "gateway secret version identity is unavailable"
+        )
+    initial_secret = _secret_string(initial_response)
+    environment, document_format = _parse_environment(
+        initial_secret,
+        target_names=target_names,
+    )
+    raw_current = environment.get(_FIRST_PASS_CONCURRENCY_ENV)
+    try:
+        current_concurrency = int(raw_current) if raw_current is not None else 1
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise GatewayRebenchmarkRetryUpdateError(
+            "gateway first-pass concurrency is invalid"
+        ) from exc
+    if not 1 <= current_concurrency <= _MAX_FIRST_PASS_CONCURRENCY:
+        raise GatewayRebenchmarkRetryUpdateError(
+            "gateway first-pass concurrency is outside the supported bound"
+        )
+
+    if current_concurrency == target:
+        prior_candidates: list[str] = []
+        explicit_prior = dict(environment)
+        explicit_prior[_FIRST_PASS_CONCURRENCY_ENV] = str(expected_concurrency)
+        prior_candidates.append(_configuration_hash(explicit_prior))
+        if expected_concurrency == 1:
+            default_prior = dict(environment)
+            default_prior.pop(_FIRST_PASS_CONCURRENCY_ENV, None)
+            prior_candidates.append(_configuration_hash(default_prior))
+        if expected_prior_hash not in prior_candidates:
+            raise GatewayRebenchmarkRetryUpdateError(
+                "gateway scoring configuration does not match the expected "
+                "checkpoint hash"
+            )
+        return {
+            "status": "already_applied",
+            "secret_id": secret_id,
+            "prior_first_pass_concurrency": expected_concurrency,
+            "current_first_pass_concurrency": target,
+            "scoring_configuration_hash": _configuration_hash(environment),
+        }
+    if current_concurrency != expected_concurrency:
+        raise GatewayRebenchmarkRetryUpdateError(
+            "gateway first-pass concurrency does not match the expected old value"
+        )
+
+    prior_scoring_hash = _configuration_hash(environment)
+    if prior_scoring_hash != expected_prior_hash:
+        raise GatewayRebenchmarkRetryUpdateError(
+            "gateway scoring configuration does not match the expected "
+            "checkpoint hash"
+        )
+    candidate_secret = _render_environment(
+        initial_secret,
+        document_format=document_format,
+        values={_FIRST_PASS_CONCURRENCY_ENV: str(target)},
+        target_names=target_names,
+    )
+    candidate_environment, _ = _parse_environment(
+        candidate_secret,
+        target_names=target_names,
+    )
+    before_unrelated = {
+        name: value
+        for name, value in environment.items()
+        if name not in target_names
+    }
+    after_unrelated = {
+        name: value
+        for name, value in candidate_environment.items()
+        if name not in target_names
+    }
+    if before_unrelated != after_unrelated:
+        raise GatewayRebenchmarkRetryUpdateError(
+            "candidate gateway secret changes unrelated environment values"
+        )
+    if candidate_environment.get(_FIRST_PASS_CONCURRENCY_ENV) != str(target):
+        raise GatewayRebenchmarkRetryUpdateError(
+            "candidate gateway secret did not preserve the target concurrency"
+        )
+    current_scoring_hash = _configuration_hash(candidate_environment)
+
+    if not apply:
+        return {
+            "status": "verified",
+            "secret_id": secret_id,
+            "prior_first_pass_concurrency": expected_concurrency,
+            "current_first_pass_concurrency": target,
+            "prior_scoring_configuration_hash": prior_scoring_hash,
+            "current_scoring_configuration_hash": current_scoring_hash,
+        }
+
+    backup_path = _write_backup(
+        initial_secret,
+        backup_directory=backup_directory,
+        now=now or datetime.now(timezone.utc),
+        operation_label="rebenchmark-concurrency",
+    )
+    current_response = secrets_client.get_secret_value(SecretId=secret_id)
+    if (
+        str(current_response.get("VersionId") or "") != initial_version
+        or _secret_string(current_response) != initial_secret
+    ):
+        raise GatewayRebenchmarkRetryUpdateError(
+            "gateway secret changed concurrently; no update was applied"
+        )
+
+    candidate_token = str(uuid.uuid4())
+    secrets_client.put_secret_value(
+        SecretId=secret_id,
+        SecretString=candidate_secret,
+        ClientRequestToken=candidate_token,
+    )
+    try:
+        persisted = secrets_client.get_secret_value(
+            SecretId=secret_id,
+            VersionId=candidate_token,
+        )
+        description = secrets_client.describe_secret(SecretId=secret_id)
+        stages = description.get("VersionIdsToStages", {}).get(candidate_token, [])
+        if (
+            _secret_string(persisted) != candidate_secret
+            or "AWSCURRENT" not in stages
+        ):
+            raise GatewayRebenchmarkRetryUpdateError(
+                "persisted gateway secret failed exact readback verification"
+            )
+    except Exception as exc:
+        description = secrets_client.describe_secret(SecretId=secret_id)
+        stages = description.get("VersionIdsToStages", {}).get(candidate_token, [])
+        if "AWSCURRENT" in stages:
+            _restore_prior_secret(
+                secrets_client,
+                secret_id=secret_id,
+                prior_secret=initial_secret,
+            )
+        if isinstance(exc, GatewayRebenchmarkRetryUpdateError):
+            raise
+        raise GatewayRebenchmarkRetryUpdateError(
+            "persisted gateway secret could not be verified"
+        ) from exc
+
+    return {
+        "status": "updated",
+        "secret_id": secret_id,
+        "backup_path": str(backup_path),
+        "prior_first_pass_concurrency": expected_concurrency,
+        "current_first_pass_concurrency": target,
+        "prior_scoring_configuration_hash": prior_scoring_hash,
+        "current_scoring_configuration_hash": current_scoring_hash,
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -390,19 +607,79 @@ def main() -> int:
         type=Path,
         default=DEFAULT_BACKUP_DIRECTORY,
     )
+    parser.add_argument(
+        "--expected-current-first-pass-concurrency",
+        type=int,
+        help=(
+            "Exact current first-pass concurrency for a bounded concurrency "
+            "change."
+        ),
+    )
+    parser.add_argument(
+        "--target-first-pass-concurrency",
+        type=int,
+        help=(
+            "Bounded first-pass concurrency to persist instead of applying "
+            "the fixed retry extension."
+        ),
+    )
     args = parser.parse_args()
 
     import boto3
 
-    result = update_gateway_rebenchmark_retry_secret(
-        secrets_client=boto3.client("secretsmanager", region_name="us-east-1"),
-        expected_prior_scoring_configuration_hash=str(
-            args.expected_prior_scoring_configuration_hash
-        ),
-        apply=bool(args.apply),
-        secret_id=str(args.secret_id),
-        backup_directory=args.backup_directory,
-    )
+    secrets_client = boto3.client("secretsmanager", region_name="us-east-1")
+    if args.target_first_pass_concurrency is not None:
+        if args.expected_current_first_pass_concurrency is None:
+            parser.error(
+                "--expected-current-first-pass-concurrency is required with "
+                "--target-first-pass-concurrency"
+            )
+        result = update_gateway_rebenchmark_concurrency_secret(
+            secrets_client=secrets_client,
+            expected_prior_scoring_configuration_hash=str(
+                args.expected_prior_scoring_configuration_hash
+            ),
+            expected_current_concurrency=(
+                args.expected_current_first_pass_concurrency
+            ),
+            target_concurrency=args.target_first_pass_concurrency,
+            apply=bool(args.apply),
+            secret_id=str(args.secret_id),
+            backup_directory=args.backup_directory,
+        )
+    else:
+        if args.expected_current_first_pass_concurrency is not None:
+            parser.error(
+                "--expected-current-first-pass-concurrency requires "
+                "--target-first-pass-concurrency"
+            )
+        result = update_gateway_rebenchmark_retry_secret(
+            secrets_client=secrets_client,
+            expected_prior_scoring_configuration_hash=str(
+                args.expected_prior_scoring_configuration_hash
+            ),
+            apply=bool(args.apply),
+            secret_id=str(args.secret_id),
+            backup_directory=args.backup_directory,
+        )
+    if "current_first_pass_concurrency" in result:
+        print(
+            "Gateway rebenchmark first-pass concurrency %s; "
+            "prior=%s current=%s scoring_configuration_hash=%s%s"
+            % (
+                result["status"],
+                result["prior_first_pass_concurrency"],
+                result["current_first_pass_concurrency"],
+                result.get("current_scoring_configuration_hash")
+                or result["scoring_configuration_hash"],
+                (
+                    " backup=%s" % result["backup_path"]
+                    if result.get("backup_path")
+                    else ""
+                ),
+            )
+        )
+        return 0
     if result["status"] == "already_applied":
         print(
             "Gateway rebenchmark retry extension was already applied; "

--- a/scripts/restart_attested_release_local.sh
+++ b/scripts/restart_attested_release_local.sh
@@ -6,6 +6,7 @@ PRODUCTION_GATEWAY_HOST="ec2-user@52.91.135.79"
 PRODUCTION_GATEWAY_RESTART="/home/ec2-user/gw_restart.sh"
 PRODUCTION_GATEWAY_REPO_ROOT="/home/ec2-user/leadpoet_repo"
 PRODUCTION_GATEWAY_PYTHON_BIN="/home/ec2-user/venv311/bin/python3"
+PRODUCTION_VALIDATOR_PYTHON_BIN="/home/ec2-user/venv311/bin/python3"
 PRODUCTION_GATEWAY_DEPLOY_READINESS_PATH="/home/ec2-user/gateway/deploy_readiness.json"
 PRODUCTION_GATEWAY_RESTART_CONTROLLER_ROOT="/home/ec2-user/.config/leadpoet/restart-controller/gateway"
 PRODUCTION_GATEWAY_RESTART_CONTROLLER_CURRENT="$PRODUCTION_GATEWAY_RESTART_CONTROLLER_ROOT/current"
@@ -18,6 +19,7 @@ VALIDATOR_RESTART="${LEADPOET_VALIDATOR_RESTART_PATH:-/home/ec2-user/validator_r
 GATEWAY_REPO_ROOT="${LEADPOET_GATEWAY_REPO_ROOT:-$PRODUCTION_GATEWAY_REPO_ROOT}"
 GATEWAY_PYTHON_BIN="${LEADPOET_GATEWAY_PYTHON_BIN:-$PRODUCTION_GATEWAY_PYTHON_BIN}"
 VALIDATOR_REPO_ROOT="${LEADPOET_VALIDATOR_REPO_ROOT:-/home/ec2-user/leadpoet/leadpoet}"
+VALIDATOR_PYTHON_BIN="${LEADPOET_VALIDATOR_PYTHON_BIN:-$PRODUCTION_VALIDATOR_PYTHON_BIN}"
 VALIDATOR_V2_HOTKEY_CONFIG_PATH="${LEADPOET_VALIDATOR_V2_HOTKEY_CONFIG_PATH:-/home/ec2-user/.config/leadpoet/validator-hotkey-config-v2.json}"
 VALIDATOR_CHAIN_SIGNING_PROFILE_PATH="${LEADPOET_VALIDATOR_CHAIN_SIGNING_PROFILE_PATH:-$VALIDATOR_REPO_ROOT/validator_tee/enclave/chain_signing_profile_v2.json}"
 VALIDATOR_STATEFUL_CUTOVER_MANIFEST="/home/ec2-user/.config/leadpoet/stateful-epoch-cutover.json"
@@ -333,6 +335,7 @@ if [ "$disable_miner_submissions_before_restart" = "1" ]; then
       || [ "$GATEWAY_RESTART" != "$PRODUCTION_GATEWAY_RESTART" ] \
       || [ "$GATEWAY_REPO_ROOT" != "$PRODUCTION_GATEWAY_REPO_ROOT" ] \
       || [ "$GATEWAY_PYTHON_BIN" != "$PRODUCTION_GATEWAY_PYTHON_BIN" ] \
+      || [ "$VALIDATOR_PYTHON_BIN" != "$PRODUCTION_VALIDATOR_PYTHON_BIN" ] \
       || [ "$GATEWAY_DEPLOY_READINESS_PATH" != "$PRODUCTION_GATEWAY_DEPLOY_READINESS_PATH" ]; then
     echo "ERROR: miner-maintenance bootstrap requires the fixed production gateway topology" >&2
     exit 2
@@ -364,6 +367,7 @@ done
 for remote_path in \
   "$GATEWAY_REPO_ROOT" \
   "$GATEWAY_PYTHON_BIN" \
+  "$VALIDATOR_PYTHON_BIN" \
   "$GATEWAY_DEPLOY_READINESS_PATH" \
   "$GATEWAY_ACTIVE_RELEASE_REQUIREMENTS_PATH" \
   "$GATEWAY_ACTIVE_RELEASE_LINEAGE_PATH"; do
@@ -1116,10 +1120,11 @@ prepare_running_validator_release_requirements() {
      test -f '$VALIDATOR_STATEFUL_CUTOVER_MANIFEST'
      test ! -L '$VALIDATOR_STATEFUL_CUTOVER_MANIFEST'
      test -s '$VALIDATOR_STATEFUL_CUTOVER_MANIFEST'
-     lineage_id=\$(LEADPOET_SUBNET_EPOCH_CUTOVER_PATH='$VALIDATOR_STATEFUL_CUTOVER_MANIFEST' PYTHONPATH='$VALIDATOR_REPO_ROOT' python3 -c 'from Leadpoet.utils.subnet_epoch import load_subnet_epoch_cutover; from leadpoet_canonical.ancestry_checkpoint_v2 import derive_ancestry_lineage_id_v2; cutover = load_subnet_epoch_cutover(); print(derive_ancestry_lineage_id_v2(cutover_mapping_hash=str(cutover.mapping_hash), network_genesis_hash=str(cutover.network_genesis_hash), netuid=int(cutover.netuid)))')
+     test -x '$VALIDATOR_PYTHON_BIN'
+     lineage_id=\$(LEADPOET_SUBNET_EPOCH_CUTOVER_PATH='$VALIDATOR_STATEFUL_CUTOVER_MANIFEST' PYTHONPATH='$VALIDATOR_REPO_ROOT' '$VALIDATOR_PYTHON_BIN' -c 'from Leadpoet.utils.subnet_epoch import load_subnet_epoch_cutover; from leadpoet_canonical.ancestry_checkpoint_v2 import derive_ancestry_lineage_id_v2; cutover = load_subnet_epoch_cutover(); print(derive_ancestry_lineage_id_v2(cutover_mapping_hash=str(cutover.mapping_hash), network_genesis_hash=str(cutover.network_genesis_hash), netuid=int(cutover.netuid)))')
      sudo env PYTHONPATH='$VALIDATOR_REPO_ROOT' \
        AWS_REGION=us-east-1 AWS_DEFAULT_REGION=us-east-1 \
-       python3 -m gateway.tee.prepare_active_release_lineage_v2 \
+       '$VALIDATOR_PYTHON_BIN' -m gateway.tee.prepare_active_release_lineage_v2 \
        --phase validator-initial \
        --candidate-commit '$commit' \
        --authority-commit '$branch_commit' \
@@ -1662,11 +1667,13 @@ run_validator_restart() {
     GIT_NO_REPLACE_OBJECTS=1 git -C '$VALIDATOR_REPO_ROOT' archive '$branch_commit' | tar -xf - -C \"\$authority_root\"
     test -r \"\$authority_root/validator_restart.sh\"
     test -r \"\$authority_root/gateway/tee/prepare_active_release_lineage_v2.py\"
+    test -x '$VALIDATOR_PYTHON_BIN'
     test \"\$(git -C '$VALIDATOR_REPO_ROOT' hash-object --no-filters \"\$authority_root/validator_restart.sh\")\" = \"\$(git -C '$VALIDATOR_REPO_ROOT' rev-parse '$branch_commit:validator_restart.sh')\"
     find \"\$authority_root\" -type f -exec chmod 400 {} +
     find \"\$authority_root\" -type d -exec chmod 500 {} +
     exec env \\
       VALIDATOR_ROOT='$VALIDATOR_REPO_ROOT' \\
+      VALIDATOR_PYTHON_BIN='$VALIDATOR_PYTHON_BIN' \\
       VALIDATOR_HOST_RESTART_SCRIPT='$VALIDATOR_RESTART' \\
       VALIDATOR_ACTIVE_RELEASE_AUTHORITY_ROOT=\"\$authority_root\" \\
       VALIDATOR_ACTIVE_RELEASE_AUTHORITY_COMMIT='$branch_commit' \\

--- a/tests/test_attested_release_restart_operator.py
+++ b/tests/test_attested_release_restart_operator.py
@@ -118,6 +118,14 @@ def test_attested_release_restart_operator_is_fail_closed() -> None:
         f'VALIDATOR_KEY="${{LEADPOET_VALIDATOR_SSH_KEY:-{expected_key}}}"'
         in source
     )
+    assert (
+        'PRODUCTION_VALIDATOR_PYTHON_BIN="/home/ec2-user/venv311/bin/python3"'
+        in source
+    )
+    assert (
+        'VALIDATOR_PYTHON_BIN="${LEADPOET_VALIDATOR_PYTHON_BIN:-'
+        '$PRODUCTION_VALIDATOR_PYTHON_BIN}"'
+    ) in source
     assert 'component="all"' in source
     assert "exact_commit_restart_v2.py" in source
     assert "--compatibility-floor" not in source
@@ -177,11 +185,18 @@ def test_attested_release_restart_operator_is_fail_closed() -> None:
     assert "test -f '$VALIDATOR_STATEFUL_CUTOVER_MANIFEST'" in source
     assert "test ! -L '$VALIDATOR_STATEFUL_CUTOVER_MANIFEST'" in source
     assert "test -s '$VALIDATOR_STATEFUL_CUTOVER_MANIFEST'" in source
+    assert "test -x '$VALIDATOR_PYTHON_BIN'" in source
     assert (
         "LEADPOET_SUBNET_EPOCH_CUTOVER_PATH="
         "'$VALIDATOR_STATEFUL_CUTOVER_MANIFEST' "
-        "PYTHONPATH='$VALIDATOR_REPO_ROOT'"
+        "PYTHONPATH='$VALIDATOR_REPO_ROOT' '$VALIDATOR_PYTHON_BIN'"
     ) in source
+    assert (
+        "'$VALIDATOR_PYTHON_BIN' -m "
+        "gateway.tee.prepare_active_release_lineage_v2"
+    ) in source
+    assert "python3 -m gateway.tee.prepare_active_release_lineage_v2" not in source
+    assert "VALIDATOR_PYTHON_BIN='$VALIDATOR_PYTHON_BIN'" in source
     assert 'local gateway_restart_entrypoint_root="\\$authority_root"' in source
     assert 'gateway_restart_entrypoint_root="\\$candidate_root"' in source
     assert r'bash \"$gateway_restart_entrypoint_root/gw_restart.sh\"' in source

--- a/tests/test_update_gateway_rebenchmark_retry_secret.py
+++ b/tests/test_update_gateway_rebenchmark_retry_secret.py
@@ -13,11 +13,15 @@ from gateway.tee.scoring_executor import (
 from gateway.tee.update_gateway_rebenchmark_retry_secret import (
     GatewayRebenchmarkRetryUpdateError,
     _parse_shell_environment,
+    update_gateway_rebenchmark_concurrency_secret,
     update_gateway_rebenchmark_retry_secret,
 )
 
 
-def _scoring_hash(*, retry_rounds: str | None) -> str:
+def _scoring_hash(
+    *,
+    retry_rounds: str | None,
+) -> str:
     values = {name: None for name in SCORING_RUNTIME_ENV_NAMES}
     values["RESEARCH_LAB_BENCHMARK_PROVIDER_RETRY_ROUNDS"] = retry_rounds
     return scoring_configuration_hash(values)
@@ -212,7 +216,7 @@ def test_duplicate_target_setting_fails_before_backup_or_write(
 
     with pytest.raises(
         GatewayRebenchmarkRetryUpdateError,
-        match="duplicate retry setting",
+        match="duplicate target setting",
     ):
         update_gateway_rebenchmark_retry_secret(
             secrets_client=client,
@@ -442,3 +446,144 @@ def test_failed_exact_readback_restores_prior_secret(tmp_path):
 
     assert len(client.put_calls) == 2
     assert client.versions[client.current] == original
+
+
+def test_concurrency_update_is_exact_and_preserves_unrelated_values(tmp_path):
+    original = (
+        "UNRELATED='preserve me'\n"
+        "RESEARCH_LAB_BENCHMARK_CONCURRENCY=5\n"
+        "RESEARCH_LAB_BENCHMARK_PROVIDER_RETRY_ROUNDS=1\n"
+    )
+    client = FakeSecretsClient(original)
+    prior_hash = _scoring_hash(
+        retry_rounds="1",
+    )
+
+    verified = update_gateway_rebenchmark_concurrency_secret(
+        secrets_client=client,
+        expected_prior_scoring_configuration_hash=prior_hash,
+        expected_current_concurrency=5,
+        target_concurrency=20,
+        backup_directory=tmp_path,
+    )
+
+    assert verified["status"] == "verified"
+    assert verified["prior_first_pass_concurrency"] == 5
+    assert verified["current_first_pass_concurrency"] == 20
+    assert client.put_calls == []
+    assert list(tmp_path.iterdir()) == []
+
+    result = update_gateway_rebenchmark_concurrency_secret(
+        secrets_client=client,
+        expected_prior_scoring_configuration_hash=prior_hash,
+        expected_current_concurrency=5,
+        target_concurrency=20,
+        apply=True,
+        backup_directory=tmp_path,
+        now=datetime(2026, 8, 28, tzinfo=timezone.utc),
+    )
+
+    persisted = client.versions[client.current]
+    assert "UNRELATED='preserve me'" in persisted
+    assert "RESEARCH_LAB_BENCHMARK_PROVIDER_RETRY_ROUNDS=1" in persisted
+    assert persisted.count("RESEARCH_LAB_BENCHMARK_CONCURRENCY=") == 1
+    assert "RESEARCH_LAB_BENCHMARK_CONCURRENCY=20" in persisted
+    assert result["status"] == "updated"
+    assert Path(result["backup_path"]).read_text(encoding="utf-8") == original
+
+
+def test_concurrency_update_supports_default_one_and_json(tmp_path):
+    original = json.dumps({"UNRELATED": "preserved"})
+    client = FakeSecretsClient(original)
+
+    result = update_gateway_rebenchmark_concurrency_secret(
+        secrets_client=client,
+        expected_prior_scoring_configuration_hash=_scoring_hash(
+            retry_rounds=None,
+        ),
+        expected_current_concurrency=1,
+        target_concurrency=8,
+        apply=True,
+        backup_directory=tmp_path,
+    )
+
+    assert result["status"] == "updated"
+    assert json.loads(client.versions[client.current]) == {
+        "UNRELATED": "preserved",
+        "RESEARCH_LAB_BENCHMARK_CONCURRENCY": "8",
+    }
+
+
+def test_concurrency_update_is_idempotent_against_prior_hash(tmp_path):
+    client = FakeSecretsClient(
+        "UNRELATED=value\n"
+        "RESEARCH_LAB_BENCHMARK_CONCURRENCY=20\n"
+    )
+    result = update_gateway_rebenchmark_concurrency_secret(
+        secrets_client=client,
+        expected_prior_scoring_configuration_hash=_scoring_hash(
+            retry_rounds=None,
+        ),
+        expected_current_concurrency=5,
+        target_concurrency=20,
+        apply=True,
+        backup_directory=tmp_path,
+    )
+
+    assert result["status"] == "already_applied"
+    assert result["current_first_pass_concurrency"] == 20
+    assert client.put_calls == []
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    ("expected_current", "target"),
+    [(0, 20), (5, 0), (5, 65), (True, 20)],
+)
+def test_concurrency_update_rejects_out_of_bounds_before_secret_read(
+    tmp_path,
+    expected_current,
+    target,
+):
+    class NoReadClient(FakeSecretsClient):
+        def get_secret_value(self, **_kwargs):
+            raise AssertionError("secret must not be read")
+
+    with pytest.raises(
+        GatewayRebenchmarkRetryUpdateError,
+        match="invalid|between 1 and 64",
+    ):
+        update_gateway_rebenchmark_concurrency_secret(
+            secrets_client=NoReadClient(""),
+            expected_prior_scoring_configuration_hash=_scoring_hash(
+                retry_rounds=None,
+            ),
+            expected_current_concurrency=expected_current,
+            target_concurrency=target,
+            apply=True,
+            backup_directory=tmp_path,
+        )
+
+
+def test_concurrency_update_rejects_wrong_old_value_without_write(tmp_path):
+    client = FakeSecretsClient(
+        "RESEARCH_LAB_BENCHMARK_CONCURRENCY=5\n"
+    )
+
+    with pytest.raises(
+        GatewayRebenchmarkRetryUpdateError,
+        match="does not match the expected old value",
+    ):
+        update_gateway_rebenchmark_concurrency_secret(
+            secrets_client=client,
+            expected_prior_scoring_configuration_hash=_scoring_hash(
+                retry_rounds=None,
+            ),
+            expected_current_concurrency=4,
+            target_concurrency=20,
+            apply=True,
+            backup_directory=tmp_path,
+        )
+
+    assert client.put_calls == []
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary
- use the configured production validator Python for active-lineage preflight and the validator restart controller
- add a bounded, exact-prior-hash rebenchmark concurrency update operation
- preserve every unrelated gateway setting and require backup, reread, optimistic concurrency, exact persisted readback, and rollback
- protect the new operation in the committed workflow manifest

## Production evidence
A canonical restart for exact attested SHA 43551b5c90a14ddda791e95dc5a7c90b075e265a failed closed before mutation because validator preflight used bare system Python without bittensor_wallet; the configured production interpreter contains the required dependency.

The latest-model 40-ICP run is healthy but production first-pass concurrency 5 is throughput-bound. The host has substantial CPU and memory headroom, and the existing receipt frontier is already tested up to 40 concurrent ICPs. First-pass concurrency is operational and excluded from the score-producing configuration hash, so a guarded increase can resume the exact durable checkpoint without changing scoring semantics.

## Verification
- bash syntax for the canonical restart controller
- Python compile checks for touched Python files
- 80 focused updater, restart-operator, and protected-workflow tests passed
- 76 adjacent restart, supersession, and wiring tests passed before the concurrency follow-up
- diff and secret scans clean