### PR TITLE
Bootstrap Production Parity acceptance transfer imports

### DIFF
--- a/scripts/production_parity_acceptance_transfer.py
+++ b/scripts/production_parity_acceptance_transfer.py
@@ -16,6 +16,10 @@ import sys
 import tarfile
 from typing import Any, Mapping, Sequence
 
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from gateway.tee.acceptance_corpus_v2 import (
     load_and_validate_acceptance_corpus_v2,
 )

--- a/tests/test_production_parity_acceptance_transfer.py
+++ b/tests/test_production_parity_acceptance_transfer.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 import tarfile
 
 import pytest
@@ -20,6 +23,24 @@ from scripts import production_parity_acceptance_transfer as transfer
 
 CANDIDATE_SHA = "a" * 40
 RELEASE_HASH = "sha256:" + "b" * 64
+
+
+def test_direct_cli_bootstraps_candidate_repository_imports(tmp_path: Path) -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(Path(transfer.__file__).resolve()),
+            "--help",
+        ],
+        cwd=tmp_path,
+        env={key: value for key, value in os.environ.items() if key != "PYTHONPATH"},
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def _hash(label: str) -> str:


### PR DESCRIPTION
## Summary
- bootstrap the candidate repository root before the acceptance-transfer script imports candidate packages
- add a direct CLI regression from an unrelated working directory with no PYTHONPATH

## Production failure fixed
Production Parity Full run 33230024838 failed before candidate execution with ModuleNotFoundError: gateway in the signed acceptance-corpus transfer step.

## Focused validation
- python3 -m py_compile scripts/production_parity_acceptance_transfer.py tests/test_production_parity_acceptance_transfer.py
- python3 -m pytest -q tests/test_production_parity_acceptance_transfer.py tests/test_physical_v2_staging.py::test_full_workflow_uses_exact_candidate_and_tears_down_without_testnet
- 9 passed

No runtime scoring, persistence, Supabase, transport, retry, weight, or model semantics changed.