### PR TITLE
Repair Production Parity Full static bootstrap

### DIFF
--- a/.github/workflows/physical-v2-staging.yml
+++ b/.github/workflows/physical-v2-staging.yml
@@ -309,6 +309,54 @@ jobs:
             "$bundle_sha256" "$bundle_size_bytes" \
             "$binding_sha256" "$binding_size_bytes" >> "$GITHUB_OUTPUT"
 
+      - name: Transfer exact signed acceptance corpus
+        id: acceptance_transfer
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          umask 077
+          source_config="/home/ec2-user/.config/leadpoet/v2"
+          archive="$PARITY_TEMP/acceptance-corpus-v2.tar"
+          binding="$PARITY_TEMP/acceptance-corpus-v2-binding.json"
+          evidence="$PARITY_TEMP/acceptance-corpus-v2-transfer.json"
+          test "$(git rev-parse HEAD)" = "$CANDIDATE_SHA"
+          python3 scripts/production_parity_acceptance_transfer.py \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --source-config-dir "$source_config" \
+            --archive "$archive" \
+            --binding "$binding" > "$evidence"
+          test -s "$archive" && test ! -L "$archive"
+          test -s "$binding" && test ! -L "$binding"
+          aws s3 cp "$archive" \
+            "s3://${{ steps.stack.outputs.artifact_bucket }}/${{ steps.inputs.outputs.prefix }}/acceptance-corpus-v2.tar" \
+            --only-show-errors
+          aws s3 cp "$binding" \
+            "s3://${{ steps.stack.outputs.artifact_bucket }}/${{ steps.inputs.outputs.prefix }}/acceptance-corpus-v2-binding.json" \
+            --only-show-errors
+          python3 - "$evidence" "$GITHUB_OUTPUT" "$CANDIDATE_SHA" <<'PY'
+          import json
+          from pathlib import Path
+          import re
+          import sys
+
+          value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          if (
+              value.get("candidate_sha") != sys.argv[3]
+              or not isinstance(value.get("fixture_count"), int)
+              or value["fixture_count"] <= 0
+              or re.fullmatch(
+                  r"sha256:[0-9a-f]{64}",
+                  str(value.get("binding_hash") or ""),
+              )
+              is None
+          ):
+              raise SystemExit("acceptance transfer evidence differs")
+          with open(sys.argv[2], "a", encoding="utf-8") as handle:
+              handle.write(f"fixture_count={value['fixture_count']}\n")
+              handle.write(f"binding_hash={value['binding_hash']}\n")
+          PY
+          rm -f -- "$archive" "$binding" "$evidence"
+
       - name: Start candidate production paths
         id: execute
         shell: bash
@@ -905,6 +953,12 @@ jobs:
               or value.get("acceptance_corpus", {}).get("candidate_sha")
                   != sys.argv[2]
               or value.get("acceptance_corpus", {}).get("fixture_count", 0) <= 0
+              or value.get("acceptance_corpus", {}).get("transfer", {}).get(
+                  "validated_exact"
+              ) is not True
+              or value.get("acceptance_corpus", {}).get("transfer", {}).get(
+                  "source"
+              ) != "run-scoped-object-lock"
               or value.get("external_write_boundaries", {}).get("arweave")
                   != "blocked-production-parity"
               or value.get("miner_intake", {}).get("status") != "passed"

--- a/scripts/build_production_parity_contract.py
+++ b/scripts/build_production_parity_contract.py
@@ -67,6 +67,7 @@ ALWAYS_COMMITTED_PATHS = (
     "scripts/cleanup_production_parity_staging.py",
     "scripts/materialize_production_parity_secrets.py",
     "scripts/operate_rebenchmark_iam_policy.py",
+    "scripts/production_parity_acceptance_transfer.py",
     "scripts/production_parity_snapshot.py",
     "scripts/provision_production_parity_staging.py",
     "scripts/resolve_production_parity_deployed_sha.py",

--- a/scripts/materialize_production_parity_secrets.py
+++ b/scripts/materialize_production_parity_secrets.py
@@ -198,6 +198,8 @@ _FORCED_KEYS = {
     "VALIDATOR_SUBTENSOR_NETWORK",
     "VALIDATOR_NETUID",
     "GATEWAY_URL",
+    "GATEWAY_PUBLIC_KEY",
+    "GATEWAY_PRIVATE_KEY_PASSWORD",
     "VALIDATOR_V2_GATEWAY_URL",
     "DISABLE_BACKGROUND_TASKS",
     "GATEWAY_STATEFUL_CUTOVER_CEREMONY",
@@ -372,6 +374,7 @@ def build_gateway_environment(
     *,
     run_id: str,
     candidate_sha: str,
+    gateway_public_key: str,
     supabase_origin: str,
     artifact_bucket: str,
     benchmark_date: str,
@@ -381,6 +384,9 @@ def build_gateway_environment(
         raise SecretMaterializationError("parity run or candidate identity is invalid")
     if not DATE_RE.fullmatch(benchmark_date):
         raise SecretMaterializationError("parity benchmark date is invalid")
+    normalized_gateway_public_key = str(gateway_public_key or "").strip().lower()
+    if re.fullmatch(r"[0-9a-f]{64}", normalized_gateway_public_key) is None:
+        raise SecretMaterializationError("parity gateway public key is invalid")
     if not re.fullmatch(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", artifact_bucket):
         raise SecretMaterializationError("parity artifact bucket is invalid")
     boundary_environment = {
@@ -416,6 +422,8 @@ def build_gateway_environment(
         "VALIDATOR_SUBTENSOR_NETWORK": "finney",
         "VALIDATOR_NETUID": "71",
         "GATEWAY_URL": "http://127.0.0.1:8000",
+        "GATEWAY_PUBLIC_KEY": normalized_gateway_public_key,
+        "GATEWAY_PRIVATE_KEY_PASSWORD": "",
         "VALIDATOR_V2_GATEWAY_URL": "http://127.0.0.1:8000",
         "DISABLE_BACKGROUND_TASKS": "true",
         "GATEWAY_STATEFUL_CUTOVER_CEREMONY": "0",
@@ -486,6 +494,7 @@ def create(
     source_secret_id: str,
     run_id: str,
     candidate_sha: str,
+    gateway_public_key: str,
     supabase_origin: str,
     artifact_bucket: str,
     benchmark_date: str,
@@ -500,6 +509,7 @@ def create(
         source,
         run_id=run_id,
         candidate_sha=candidate_sha,
+        gateway_public_key=gateway_public_key,
         supabase_origin=supabase_origin,
         artifact_bucket=artifact_bucket,
         benchmark_date=benchmark_date,
@@ -567,6 +577,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     create_parser.add_argument("--source-secret-id", required=True)
     create_parser.add_argument("--run-id", required=True)
     create_parser.add_argument("--candidate-sha", required=True)
+    create_parser.add_argument("--gateway-public-key", required=True)
     create_parser.add_argument("--supabase-origin", required=True)
     create_parser.add_argument("--artifact-bucket", required=True)
     create_parser.add_argument("--benchmark-date", required=True)
@@ -583,6 +594,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 source_secret_id=args.source_secret_id,
                 run_id=args.run_id,
                 candidate_sha=args.candidate_sha.lower(),
+                gateway_public_key=args.gateway_public_key,
                 supabase_origin=args.supabase_origin,
                 artifact_bucket=args.artifact_bucket,
                 benchmark_date=args.benchmark_date,

--- a/scripts/production_parity_acceptance_transfer.py
+++ b/scripts/production_parity_acceptance_transfer.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+"""Transfer one signed acceptance corpus into a disposable parity host."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import stat
+import sys
+import tarfile
+from typing import Any, Mapping, Sequence
+
+from gateway.tee.acceptance_corpus_v2 import (
+    load_and_validate_acceptance_corpus_v2,
+)
+from gateway.tee.release_manifest_v2 import validate_release_manifest
+from leadpoet_canonical.attested_v2 import sha256_json
+
+
+SCHEMA_VERSION = "leadpoet.production_parity_acceptance_transfer.v1"
+ARCHIVE_NAME = "acceptance-corpus-v2.tar"
+BINDING_NAME = "acceptance-corpus-v2-binding.json"
+HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+RUN_RE = re.compile(r"^[a-z0-9-]{6,40}$")
+BUCKET_RE = re.compile(r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$")
+MAX_ARCHIVE_BYTES = 16 * 1024 * 1024
+MAX_BINDING_BYTES = 16 * 1024
+MAX_MEMBER_BYTES = 4 * 1024 * 1024
+MAX_MEMBER_COUNT = 1024
+MAX_TOTAL_FILE_BYTES = 64 * 1024 * 1024
+
+
+class AcceptanceTransferError(RuntimeError):
+    """The signed acceptance corpus transfer is incomplete or conflicting."""
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _read_bounded_body(response: Mapping[str, Any], maximum: int) -> bytes:
+    stream = response.get("Body")
+    close = getattr(stream, "close", None)
+    try:
+        length = response.get("ContentLength")
+        if not isinstance(length, int) or not 0 < length <= maximum:
+            raise AcceptanceTransferError(
+                "acceptance transfer object size is invalid"
+            )
+        if stream is None or not callable(getattr(stream, "read", None)):
+            raise AcceptanceTransferError(
+                "acceptance transfer object body is invalid"
+            )
+        payload = stream.read(maximum + 1)
+    finally:
+        if callable(close):
+            close()
+    if not isinstance(payload, bytes) or len(payload) != length:
+        raise AcceptanceTransferError("acceptance transfer object body differs")
+    return payload
+
+
+def _write_exclusive(path: Path, payload: bytes, *, mode: int = 0o600) -> None:
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | os.O_CLOEXEC
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(path, flags, mode)
+    try:
+        view = memoryview(payload)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise AcceptanceTransferError("acceptance transfer write failed")
+            view = view[written:]
+        os.fchmod(descriptor, mode)
+        os.fsync(descriptor)
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+    finally:
+        os.close(descriptor)
+
+
+def _read_regular(
+    path: Path,
+    maximum: int,
+    *,
+    owner: tuple[int, int] | None = None,
+    mode: int = 0o600,
+) -> bytes:
+    try:
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | os.O_CLOEXEC | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except OSError as exc:
+        raise AcceptanceTransferError(
+            "acceptance transfer file is unavailable"
+        ) from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or stat.S_IMODE(metadata.st_mode) != mode
+            or not 0 < metadata.st_size <= maximum
+            or (
+                owner is not None
+                and (metadata.st_uid, metadata.st_gid) != owner
+            )
+        ):
+            raise AcceptanceTransferError("acceptance transfer file differs")
+        chunks: list[bytes] = []
+        observed = 0
+        while True:
+            chunk = os.read(descriptor, min(1024 * 1024, maximum + 1 - observed))
+            if not chunk:
+                break
+            observed += len(chunk)
+            if observed > maximum:
+                raise AcceptanceTransferError("acceptance transfer file is oversized")
+            chunks.append(chunk)
+        payload = b"".join(chunks)
+        if len(payload) != metadata.st_size:
+            raise AcceptanceTransferError("acceptance transfer file body differs")
+        return payload
+    finally:
+        os.close(descriptor)
+
+
+def _release_identity(
+    *,
+    candidate_sha: str,
+    candidate_release_manifest: Mapping[str, Any],
+) -> tuple[dict[str, Any], str]:
+    if SHA_RE.fullmatch(candidate_sha) is None:
+        raise AcceptanceTransferError("acceptance transfer candidate is invalid")
+    try:
+        release = validate_release_manifest(candidate_release_manifest)
+    except Exception as exc:
+        raise AcceptanceTransferError(
+            "acceptance release identity differs"
+        ) from exc
+    signer_hash = str(release.get("acceptance_signer_pubkey_hash") or "")
+    if (
+        release.get("commit_sha") != candidate_sha
+        or HASH_RE.fullmatch(str(release.get("release_hash") or "")) is None
+        or HASH_RE.fullmatch(signer_hash) is None
+    ):
+        raise AcceptanceTransferError("acceptance release identity differs")
+    return release, signer_hash
+
+
+def _declared_signer_hash(manifest: Path) -> str:
+    try:
+        payload = _read_regular(manifest, MAX_MEMBER_BYTES)
+        value = json.loads(payload.decode("ascii"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise AcceptanceTransferError(
+            "acceptance corpus signer identity differs"
+        ) from exc
+    public_key = (
+        str(value.get("signing_pubkey_hex") or "")
+        if isinstance(value, Mapping)
+        else ""
+    )
+    if re.fullmatch(r"[0-9a-f]{64}", public_key) is None:
+        raise AcceptanceTransferError(
+            "acceptance corpus signer identity differs"
+        )
+    return _sha256_bytes(bytes.fromhex(public_key))
+
+
+def _validated_tree(
+    config_dir: Path,
+    *,
+    signer_hash: str,
+) -> tuple[dict[str, Any], list[Path], list[Path], tuple[int, int]]:
+    root = Path(config_dir)
+    manifest = root / "acceptance-corpus-v2.json"
+    corpus = root / "acceptance-corpus-v2"
+    try:
+        root_metadata = root.lstat()
+        corpus_metadata = corpus.lstat()
+    except OSError as exc:
+        raise AcceptanceTransferError("acceptance corpus is unavailable") from exc
+    owner = (root_metadata.st_uid, root_metadata.st_gid)
+    if (
+        root.is_symlink()
+        or corpus.is_symlink()
+        or not stat.S_ISDIR(root_metadata.st_mode)
+        or not stat.S_ISDIR(corpus_metadata.st_mode)
+        or stat.S_IMODE(root_metadata.st_mode) != 0o700
+        or stat.S_IMODE(corpus_metadata.st_mode) != 0o700
+        or (corpus_metadata.st_uid, corpus_metadata.st_gid) != owner
+    ):
+        raise AcceptanceTransferError("acceptance corpus ownership differs")
+    manifest_payload = _read_regular(
+        manifest,
+        MAX_MEMBER_BYTES,
+        owner=owner,
+    )
+
+    directories: list[Path] = []
+    files: list[Path] = []
+    total_bytes = len(manifest_payload)
+    for current, names, filenames in os.walk(corpus, followlinks=False):
+        current_path = Path(current)
+        for name in sorted(names):
+            path = current_path / name
+            metadata = path.lstat()
+            if (
+                path.is_symlink()
+                or not stat.S_ISDIR(metadata.st_mode)
+                or stat.S_IMODE(metadata.st_mode) != 0o700
+                or (metadata.st_uid, metadata.st_gid) != owner
+            ):
+                raise AcceptanceTransferError(
+                    "acceptance corpus ownership differs"
+                )
+            directories.append(path)
+        for name in sorted(filenames):
+            path = current_path / name
+            metadata = path.lstat()
+            if (
+                path.is_symlink()
+                or not stat.S_ISREG(metadata.st_mode)
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+                or (metadata.st_uid, metadata.st_gid) != owner
+                or not 0 < metadata.st_size <= MAX_MEMBER_BYTES
+            ):
+                raise AcceptanceTransferError("acceptance corpus file differs")
+            total_bytes += metadata.st_size
+            files.append(path)
+    if (
+        not files
+        or len(directories) + len(files) + 2 > MAX_MEMBER_COUNT
+        or total_bytes > MAX_TOTAL_FILE_BYTES
+    ):
+        raise AcceptanceTransferError("acceptance corpus size differs")
+    try:
+        document = load_and_validate_acceptance_corpus_v2(
+            manifest,
+            corpus_root=corpus,
+            expected_signing_pubkey_hash=signer_hash,
+        )
+    except Exception as exc:
+        raise AcceptanceTransferError(
+            "acceptance corpus signature differs"
+        ) from exc
+    listed = {
+        PurePosixPath(str(item.get("artifact_path") or "")).as_posix()
+        for item in document.get("fixtures") or ()
+        if isinstance(item, Mapping)
+    }
+    discovered = {path.relative_to(corpus).as_posix() for path in files}
+    expected_directories = {
+        parent.as_posix()
+        for listed_file in listed
+        for parent in PurePosixPath(listed_file).parents
+        if parent != PurePosixPath(".")
+    }
+    discovered_directories = {
+        path.relative_to(corpus).as_posix() for path in directories
+    }
+    if (
+        not listed
+        or listed != discovered
+        or expected_directories != discovered_directories
+        or len(listed) != len(document.get("fixtures") or ())
+    ):
+        raise AcceptanceTransferError("acceptance corpus file set differs")
+    return document, directories, files, owner
+
+
+def _tar_info(name: str, *, directory: bool, size: int = 0) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name)
+    info.type = tarfile.DIRTYPE if directory else tarfile.REGTYPE
+    info.mode = 0o700 if directory else 0o600
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    info.mtime = 0
+    info.size = 0 if directory else size
+    return info
+
+
+def _secure_directory(path: Path, *, field: str) -> None:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise AcceptanceTransferError(f"{field} is unavailable") from exc
+    if (
+        path.is_symlink()
+        or not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+        or (metadata.st_uid, metadata.st_gid) != (os.getuid(), os.getgid())
+    ):
+        raise AcceptanceTransferError(f"{field} differs")
+
+
+def package_transfer(
+    *,
+    source_config_dir: Path,
+    candidate_sha: str,
+    archive_path: Path,
+    binding_path: Path,
+) -> dict[str, Any]:
+    if SHA_RE.fullmatch(candidate_sha) is None:
+        raise AcceptanceTransferError("acceptance transfer candidate is invalid")
+    source_root = Path(source_config_dir)
+    signer_hash = _declared_signer_hash(
+        source_root / "acceptance-corpus-v2.json"
+    )
+    document, directories, files, owner = _validated_tree(
+        source_root,
+        signer_hash=signer_hash,
+    )
+    corpus_root = source_root / "acceptance-corpus-v2"
+    manifest = source_root / "acceptance-corpus-v2.json"
+    if (
+        archive_path.parent != binding_path.parent
+        or archive_path.exists()
+        or binding_path.exists()
+    ):
+        raise AcceptanceTransferError("acceptance transfer output differs")
+    _secure_directory(
+        archive_path.parent,
+        field="acceptance transfer output root",
+    )
+    descriptor = os.open(
+        archive_path,
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | os.O_CLOEXEC
+        | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            with tarfile.open(fileobj=handle, mode="w") as archive:
+                manifest_payload = _read_regular(
+                    manifest,
+                    MAX_MEMBER_BYTES,
+                    owner=owner,
+                )
+                archive.addfile(
+                    _tar_info(
+                        "acceptance-corpus-v2.json",
+                        directory=False,
+                        size=len(manifest_payload),
+                    ),
+                    io.BytesIO(manifest_payload),
+                )
+                archive.addfile(
+                    _tar_info("acceptance-corpus-v2", directory=True)
+                )
+                for directory in sorted(directories):
+                    archive.addfile(
+                        _tar_info(
+                            "acceptance-corpus-v2/"
+                            + directory.relative_to(corpus_root).as_posix(),
+                            directory=True,
+                        )
+                    )
+                for source in sorted(files):
+                    payload = _read_regular(
+                        source,
+                        MAX_MEMBER_BYTES,
+                        owner=owner,
+                    )
+                    archive.addfile(
+                        _tar_info(
+                            "acceptance-corpus-v2/"
+                            + source.relative_to(corpus_root).as_posix(),
+                            directory=False,
+                            size=len(payload),
+                        ),
+                        io.BytesIO(payload),
+                    )
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        archive_path.unlink(missing_ok=True)
+        raise
+    archive_payload = _read_regular(archive_path, MAX_ARCHIVE_BYTES)
+    body = {
+        "schema_version": SCHEMA_VERSION,
+        "candidate_sha": candidate_sha,
+        "manifest_hash": document["manifest_hash"],
+        "fixture_count": len(files),
+        "archive_sha256": _sha256_bytes(archive_payload),
+        "archive_size_bytes": len(archive_payload),
+    }
+    binding = {**body, "binding_hash": sha256_json(body)}
+    binding_payload = (
+        json.dumps(binding, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("ascii")
+    try:
+        _write_exclusive(binding_path, binding_payload)
+    except BaseException:
+        archive_path.unlink(missing_ok=True)
+        raise
+    return binding
+
+
+def _validated_binding(payload: bytes, *, candidate_sha: str) -> dict[str, Any]:
+    if not 0 < len(payload) <= MAX_BINDING_BYTES:
+        raise AcceptanceTransferError("acceptance transfer binding size differs")
+    try:
+        value = json.loads(payload.decode("ascii"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise AcceptanceTransferError(
+            "acceptance transfer binding is invalid"
+        ) from exc
+    fields = {
+        "schema_version",
+        "candidate_sha",
+        "manifest_hash",
+        "fixture_count",
+        "archive_sha256",
+        "archive_size_bytes",
+        "binding_hash",
+    }
+    if not isinstance(value, dict) or set(value) != fields:
+        raise AcceptanceTransferError("acceptance transfer binding fields differ")
+    body = {key: value[key] for key in fields if key != "binding_hash"}
+    if (
+        value.get("schema_version") != SCHEMA_VERSION
+        or value.get("candidate_sha") != candidate_sha
+        or HASH_RE.fullmatch(str(value.get("manifest_hash") or "")) is None
+        or HASH_RE.fullmatch(str(value.get("archive_sha256") or "")) is None
+        or not isinstance(value.get("fixture_count"), int)
+        or not 0 < value["fixture_count"] < MAX_MEMBER_COUNT
+        or not isinstance(value.get("archive_size_bytes"), int)
+        or not 0 < value["archive_size_bytes"] <= MAX_ARCHIVE_BYTES
+        or value.get("binding_hash") != sha256_json(body)
+    ):
+        raise AcceptanceTransferError("acceptance transfer binding differs")
+    return value
+
+
+def unpack_transfer(
+    *,
+    archive_payload: bytes,
+    binding_payload: bytes,
+    candidate_sha: str,
+    destination_config_dir: Path,
+    candidate_release_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    binding = _validated_binding(binding_payload, candidate_sha=candidate_sha)
+    if (
+        len(archive_payload) != binding["archive_size_bytes"]
+        or _sha256_bytes(archive_payload) != binding["archive_sha256"]
+    ):
+        raise AcceptanceTransferError("acceptance transfer archive differs")
+    release, signer_hash = _release_identity(
+        candidate_sha=candidate_sha,
+        candidate_release_manifest=candidate_release_manifest,
+    )
+    destination = Path(destination_config_dir)
+    if destination.exists() or destination.is_symlink():
+        raise AcceptanceTransferError("acceptance transfer destination exists")
+    members: list[tuple[tarfile.TarInfo, bytes | None]] = []
+    total_bytes = 0
+    try:
+        with tarfile.open(fileobj=io.BytesIO(archive_payload), mode="r:") as archive:
+            for member in archive.getmembers():
+                path = PurePosixPath(member.name)
+                is_manifest = path.parts == ("acceptance-corpus-v2.json",)
+                is_corpus_root = path.parts == ("acceptance-corpus-v2",)
+                is_corpus_member = (
+                    len(path.parts) > 1
+                    and path.parts[0] == "acceptance-corpus-v2"
+                )
+                if (
+                    path.is_absolute()
+                    or ".." in path.parts
+                    or not path.parts
+                    or path.as_posix() != member.name
+                    or not (is_manifest or is_corpus_root or is_corpus_member)
+                    or (is_manifest and not member.isfile())
+                    or (is_corpus_root and not member.isdir())
+                    or member.uid != 0
+                    or member.gid != 0
+                    or member.mtime != 0
+                ):
+                    raise AcceptanceTransferError(
+                        "acceptance transfer member differs"
+                    )
+                if member.isdir():
+                    if member.mode != 0o700 or member.size != 0:
+                        raise AcceptanceTransferError(
+                            "acceptance directory member differs"
+                        )
+                    payload = None
+                elif member.isfile():
+                    if (
+                        member.mode != 0o600
+                        or not 0 < member.size <= MAX_MEMBER_BYTES
+                    ):
+                        raise AcceptanceTransferError(
+                            "acceptance file member differs"
+                        )
+                    extracted = archive.extractfile(member)
+                    payload = (
+                        extracted.read(MAX_MEMBER_BYTES + 1)
+                        if extracted is not None
+                        else b""
+                    )
+                    if len(payload) != member.size:
+                        raise AcceptanceTransferError(
+                            "acceptance file member body differs"
+                        )
+                    total_bytes += len(payload)
+                else:
+                    raise AcceptanceTransferError(
+                        "acceptance transfer member type differs"
+                    )
+                members.append((member, payload))
+    except (tarfile.TarError, OSError) as exc:
+        raise AcceptanceTransferError(
+            "acceptance transfer archive is invalid"
+        ) from exc
+    names = [member.name for member, _ in members]
+    directory_names = {
+        member.name for member, _ in members if member.isdir()
+    }
+    expected_order = [
+        "acceptance-corpus-v2.json",
+        "acceptance-corpus-v2",
+        *sorted(directory_names - {"acceptance-corpus-v2"}),
+        *sorted(
+            member.name
+            for member, _ in members
+            if member.isfile()
+            and member.name != "acceptance-corpus-v2.json"
+        ),
+    ]
+    parents_are_explicit = all(
+        PurePosixPath(name).parent.as_posix() in directory_names
+        for name in names
+        if name
+        not in {"acceptance-corpus-v2.json", "acceptance-corpus-v2"}
+    )
+    if (
+        len(names) != len(set(names))
+        or not 2 < len(names) <= MAX_MEMBER_COUNT
+        or names.count("acceptance-corpus-v2.json") != 1
+        or names.count("acceptance-corpus-v2") != 1
+        or names != expected_order
+        or not parents_are_explicit
+        or total_bytes > MAX_TOTAL_FILE_BYTES
+    ):
+        raise AcceptanceTransferError("acceptance transfer member set differs")
+    _secure_directory(
+        destination.parent,
+        field="acceptance transfer destination root",
+    )
+    try:
+        destination.mkdir(mode=0o700)
+        for member, payload in sorted(
+            members,
+            key=lambda item: (
+                0 if item[0].isdir() else 1,
+                len(PurePosixPath(item[0].name).parts),
+                item[0].name,
+            ),
+        ):
+            target = destination.joinpath(*PurePosixPath(member.name).parts)
+            if member.isdir():
+                target.mkdir(mode=0o700)
+            else:
+                if not target.parent.is_dir() or target.parent.is_symlink():
+                    raise AcceptanceTransferError(
+                        "acceptance transfer member parent differs"
+                    )
+                _write_exclusive(target, payload or b"")
+        document, _directories, files, _owner = _validated_tree(
+            destination,
+            signer_hash=signer_hash,
+        )
+        if (
+            document["manifest_hash"] != binding["manifest_hash"]
+            or len(files) != binding["fixture_count"]
+        ):
+            raise AcceptanceTransferError(
+                "acceptance transfer content differs"
+            )
+    except BaseException:
+        shutil.rmtree(destination, ignore_errors=True)
+        raise
+    return {
+        **binding,
+        "release_hash": release["release_hash"],
+        "copied_exact": True,
+    }
+
+
+def fetch_and_unpack_transfer(
+    *,
+    s3_client: Any,
+    artifact_bucket: str,
+    run_id: str,
+    candidate_sha: str,
+    destination_config_dir: Path,
+    candidate_release_manifest: Mapping[str, Any],
+) -> dict[str, Any]:
+    if (
+        BUCKET_RE.fullmatch(artifact_bucket) is None
+        or RUN_RE.fullmatch(run_id) is None
+        or SHA_RE.fullmatch(candidate_sha) is None
+    ):
+        raise AcceptanceTransferError(
+            "acceptance transfer source identity differs"
+        )
+    prefix = f"production-parity/runs/{run_id}"
+    archive_payload = _read_bounded_body(
+        s3_client.get_object(
+            Bucket=artifact_bucket,
+            Key=f"{prefix}/{ARCHIVE_NAME}",
+        ),
+        MAX_ARCHIVE_BYTES,
+    )
+    binding_payload = _read_bounded_body(
+        s3_client.get_object(
+            Bucket=artifact_bucket,
+            Key=f"{prefix}/{BINDING_NAME}",
+        ),
+        MAX_BINDING_BYTES,
+    )
+    return unpack_transfer(
+        archive_payload=archive_payload,
+        binding_payload=binding_payload,
+        candidate_sha=candidate_sha,
+        destination_config_dir=destination_config_dir,
+        candidate_release_manifest=candidate_release_manifest,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument("--source-config-dir", type=Path, required=True)
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument("--binding", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        result = package_transfer(
+            source_config_dir=args.source_config_dir,
+            candidate_sha=args.candidate_sha.lower(),
+            archive_path=args.archive,
+            binding_path=args.binding,
+        )
+    except (OSError, ValueError, AcceptanceTransferError):
+        print(
+            "ERROR: acceptance corpus transfer packaging failed",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        json.dumps(
+            {
+                key: result[key]
+                for key in (
+                    "candidate_sha",
+                    "manifest_hash",
+                    "fixture_count",
+                    "archive_sha256",
+                    "archive_size_bytes",
+                    "binding_hash",
+                )
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_production_parity_full_host.py
+++ b/scripts/run_production_parity_full_host.py
@@ -37,6 +37,9 @@ from urllib.request import (
 )
 
 import boto3
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -65,6 +68,10 @@ from scripts.materialize_production_parity_secrets import (  # noqa: E402
 from scripts.production_parity_snapshot import (  # noqa: E402
     capture_snapshot,
     restore_snapshot,
+)
+from scripts.production_parity_acceptance_transfer import (  # noqa: E402
+    AcceptanceTransferError,
+    fetch_and_unpack_transfer,
 )
 from scripts.run_production_parity_fast import _DockerDatabase  # noqa: E402
 from gateway.tee.acceptance_corpus_v2 import (  # noqa: E402
@@ -109,20 +116,6 @@ EARLY_BOOT_MARKER = Path(
     "/run/leadpoet-production-parity/early-boot-isolated"
 )
 FULL_WORK_ROOT = Path("/opt/leadpoet-production-parity")
-PRODUCTION_V2_CONFIG_DIR = Path("/home/ec2-user/.config/leadpoet/v2")
-PRODUCTION_GATEWAY_PRIVATE_KEY_PATH = Path(
-    "/home/ec2-user/gateway/secrets/gateway_private_key.pem"
-)
-PRODUCTION_ARWEAVE_KEYFILE_PATH = Path(
-    "/home/ec2-user/gateway/secrets/arweave_keyfile.json"
-)
-PRODUCTION_PRIVATE_MODEL_DEPLOY_KEY_PATH = Path(
-    "/home/ec2-user/.ssh/research_lab_private_model_deploy"
-)
-PRODUCTION_PRIVATE_MODEL_KNOWN_HOSTS_PATH = Path(
-    "/home/ec2-user/.ssh/known_hosts"
-)
-PRODUCTION_GATEWAY_PRIVATE_KEY_OWNER = (1000, 1000)
 ATTESTED_V2_RELEASE_BUCKET = "leadpoet-attested-v2-artifacts-493765492819"
 ATTESTED_V2_RELEASE_PREFIX = "attested-v2/releases"
 ATTESTED_V2_KMS_KEY_ID = (
@@ -142,9 +135,7 @@ FULL_FAILURE_STAGES = frozenset(
         "public-origin",
         "checkout-identity",
         "early-boot-isolation",
-        "gateway-key-identity",
-        "arweave-key-identity",
-        "private-model-ssh-identity",
+        "runtime-identity",
         "work-root",
         "runtime-config-capture",
         "parity-contract",
@@ -154,6 +145,7 @@ FULL_FAILURE_STAGES = frozenset(
         "snapshot-restore",
         "clone-http-origin",
         "clone-secret",
+        "acceptance-transfer",
         "acceptance-corpus",
         "gateway-restart",
         "gateway-health",
@@ -173,6 +165,7 @@ FULL_ERROR_TYPES = frozenset(
     {
         "BotoCoreError",
         "AcceptanceCorpusV2Error",
+        "AcceptanceTransferError",
         "CalledProcessError",
         "ClientError",
         "CleanupError",
@@ -994,56 +987,131 @@ def _validated_clone_environment(
     return values
 
 
-def _validated_baked_secret_path(path: Path, *, field: str) -> str:
-    """Return an AMI-baked secret path without reading its contents."""
-
+def _write_run_owned_secret(path: Path, payload: bytes, *, field: str) -> str:
+    if not payload:
+        raise FullParityError(f"run-owned {field} payload is empty")
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | os.O_CLOEXEC
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(path, flags, 0o600)
     try:
-        metadata = path.lstat()
-        resolved = path.resolve(strict=True)
-    except OSError as exc:
-        raise FullParityError(f"baked {field} path is unavailable") from exc
+        view = memoryview(payload)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise FullParityError(f"run-owned {field} write failed")
+            view = view[written:]
+        os.fchmod(descriptor, 0o600)
+        os.fsync(descriptor)
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+    finally:
+        os.close(descriptor)
+    metadata = path.lstat()
     if (
-        resolved != path
-        or path.is_symlink()
+        path.is_symlink()
+        or path.resolve(strict=True) != path
         or not stat.S_ISREG(metadata.st_mode)
-        or metadata.st_size <= 0
+        or metadata.st_size != len(payload)
         or stat.S_IMODE(metadata.st_mode) != 0o600
-        or (metadata.st_uid, metadata.st_gid)
-        != PRODUCTION_GATEWAY_PRIVATE_KEY_OWNER
+        or (metadata.st_uid, metadata.st_gid) != (os.getuid(), os.getgid())
     ):
-        raise FullParityError(f"baked {field} path identity differs")
+        raise FullParityError(f"run-owned {field} identity differs")
     return str(path)
 
 
-def _validated_baked_gateway_private_key_path() -> str:
-    return _validated_baked_secret_path(
-        PRODUCTION_GATEWAY_PRIVATE_KEY_PATH,
+def _b64url_uint(value: int) -> str:
+    if not isinstance(value, int) or value < 0:
+        raise FullParityError("run-owned RSA identity is invalid")
+    width = max(1, (value.bit_length() + 7) // 8)
+    return base64.urlsafe_b64encode(value.to_bytes(width, "big")).decode(
+        "ascii"
+    ).rstrip("=")
+
+
+def _materialize_run_owned_runtime_identity(identity_dir: Path) -> dict[str, str]:
+    """Create non-production signing material for the non-forwarding clone."""
+
+    try:
+        identity_dir.mkdir(mode=0o700)
+    except OSError as exc:
+        raise FullParityError(
+            "run-owned runtime identity directory is unavailable"
+        ) from exc
+    directory_metadata = identity_dir.lstat()
+    if (
+        identity_dir.is_symlink()
+        or not stat.S_ISDIR(directory_metadata.st_mode)
+        or stat.S_IMODE(directory_metadata.st_mode) != 0o700
+        or (directory_metadata.st_uid, directory_metadata.st_gid)
+        != (os.getuid(), os.getgid())
+    ):
+        raise FullParityError("run-owned runtime identity directory differs")
+
+    gateway_key = Ed25519PrivateKey.generate()
+    gateway_private_key = gateway_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    gateway_public_key = gateway_key.public_key().public_bytes(
+        serialization.Encoding.Raw,
+        serialization.PublicFormat.Raw,
+    ).hex()
+    gateway_private_key_path = _write_run_owned_secret(
+        identity_dir / "gateway_private_key.pem",
+        gateway_private_key,
         field="gateway private-key",
     )
 
-
-def _validated_baked_arweave_keyfile_path() -> str:
-    return _validated_baked_secret_path(
-        PRODUCTION_ARWEAVE_KEYFILE_PATH,
+    arweave_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=4096,
+    )
+    numbers = arweave_key.private_numbers()
+    public_numbers = numbers.public_numbers
+    arweave_jwk = {
+        "d": _b64url_uint(numbers.d),
+        "dp": _b64url_uint(numbers.dmp1),
+        "dq": _b64url_uint(numbers.dmq1),
+        "e": _b64url_uint(public_numbers.e),
+        "kty": "RSA",
+        "n": _b64url_uint(public_numbers.n),
+        "p": _b64url_uint(numbers.p),
+        "q": _b64url_uint(numbers.q),
+        "qi": _b64url_uint(numbers.iqmp),
+    }
+    arweave_payload = (
+        json.dumps(arweave_jwk, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("ascii")
+    arweave_keyfile_path = _write_run_owned_secret(
+        identity_dir / "arweave_keyfile.json",
+        arweave_payload,
         field="Arweave keyfile",
     )
+    try:
+        from arweave.arweave_lib import Wallet
 
+        arweave_address = str(Wallet(arweave_keyfile_path).address or "")
+    except Exception as exc:
+        raise FullParityError("run-owned Arweave identity is invalid") from exc
+    if not re.fullmatch(r"[A-Za-z0-9_-]{43}", arweave_address):
+        raise FullParityError("run-owned Arweave identity is invalid")
 
-def _validated_baked_private_model_ssh_command() -> str:
-    deploy_key = _validated_baked_secret_path(
-        PRODUCTION_PRIVATE_MODEL_DEPLOY_KEY_PATH,
-        field="private-model deploy key",
-    )
-    known_hosts = _validated_baked_secret_path(
-        PRODUCTION_PRIVATE_MODEL_KNOWN_HOSTS_PATH,
-        field="private-model known-hosts",
-    )
-    return (
-        f"ssh -i {deploy_key} -o IdentitiesOnly=yes -o BatchMode=yes "
-        "-o StrictHostKeyChecking=yes "
-        f"-o UserKnownHostsFile={known_hosts} "
-        "-o GlobalKnownHostsFile=/dev/null"
-    )
+    return {
+        "gateway_private_key_path": gateway_private_key_path,
+        "gateway_public_key": gateway_public_key,
+        "gateway_public_key_hash": "sha256:"
+        + hashlib.sha256(bytes.fromhex(gateway_public_key)).hexdigest(),
+        "arweave_keyfile_path": arweave_keyfile_path,
+        "arweave_address_hash": "sha256:"
+        + hashlib.sha256(arweave_address.encode("ascii")).hexdigest(),
+    }
 
 
 @contextmanager
@@ -2568,17 +2636,26 @@ def run_full(
             raise FullParityError(
                 "transient host early production-service isolation differs"
             )
-        failure_stage = "gateway-key-identity"
-        gateway_private_key_path = _validated_baked_gateway_private_key_path()
-        failure_stage = "arweave-key-identity"
-        arweave_keyfile_path = _validated_baked_arweave_keyfile_path()
-        failure_stage = "private-model-ssh-identity"
-        private_model_git_ssh_command = (
-            _validated_baked_private_model_ssh_command()
-        )
         failure_stage = "work-root"
         work.mkdir(parents=True, mode=0o700, exist_ok=False)
         scoring_cache.mkdir(mode=0o700)
+        failure_stage = "runtime-identity"
+        runtime_identity = _materialize_run_owned_runtime_identity(
+            work / "runtime-identity"
+        )
+        gateway_private_key_path = runtime_identity["gateway_private_key_path"]
+        arweave_keyfile_path = runtime_identity["arweave_keyfile_path"]
+        evidence["runtime_identity"] = {
+            "gateway": "run-scoped-ephemeral",
+            "gateway_public_key_hash": runtime_identity[
+                "gateway_public_key_hash"
+            ],
+            "arweave": "run-scoped-ephemeral-write-blocked",
+            "arweave_address_hash": runtime_identity[
+                "arweave_address_hash"
+            ],
+            "private_model_source": "signed-immutable-artifact",
+        }
         secrets_client = boto3.client("secretsmanager", region_name=region)
         database = _DockerDatabase(
             candidate_sha=candidate_sha,
@@ -2674,6 +2751,7 @@ def run_full(
             source_secret_id=production_gateway_secret_id,
             run_id=run_id,
             candidate_sha=candidate_sha,
+            gateway_public_key=runtime_identity["gateway_public_key"],
             supabase_origin=supabase_origin,
             artifact_bucket=artifact_bucket,
             benchmark_date=manifest["database"]["target_rebenchmark_date"],
@@ -2698,21 +2776,55 @@ def run_full(
             encoding="utf-8",
         )
         artifact_policy.chmod(0o600)
-        failure_stage = "acceptance-corpus"
+        candidate_s3 = boto3.client("s3", region_name=region)
+        failure_stage = "acceptance-transfer"
         release_channel = fetch_release_channel_v2(
             bucket=ATTESTED_V2_RELEASE_BUCKET,
             commit_sha=candidate_sha,
             prefix=ATTESTED_V2_RELEASE_PREFIX,
-            s3_client=boto3.client("s3", region_name=region),
+            s3_client=candidate_s3,
         )
+        transferred_config = work / "transferred-v2-config"
+        acceptance_transfer = fetch_and_unpack_transfer(
+            s3_client=candidate_s3,
+            artifact_bucket=artifact_bucket,
+            run_id=run_id,
+            candidate_sha=candidate_sha,
+            destination_config_dir=transferred_config,
+            candidate_release_manifest=release_channel[
+                "gateway_release_manifest"
+            ],
+        )
+        failure_stage = "acceptance-corpus"
         acceptance_corpus = _materialize_acceptance_corpus(
-            source_config_dir=PRODUCTION_V2_CONFIG_DIR,
+            source_config_dir=transferred_config,
             destination_config_dir=artifact_policy.parent,
             candidate_sha=candidate_sha,
             candidate_release_manifest=release_channel[
                 "gateway_release_manifest"
             ],
         )
+        compared_fields = (
+            "candidate_sha",
+            "release_hash",
+            "manifest_hash",
+            "fixture_count",
+        )
+        if any(
+            acceptance_transfer.get(field) != acceptance_corpus.get(field)
+            for field in compared_fields
+        ):
+            raise FullParityError(
+                "transferred acceptance corpus identity differs"
+            )
+        acceptance_corpus["transfer"] = {
+            "archive_sha256": acceptance_transfer["archive_sha256"],
+            "archive_size_bytes": acceptance_transfer["archive_size_bytes"],
+            "binding_hash": acceptance_transfer["binding_hash"],
+            "source": "run-scoped-object-lock",
+            "validated_exact": acceptance_transfer.get("copied_exact") is True,
+        }
+        shutil.rmtree(transferred_config)
         env = _full_restart_environment(
             region=region,
             updates={
@@ -2724,9 +2836,6 @@ def run_full(
                 "GATEWAY_LOG_FILE": str(work / "gateway" / "gateway.log"),
                 "GATEWAY_PRIVATE_KEY_PATH": gateway_private_key_path,
                 "ARWEAVE_KEYFILE_PATH": arweave_keyfile_path,
-                "GATEWAY_RESTART_GIT_SSH_COMMAND": (
-                    private_model_git_ssh_command
-                ),
                 "GATEWAY_RESTART_CONTROLLER_ROOT": str(work / "restart-controller"),
                 "GATEWAY_DEPLOYMENT_DIR": str(work / "deployments"),
                 "GATEWAY_HOST_RESTART_SCRIPT": str(ROOT / "gw_restart.sh"),
@@ -2743,7 +2852,7 @@ def run_full(
                 "GATEWAY_RESTART_LOCK_FILE": str(work / "gateway-restart.lock"),
                 "LEADPOET_DOCKER_OPERATION_LOCK_FILE": str(work / "docker-operation.lock"),
                 "GATEWAY_DEPLOY_COMMIT": candidate_sha,
-                "GATEWAY_PYTHON_BIN": "/home/ec2-user/venv311/bin/python3",
+                "GATEWAY_PYTHON_BIN": sys.executable,
                 "GATEWAY_V2_RELEASE_BUCKET": ATTESTED_V2_RELEASE_BUCKET,
                 "GATEWAY_V2_RELEASE_PREFIX": ATTESTED_V2_RELEASE_PREFIX,
                 "GATEWAY_V2_KMS_KEY_ID": ATTESTED_V2_KMS_KEY_ID,
@@ -2806,7 +2915,7 @@ def run_full(
         failure_stage = "weight-readiness"
         readiness = _run(
             [
-                "/home/ec2-user/venv311/bin/python3",
+                sys.executable,
                 "-m",
                 "gateway.tee.verify_weight_submission_ready_v2",
                 "--gateway-url",

--- a/tests/test_physical_v2_staging.py
+++ b/tests/test_physical_v2_staging.py
@@ -954,6 +954,17 @@ def test_full_workflow_uses_exact_candidate_and_tears_down_without_testnet():
     assert 'get("acceptance_corpus", {}).get("copied_exact") is not True' in source
     assert 'get("acceptance_corpus", {}).get("candidate_sha")' in source
     assert 'get("acceptance_corpus", {}).get("fixture_count", 0) <= 0' in source
+    transfer = source.index(
+        "python3 scripts/production_parity_acceptance_transfer.py"
+    )
+    execute = source.index(
+        '"$host_python" scripts/run_production_parity_full_host.py'
+    )
+    assert transfer < execute
+    assert "/home/ec2-user/.config/leadpoet/v2" in source
+    assert "acceptance-corpus-v2-binding.json" in source
+    assert '"validated_exact"' in source
+    assert '"run-scoped-object-lock"' in source
     assert 'get("external_write_boundaries", {}).get("arweave")' in source
     assert '!= "blocked-production-parity"' in source
 

--- a/tests/test_production_parity.py
+++ b/tests/test_production_parity.py
@@ -82,6 +82,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SHA = "a" * 40
 HASH = "sha256:" + "b" * 64
 ORIGIN = "https://d111111abcdef8.cloudfront.net"
+PARITY_GATEWAY_PUBLIC_KEY = "c" * 64
 
 
 def test_setup_targets_the_authoritative_github_repository():
@@ -1448,6 +1449,9 @@ def test_full_acceptance_corpus_fails_before_restart(
     assert not (destination_config / "acceptance-corpus-v2").exists()
 
     source = inspect.getsource(full_host.run_full)
+    assert source.index("fetch_and_unpack_transfer(") < source.index(
+        "_materialize_acceptance_corpus("
+    )
     assert source.index("_materialize_acceptance_corpus(") < source.index(
         '["bash", str(ROOT / "gw_restart.sh"), "--commit", candidate_sha]'
     )
@@ -1730,18 +1734,14 @@ def test_full_runner_forwards_remaining_clone_budget_and_cleans_runtime(
     monkeypatch.setattr(full_host, "FULL_WORK_ROOT", work_root)
     monkeypatch.setattr(
         full_host,
-        "_validated_baked_gateway_private_key_path",
-        lambda: "/home/ec2-user/gateway/secrets/gateway_private_key.pem",
-    )
-    monkeypatch.setattr(
-        full_host,
-        "_validated_baked_arweave_keyfile_path",
-        lambda: "/home/ec2-user/gateway/secrets/arweave_keyfile.json",
-    )
-    monkeypatch.setattr(
-        full_host,
-        "_validated_baked_private_model_ssh_command",
-        lambda: "ssh -i /home/ec2-user/.ssh/research_lab_private_model_deploy",
+        "_materialize_run_owned_runtime_identity",
+        lambda _path: {
+            "gateway_private_key_path": "/run/parity/gateway-private.pem",
+            "gateway_public_key": PARITY_GATEWAY_PUBLIC_KEY,
+            "gateway_public_key_hash": "sha256:" + "1" * 64,
+            "arweave_keyfile_path": "/run/parity/arweave.json",
+            "arweave_address_hash": "sha256:" + "2" * 64,
+        },
     )
     monkeypatch.setattr(full_host, "_checkout_identity", lambda _sha: None)
     monkeypatch.setattr(full_host.time, "monotonic", lambda: next(monotonic_values))
@@ -1814,18 +1814,8 @@ def test_full_runner_retains_exact_bounded_initialization_stage(
     monkeypatch.setattr(full_host, "_checkout_identity", lambda _sha: None)
     monkeypatch.setattr(
         full_host,
-        "_validated_baked_gateway_private_key_path",
-        lambda: "/home/ec2-user/gateway/secrets/gateway_private_key.pem",
-    )
-    monkeypatch.setattr(
-        full_host,
-        "_validated_baked_arweave_keyfile_path",
-        lambda: "/home/ec2-user/gateway/secrets/arweave_keyfile.json",
-    )
-    monkeypatch.setattr(
-        full_host,
-        "_validated_baked_private_model_ssh_command",
-        lambda: (_ for _ in ()).throw(FullParityError(secret)),
+        "_materialize_run_owned_runtime_identity",
+        lambda _path: (_ for _ in ()).throw(FullParityError(secret)),
     )
 
     with pytest.raises(FullParityError, match=secret):
@@ -1848,9 +1838,9 @@ def test_full_runner_retains_exact_bounded_initialization_stage(
     encoded = output.read_text(encoding="utf-8")
     evidence = json.loads(encoded)
     assert evidence["status"] == "failed"
-    assert evidence["failure_stage"] == "private-model-ssh-identity"
+    assert evidence["failure_stage"] == "runtime-identity"
     assert evidence["error_type"] == "FullParityError"
-    assert evidence["cleanup"] == {"work": "already_absent"}
+    assert evidence["cleanup"] == {"work": "removed"}
     assert secret not in encoded
 
 
@@ -3600,6 +3590,7 @@ def test_gateway_secret_keeps_real_reads_but_isolates_every_mutation():
         },
         run_id="pp-1-1",
         candidate_sha=SHA,
+        gateway_public_key=PARITY_GATEWAY_PUBLIC_KEY,
         supabase_origin=ORIGIN,
         artifact_bucket=artifact_bucket,
         benchmark_date="2026-08-16",
@@ -3708,6 +3699,7 @@ def test_full_clone_environment_rejects_tampered_trace_destination(
         {},
         run_id=run_id,
         candidate_sha=SHA,
+        gateway_public_key=PARITY_GATEWAY_PUBLIC_KEY,
         supabase_origin=ORIGIN,
         artifact_bucket=artifact_bucket,
         benchmark_date="2026-08-19",
@@ -3812,92 +3804,40 @@ def test_full_clone_environment_rejects_tampered_trace_destination(
             )
 
 
-def test_full_baked_gateway_private_key_path_is_exact_and_metadata_only(
-    monkeypatch, tmp_path: Path
-):
-    private_key_path = tmp_path / "gateway_private_key.pem"
-    private_key_path.write_bytes(b"not-read-by-validator")
-    private_key_path.chmod(0o600)
-    monkeypatch.setattr(
-        full_host, "PRODUCTION_GATEWAY_PRIVATE_KEY_PATH", private_key_path
-    )
-    monkeypatch.setattr(
-        full_host,
-        "PRODUCTION_GATEWAY_PRIVATE_KEY_OWNER",
-        (os.getuid(), os.getgid()),
-    )
-    assert full_host._validated_baked_gateway_private_key_path() == str(
-        private_key_path
-    )
+def test_full_runtime_identity_is_run_owned_and_non_production(tmp_path: Path):
+    identity_dir = tmp_path / "runtime-identity"
+    identity = full_host._materialize_run_owned_runtime_identity(identity_dir)
 
-    private_key_path.chmod(0o640)
-    with pytest.raises(FullParityError, match="private-key path identity differs"):
-        full_host._validated_baked_gateway_private_key_path()
-
-    private_key_path.chmod(0o600)
-    symlink_path = tmp_path / "gateway-private-key-link.pem"
-    symlink_path.symlink_to(private_key_path)
-    monkeypatch.setattr(
-        full_host, "PRODUCTION_GATEWAY_PRIVATE_KEY_PATH", symlink_path
-    )
-    with pytest.raises(FullParityError, match="private-key path identity differs"):
-        full_host._validated_baked_gateway_private_key_path()
+    assert set(identity) == {
+        "gateway_private_key_path",
+        "gateway_public_key",
+        "gateway_public_key_hash",
+        "arweave_keyfile_path",
+        "arweave_address_hash",
+    }
+    assert re.fullmatch(r"[0-9a-f]{64}", identity["gateway_public_key"])
+    for field in ("gateway_public_key_hash", "arweave_address_hash"):
+        assert re.fullmatch(r"sha256:[0-9a-f]{64}", identity[field])
+    for field in ("gateway_private_key_path", "arweave_keyfile_path"):
+        path = Path(identity[field])
+        metadata = path.lstat()
+        assert path.parent == identity_dir
+        assert path.is_file()
+        assert not path.is_symlink()
+        assert metadata.st_size > 0
+        assert metadata.st_uid == os.getuid()
+        assert metadata.st_gid == os.getgid()
+        assert metadata.st_mode & 0o777 == 0o600
 
 
-def test_full_baked_arweave_keyfile_path_is_exact_and_metadata_only(
-    monkeypatch, tmp_path: Path
-):
-    keyfile_path = tmp_path / "arweave_keyfile.json"
-    keyfile_path.write_bytes(b"not-read-by-validator")
-    keyfile_path.chmod(0o600)
-    monkeypatch.setattr(
-        full_host, "PRODUCTION_ARWEAVE_KEYFILE_PATH", keyfile_path
-    )
-    monkeypatch.setattr(
-        full_host,
-        "PRODUCTION_GATEWAY_PRIVATE_KEY_OWNER",
-        (os.getuid(), os.getgid()),
-    )
-    assert full_host._validated_baked_arweave_keyfile_path() == str(
-        keyfile_path
-    )
-
-    keyfile_path.chmod(0o640)
-    with pytest.raises(FullParityError, match="Arweave keyfile path identity"):
-        full_host._validated_baked_arweave_keyfile_path()
-
-
-def test_full_baked_private_model_ssh_command_is_exact_and_metadata_only(
-    monkeypatch, tmp_path: Path
-):
-    deploy_key = tmp_path / "research_lab_private_model_deploy"
-    known_hosts = tmp_path / "known_hosts"
-    for path in (deploy_key, known_hosts):
-        path.write_bytes(b"not-read-by-validator")
-        path.chmod(0o600)
-    monkeypatch.setattr(
-        full_host, "PRODUCTION_PRIVATE_MODEL_DEPLOY_KEY_PATH", deploy_key
-    )
-    monkeypatch.setattr(
-        full_host, "PRODUCTION_PRIVATE_MODEL_KNOWN_HOSTS_PATH", known_hosts
-    )
-    monkeypatch.setattr(
-        full_host,
-        "PRODUCTION_GATEWAY_PRIVATE_KEY_OWNER",
-        (os.getuid(), os.getgid()),
-    )
-    assert full_host._validated_baked_private_model_ssh_command() == (
-        f"ssh -i {deploy_key} -o IdentitiesOnly=yes -o BatchMode=yes "
-        "-o StrictHostKeyChecking=yes "
-        f"-o UserKnownHostsFile={known_hosts} "
-        "-o GlobalKnownHostsFile=/dev/null"
-    )
-
-    known_hosts.write_bytes(b"")
+def test_full_runtime_identity_rejects_existing_directory(tmp_path: Path):
+    identity_dir = tmp_path / "runtime-identity"
+    identity_dir.mkdir(mode=0o700)
     with pytest.raises(
-        FullParityError, match="private-model known-hosts path identity"
+        FullParityError,
+        match="runtime identity directory is unavailable",
     ):
-        full_host._validated_baked_private_model_ssh_command()
+        full_host._materialize_run_owned_runtime_identity(identity_dir)
 
 
 def test_full_gateway_restart_reasserts_run_owned_path_authority():
@@ -3956,10 +3896,8 @@ def test_full_gateway_restart_reasserts_run_owned_path_authority():
     assert '"GATEWAY_V2_KMS_KEY_ID": ATTESTED_V2_KMS_KEY_ID' in full_source
     assert '"GATEWAY_PRIVATE_KEY_PATH": gateway_private_key_path' in full_source
     assert '"ARWEAVE_KEYFILE_PATH": arweave_keyfile_path' in full_source
-    assert (
-        '"GATEWAY_RESTART_GIT_SSH_COMMAND": ('
-        in full_source
-    )
+    assert '"GATEWAY_RESTART_GIT_SSH_COMMAND":' not in full_source
+    assert "research_lab_private_model_deploy" not in full_source
 
 
 def test_controller_dependency_closure_includes_gateway_database_client():
@@ -3980,6 +3918,7 @@ def test_full_baseline_checkpoint_is_run_scoped_and_production_default_is_unchan
         {},
         run_id=run_id,
         candidate_sha=SHA,
+        gateway_public_key=PARITY_GATEWAY_PUBLIC_KEY,
         supabase_origin=ORIGIN,
         artifact_bucket=bucket,
         benchmark_date="2026-08-19",
@@ -4052,6 +3991,7 @@ def test_full_baseline_checkpoint_rejects_mismatched_run_identity(
         {},
         run_id=run_id,
         candidate_sha=SHA,
+        gateway_public_key=PARITY_GATEWAY_PUBLIC_KEY,
         supabase_origin=ORIGIN,
         artifact_bucket=bucket,
         benchmark_date="2026-08-19",
@@ -4312,6 +4252,7 @@ def test_full_clone_final_evidence_uses_run_scoped_gateway_token():
         {},
         run_id="parity-20260815",
         candidate_sha=SHA,
+        gateway_public_key=PARITY_GATEWAY_PUBLIC_KEY,
         supabase_origin=ORIGIN,
         artifact_bucket="leadpoet-parity-artifacts-example",
         benchmark_date="2026-08-16",
@@ -4402,6 +4343,7 @@ def test_rebenchmark_readiness_uses_explicit_region_and_filters_secret_poison(
         {},
         run_id="pp-1-1",
         candidate_sha=SHA,
+        gateway_public_key=PARITY_GATEWAY_PUBLIC_KEY,
         supabase_origin=ORIGIN,
         artifact_bucket="leadpoet-parity-493765492819-" + "d" * 16,
         benchmark_date="2026-08-19",

--- a/tests/test_production_parity_acceptance_transfer.py
+++ b/tests/test_production_parity_acceptance_transfer.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from pathlib import Path
+import tarfile
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from gateway.tee.acceptance_corpus_v2 import (
+    REQUIRED_PROMOTION_BRANCHES,
+    build_acceptance_corpus_v2,
+)
+from leadpoet_canonical.attested_v2 import sha256_bytes
+from leadpoet_canonical.production_parity import sha256_json
+from scripts import production_parity_acceptance_transfer as transfer
+
+
+CANDIDATE_SHA = "a" * 40
+RELEASE_HASH = "sha256:" + "b" * 64
+
+
+def _hash(label: str) -> str:
+    return "sha256:" + hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _fixture(
+    root: Path,
+    *,
+    kind: str,
+    index: int,
+    metadata: dict | None = None,
+) -> dict:
+    relative = Path(kind) / f"{index:04d}.json"
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.chmod(0o700)
+    payload = f'{{"index":{index},"kind":"{kind}"}}\n'.encode("ascii")
+    path.write_bytes(payload)
+    path.chmod(0o600)
+    return {
+        "kind": kind,
+        "fixture_id": f"{kind}:{index:04d}",
+        "captured_at": f"2026-06-{1 + (index % 30):02d}T00:00:00Z",
+        "artifact_path": relative.as_posix(),
+        "artifact_hash": sha256_bytes(payload),
+        "expected_output_hash": _hash(f"output:{kind}:{index}"),
+        "receipt_root": _hash(f"receipt:{kind}:{index}"),
+        "metadata": dict(metadata or {}),
+    }
+
+
+def _signed_source(tmp_path: Path) -> tuple[Path, str]:
+    config = tmp_path / "production-v2"
+    corpus = config / "acceptance-corpus-v2"
+    corpus.mkdir(parents=True, mode=0o700)
+    config.chmod(0o700)
+    corpus.chmod(0o700)
+    fixtures = [
+        _fixture(corpus, kind="autoresearch_run", index=0),
+        _fixture(corpus, kind="provider_tape", index=0),
+        _fixture(corpus, kind="reward_allocation", index=0),
+    ]
+    fixtures.extend(
+        _fixture(corpus, kind="score_bundle", index=index)
+        for index in range(100)
+    )
+    fixtures.extend(
+        _fixture(
+            corpus,
+            kind="daily_benchmark",
+            index=index,
+            metadata={"benchmark_date": f"2026-06-{index + 1:02d}"},
+        )
+        for index in range(14)
+    )
+    fixtures.extend(
+        _fixture(
+            corpus,
+            kind="promotion_branch",
+            index=index,
+            metadata={"status": status},
+        )
+        for index, status in enumerate(sorted(REQUIRED_PROMOTION_BRANCHES))
+    )
+    fixtures.extend(
+        _fixture(
+            corpus,
+            kind="weight_epoch",
+            index=index,
+            metadata={"epoch_id": 23_000 + index},
+        )
+        for index in range(50)
+    )
+    signing_key = Ed25519PrivateKey.generate()
+    public_key = signing_key.public_key().public_bytes_raw()
+    manifest = build_acceptance_corpus_v2(
+        fixtures=fixtures,
+        captured_from="2026-06-01T00:00:00Z",
+        captured_through="2026-07-01T00:00:00Z",
+        signing_pubkey_hex=public_key.hex(),
+        sign_digest=signing_key.sign,
+    )
+    manifest_path = config / "acceptance-corpus-v2.json"
+    manifest_path.write_text(
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="ascii",
+    )
+    manifest_path.chmod(0o600)
+    return config, sha256_bytes(public_key)
+
+
+def _release_identity(monkeypatch, signer_hash: str) -> None:
+    monkeypatch.setattr(
+        transfer,
+        "_release_identity",
+        lambda **_kwargs: (
+            {
+                "commit_sha": CANDIDATE_SHA,
+                "release_hash": RELEASE_HASH,
+                "acceptance_signer_pubkey_hash": signer_hash,
+            },
+            signer_hash,
+        ),
+    )
+
+
+def _pack(
+    monkeypatch,
+    tmp_path: Path,
+) -> tuple[bytes, bytes, dict]:
+    source, signer_hash = _signed_source(tmp_path)
+    _release_identity(monkeypatch, signer_hash)
+    output = tmp_path / "output"
+    output.mkdir(mode=0o700)
+    output.chmod(0o700)
+    archive = output / transfer.ARCHIVE_NAME
+    binding = output / transfer.BINDING_NAME
+    evidence = transfer.package_transfer(
+        source_config_dir=source,
+        candidate_sha=CANDIDATE_SHA,
+        archive_path=archive,
+        binding_path=binding,
+    )
+    return archive.read_bytes(), binding.read_bytes(), evidence
+
+
+def _destination(tmp_path: Path, name: str = "destination") -> Path:
+    parent = tmp_path / "destination-root"
+    parent.mkdir(mode=0o700, exist_ok=True)
+    parent.chmod(0o700)
+    return parent / name
+
+
+def test_signed_acceptance_transfer_round_trips_exactly(
+    monkeypatch,
+    tmp_path: Path,
+):
+    archive, binding, packaged = _pack(monkeypatch, tmp_path)
+    destination = _destination(tmp_path)
+    unpacked = transfer.unpack_transfer(
+        archive_payload=archive,
+        binding_payload=binding,
+        candidate_sha=CANDIDATE_SHA,
+        destination_config_dir=destination,
+        candidate_release_manifest={},
+    )
+
+    assert unpacked == {
+        **packaged,
+        "release_hash": RELEASE_HASH,
+        "copied_exact": True,
+    }
+    assert (destination / "acceptance-corpus-v2.json").is_file()
+    assert unpacked["fixture_count"] == 173
+    assert destination.stat().st_mode & 0o777 == 0o700
+    assert all(
+        path.stat().st_mode & 0o777 == (0o700 if path.is_dir() else 0o600)
+        for path in destination.rglob("*")
+    )
+
+
+class _S3:
+    def __init__(self, objects: dict[str, bytes]):
+        self.objects = objects
+        self.bodies: list[io.BytesIO] = []
+
+    def get_object(self, *, Bucket: str, Key: str):
+        assert Bucket == "parity-artifacts"
+        body = io.BytesIO(self.objects[Key])
+        self.bodies.append(body)
+        return {"Body": body, "ContentLength": len(self.objects[Key])}
+
+
+def test_fetch_closes_every_s3_body_and_unpacks_exactly(
+    monkeypatch,
+    tmp_path: Path,
+):
+    archive, binding, _packaged = _pack(monkeypatch, tmp_path)
+    prefix = "production-parity/runs/pp-test-1"
+    s3 = _S3(
+        {
+            f"{prefix}/{transfer.ARCHIVE_NAME}": archive,
+            f"{prefix}/{transfer.BINDING_NAME}": binding,
+        }
+    )
+    result = transfer.fetch_and_unpack_transfer(
+        s3_client=s3,
+        artifact_bucket="parity-artifacts",
+        run_id="pp-test-1",
+        candidate_sha=CANDIDATE_SHA,
+        destination_config_dir=_destination(tmp_path),
+        candidate_release_manifest={},
+    )
+
+    assert result["copied_exact"] is True
+    assert len(s3.bodies) == 2
+    assert all(body.closed for body in s3.bodies)
+
+
+def test_bounded_reader_closes_body_when_object_size_is_invalid():
+    body = io.BytesIO(b"payload")
+
+    with pytest.raises(
+        transfer.AcceptanceTransferError,
+        match="object size is invalid",
+    ):
+        transfer._read_bounded_body(
+            {"Body": body, "ContentLength": transfer.MAX_ARCHIVE_BYTES + 1},
+            transfer.MAX_ARCHIVE_BYTES,
+        )
+
+    assert body.closed
+
+
+def _rebind(binding_payload: bytes, archive_payload: bytes) -> bytes:
+    binding = json.loads(binding_payload)
+    binding["archive_sha256"] = transfer._sha256_bytes(archive_payload)
+    binding["archive_size_bytes"] = len(archive_payload)
+    body = {key: value for key, value in binding.items() if key != "binding_hash"}
+    binding["binding_hash"] = sha256_json(body)
+    return (
+        json.dumps(binding, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("ascii")
+
+
+def _unsafe_archive(kind: str) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        root = transfer._tar_info("acceptance-corpus-v2", directory=True)
+        manifest_payload = b"{}\n"
+        manifest = transfer._tar_info(
+            "acceptance-corpus-v2.json",
+            directory=False,
+            size=len(manifest_payload),
+        )
+        if kind == "reordered":
+            archive.addfile(root)
+            archive.addfile(manifest, io.BytesIO(manifest_payload))
+        else:
+            archive.addfile(manifest, io.BytesIO(manifest_payload))
+            archive.addfile(root)
+        if kind == "traversal":
+            payload = b"x"
+            member = transfer._tar_info(
+                "acceptance-corpus-v2/../escape",
+                directory=False,
+                size=len(payload),
+            )
+            archive.addfile(member, io.BytesIO(payload))
+        elif kind == "symlink":
+            member = tarfile.TarInfo("acceptance-corpus-v2/link")
+            member.type = tarfile.SYMTYPE
+            member.linkname = "/etc/passwd"
+            member.mode = 0o600
+            member.uid = 0
+            member.gid = 0
+            member.mtime = 0
+            archive.addfile(member)
+    return buffer.getvalue()
+
+
+@pytest.mark.parametrize("kind", ["reordered", "traversal", "symlink"])
+def test_unpack_rejects_noncanonical_or_unsafe_members(
+    monkeypatch,
+    tmp_path: Path,
+    kind: str,
+):
+    _archive, binding, _packaged = _pack(monkeypatch, tmp_path)
+    unsafe = _unsafe_archive(kind)
+    destination = _destination(tmp_path)
+
+    with pytest.raises(transfer.AcceptanceTransferError):
+        transfer.unpack_transfer(
+            archive_payload=unsafe,
+            binding_payload=_rebind(binding, unsafe),
+            candidate_sha=CANDIDATE_SHA,
+            destination_config_dir=destination,
+            candidate_release_manifest={},
+        )
+
+    assert not destination.exists()
+
+
+def test_unpack_rejects_conflicting_archive_without_creating_destination(
+    monkeypatch,
+    tmp_path: Path,
+):
+    archive, binding, _packaged = _pack(monkeypatch, tmp_path)
+    changed = archive[:-1] + bytes([archive[-1] ^ 1])
+    destination = _destination(tmp_path)
+
+    with pytest.raises(
+        transfer.AcceptanceTransferError,
+        match="archive differs",
+    ):
+        transfer.unpack_transfer(
+            archive_payload=changed,
+            binding_payload=binding,
+            candidate_sha=CANDIDATE_SHA,
+            destination_config_dir=destination,
+            candidate_release_manifest={},
+        )
+
+    assert not destination.exists()


### PR DESCRIPTION
## Summary

- Replace assumptions about mutable production-host files in the stock parity AMI with run-owned ephemeral gateway and Arweave identities.
- Transfer the already-signed sanitized acceptance corpus through the run-scoped Object-Locked bucket and validate it against the exact candidate release on the disposable host.
- Keep private model execution on the signed immutable artifact path and use the candidate runtime Python.
- Close every S3 response body, including invalid-length failure paths.

## Safety boundaries

- No production secret, private deploy key, provider payload, or raw acceptance data is committed.
- No IAM widening and no production writes.
- Acceptance transfer fails closed on candidate, archive, binding, signer, release, ownership, mode, member ordering, traversal, or content mismatch.
- Arweave and chain paths remain non-forwarding.
- Scoring, Supabase, model routing, retry policy, persistence, restart policy, and weight policy are unchanged.

## Validation

- 198 passed, 1 skipped in focused parity/static-bootstrap tests.
- 433 passed, 1 skipped in the exact committed-tree parity, checkout, gateway-signing, bootstrap, and evidence gate.
- Python compile, YAML parse, diff check, and secret scan passed.
