### PR TITLE
Unblock resumed rebenchmark execution

### DIFF
--- a/.github/workflows/physical-v2-staging.yml
+++ b/.github/workflows/physical-v2-staging.yml
@@ -475,7 +475,7 @@ jobs:
             if [ "$final_status" -ne 0 ] && \
                [ "$failure_stage" = host-python-bootstrap ]; then
               case "$host_bootstrap_step" in
-                venv-absence|runtime-package|venv-create|venv-identity|python-version|requirements-resolve|pip-bootstrap|pip-install|pip-check)
+                container-runtime-package|container-runtime-identity|container-runtime-service|venv-absence|runtime-package|venv-create|venv-identity|python-version|requirements-resolve|pip-bootstrap|pip-install|pip-check)
                   printf 'LEADPOET_BOOTSTRAP_STEP=%s\n' \
                     "$host_bootstrap_step" >&2
                   ;;
@@ -612,6 +612,19 @@ jobs:
           host_python="$host_venv/bin/python3"
           failure_stage=host-python-bootstrap
           failure_category=CommandFailed
+          host_bootstrap_step=container-runtime-package
+          if [ ! -x /usr/bin/docker ]; then
+            test -x /usr/bin/dnf
+            sudo -n /usr/bin/dnf -q -y install docker >/dev/null 2>&1
+          fi
+          host_bootstrap_step=container-runtime-identity
+          test -x /usr/bin/docker
+          /usr/bin/rpm -qf /usr/bin/docker \
+            | /usr/bin/grep -Eq '^docker-[0-9]'
+          host_bootstrap_step=container-runtime-service
+          sudo -n /usr/bin/systemctl start docker.service >/dev/null 2>&1
+          sudo -n /usr/bin/systemctl is-active --quiet docker.service
+          sudo -n /usr/bin/docker info >/dev/null 2>&1
           host_bootstrap_step=venv-absence
           test ! -e "$host_venv"
           host_bootstrap_step=runtime-package
@@ -744,6 +757,9 @@ jobs:
           import sys
 
           allowed = {
+              "container-runtime-package",
+              "container-runtime-identity",
+              "container-runtime-service",
               "venv-absence",
               "runtime-package",
               "venv-create",

--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -2783,6 +2783,91 @@ def _baseline_attempt_ledger_doc(
     return {**payload, "ledger_hash": canonical_hash(payload)}
 
 
+async def _replay_exact_baseline_checkpoints(
+    *,
+    runner: ExactOfficialBaselineRunner,
+    benchmark_items: Sequence[Mapping[str, Any]],
+    progress_rows: Sequence[Mapping[str, Any]],
+    attempt_ledger: Sequence[Mapping[str, Any]],
+    max_concurrency: int,
+) -> int:
+    """Revalidate independent closed checkpoints without serial replay."""
+
+    items_by_ref = {
+        _benchmark_item_ref_for_progress(item): item
+        for item in benchmark_items
+    }
+    attempts_by_ref: dict[str, list[Mapping[str, Any]]] = {}
+    for entry in attempt_ledger:
+        if isinstance(entry, Mapping):
+            attempts_by_ref.setdefault(
+                str(entry.get("icp_ref") or ""), []
+            ).append(entry)
+
+    replay_inputs: list[
+        tuple[Mapping[str, Any], str, int, Mapping[str, Any]]
+    ] = []
+    for resumed_row in progress_rows:
+        resumed_ref = _benchmark_item_ref_for_progress(resumed_row)
+        item = items_by_ref.get(resumed_ref)
+        attempts = sorted(
+            attempts_by_ref.get(resumed_ref) or [],
+            key=lambda value: int(value.get("retry_round") or 0),
+        )
+        latest_result = attempts[-1].get("result_row") if attempts else None
+        latest_retry_round = (
+            int(attempts[-1].get("retry_round") or 0)
+            if attempts
+            else 0
+        )
+        checkpoint = (
+            latest_result.get(_OFFICIAL_BASELINE_CHECKPOINT_FIELD)
+            if isinstance(latest_result, Mapping)
+            else None
+        )
+        if item is None or not isinstance(checkpoint, Mapping):
+            raise RuntimeError(
+                "official baseline v3 checkpoint is missing its exact model frontier"
+            )
+        replay_inputs.append(
+            (item, resumed_ref, latest_retry_round, checkpoint)
+        )
+
+    if not replay_inputs:
+        return 0
+    semaphore = asyncio.Semaphore(
+        max(1, min(len(replay_inputs), int(max_concurrency or 1)))
+    )
+
+    async def replay_one(
+        item: Mapping[str, Any],
+        resumed_ref: str,
+        retry_round: int,
+        checkpoint: Mapping[str, Any],
+    ) -> None:
+        async with semaphore:
+            await asyncio.to_thread(
+                runner.run_icp,
+                raw_icp=item["icp"],
+                icp_ref=resumed_ref,
+                target_count=_icp_company_goal(item["icp"]) or 1,
+                attempt_ordinal=retry_round,
+                expected_checkpoint=checkpoint,
+            )
+
+    settled = await asyncio.gather(
+        *(
+            replay_one(item, resumed_ref, retry_round, checkpoint)
+            for item, resumed_ref, retry_round, checkpoint in replay_inputs
+        ),
+        return_exceptions=True,
+    )
+    for outcome in settled:
+        if isinstance(outcome, BaseException):
+            raise outcome
+    return len(replay_inputs)
+
+
 def _baseline_distribution_complete(
     rows: Sequence[Mapping[str, Any]],
     benchmark_items: Sequence[Mapping[str, Any]],
@@ -6234,7 +6319,10 @@ class ResearchLabGatewayScoringWorker:
         }
 
     async def _run_lease_held_recovery_and_preflight(
-        self, maintenance_state: Mapping[str, Any]
+        self,
+        maintenance_state: Mapping[str, Any],
+        *,
+        force_full_fleet_measurement: bool = False,
     ) -> Mapping[str, Any]:
         """Run scoring maintenance under a continuously renewed lease."""
 
@@ -6313,11 +6401,22 @@ class ResearchLabGatewayScoringWorker:
                     maintenance_state=maintenance_state,
                     heartbeat=heartbeat,
                     force_measurement=(
-                        self._is_private_baseline_owner()
-                        and not baseline_full_fleet_proven
+                        force_full_fleet_measurement
+                        or (
+                            self._is_private_baseline_owner()
+                            and not baseline_full_fleet_proven
+                        )
                     ),
                 )
             else:
+                if force_full_fleet_measurement:
+                    return {
+                        "proceed": False,
+                        "reason": (
+                            "provider_preflight_full_fleet_owner_pending"
+                        ),
+                        "verdicts": [],
+                    }
                 if (
                     bool(
                         getattr(
@@ -6588,6 +6687,33 @@ class ResearchLabGatewayScoringWorker:
             completed_icps=completed_icps,
             total_icps=total_icps,
         )
+
+    def _baseline_full_fleet_preflight_is_fresh(self) -> bool:
+        """Return whether every bound scoring profile has a live proof."""
+
+        ttl_seconds = max(
+            60.0,
+            float(provider_preflight_settings().get("ttl_seconds") or 600.0),
+        )
+        worker_count = max(
+            1,
+            int(getattr(self.config, "scoring_worker_total_workers", 1) or 1),
+        )
+        measurements = dict(
+            getattr(self, "_baseline_profile_preflight_monotonic_at", {}) or {}
+        )
+        now = _baseline_preflight_monotonic()
+        for worker_index in range(worker_count):
+            measured_at = measurements.get(worker_index)
+            if measured_at is None:
+                return False
+            try:
+                age_seconds = now - float(measured_at)
+            except (TypeError, ValueError, OverflowError):
+                return False
+            if age_seconds < 0 or age_seconds >= ttl_seconds:
+                return False
+        return True
 
     async def _candidate_claim_capacity(self) -> dict[str, Any]:
         from leadpoet_canonical.production_parity_boundary_v2 import (
@@ -14159,48 +14285,34 @@ class ResearchLabGatewayScoringWorker:
                     )
                 )
 
+        exact_checkpoint_replay_count = 0
         if isinstance(runner, ExactOfficialBaselineRunner):
-            items_by_ref = {
-                _benchmark_item_ref_for_progress(item): item
-                for item in window.benchmark_items
-            }
-            attempts_by_ref: dict[str, list[Mapping[str, Any]]] = {}
-            for entry in baseline_progress_attempt_ledger:
-                if isinstance(entry, Mapping):
-                    attempts_by_ref.setdefault(
-                        str(entry.get("icp_ref") or ""), []
-                    ).append(entry)
-            for resumed_row in baseline_progress_rows:
-                resumed_ref = _benchmark_item_ref_for_progress(resumed_row)
-                item = items_by_ref.get(resumed_ref)
-                attempts = sorted(
-                    attempts_by_ref.get(resumed_ref) or [],
-                    key=lambda value: int(value.get("retry_round") or 0),
+            replay_started = time.monotonic()
+            exact_checkpoint_replay_count = (
+                await _replay_exact_baseline_checkpoints(
+                    runner=runner,
+                    benchmark_items=window.benchmark_items,
+                    progress_rows=baseline_progress_rows,
+                    attempt_ledger=baseline_progress_attempt_ledger,
+                    max_concurrency=self.config.private_baseline_concurrency,
                 )
-                latest_result = (
-                    attempts[-1].get("result_row") if attempts else None
-                )
-                latest_retry_round = (
-                    int(attempts[-1].get("retry_round") or 0)
-                    if attempts
-                    else 0
-                )
-                checkpoint = (
-                    latest_result.get(_OFFICIAL_BASELINE_CHECKPOINT_FIELD)
-                    if isinstance(latest_result, Mapping)
-                    else None
-                )
-                if item is None or checkpoint is None:
-                    raise RuntimeError(
-                        "official baseline v3 checkpoint is missing its exact model frontier"
-                    )
-                await asyncio.to_thread(
-                    runner.run_icp,
-                    raw_icp=item["icp"],
-                    icp_ref=resumed_ref,
-                    target_count=_icp_company_goal(item["icp"]) or 1,
-                    attempt_ordinal=latest_retry_round,
-                    expected_checkpoint=checkpoint,
+            )
+            if exact_checkpoint_replay_count:
+                _record_private_baseline_stage(
+                    worker_ref=self.worker_ref,
+                    stage="checkpoint_model_replay",
+                    status="passed",
+                    benchmark_date=today,
+                    benchmark_attempt=benchmark_attempt,
+                    epoch_id=evaluation_epoch,
+                    window_hash=window.window_hash,
+                    manifest_hash=artifact.manifest_hash,
+                    row_count=exact_checkpoint_replay_count,
+                    concurrency=min(
+                        exact_checkpoint_replay_count,
+                        max(1, self.config.private_baseline_concurrency),
+                    ),
+                    duration_seconds=time.monotonic() - replay_started,
                 )
 
         if baseline_telemetry_session is not None:
@@ -14517,6 +14629,58 @@ class ResearchLabGatewayScoringWorker:
                     }
                 )
             total_icps = len(window.benchmark_items)
+            if (
+                exact_checkpoint_replay_count
+                and not self._baseline_full_fleet_preflight_is_fresh()
+            ):
+                refresh_state = await get_scoring_maintenance_state()
+                if _operator_scoring_pause_active(refresh_state):
+                    raise BaselineMaintenancePause(
+                        completed_icps=len(baseline_progress_rows),
+                        total_icps=total_icps,
+                        maintenance_state=refresh_state,
+                    )
+                refreshed = await self._run_lease_held_recovery_and_preflight(
+                    refresh_state,
+                    force_full_fleet_measurement=True,
+                )
+                if (
+                    not refreshed.get("proceed")
+                    or not self._baseline_full_fleet_preflight_is_fresh()
+                ):
+                    raise BaselineCheckpointRecycle(
+                        pressure={
+                            "reason": str(
+                                refreshed.get("reason")
+                                or "provider_preflight_refresh_proof_missing"
+                            ),
+                            "provider_preflight_profile_count": max(
+                                1,
+                                int(
+                                    self.config.scoring_worker_total_workers
+                                    or 1
+                                ),
+                            ),
+                        },
+                        completed_icps=len(baseline_progress_rows),
+                        total_icps=total_icps,
+                    )
+                _record_private_baseline_stage(
+                    worker_ref=self.worker_ref,
+                    stage="checkpoint_restore_preflight_refresh",
+                    status="passed",
+                    benchmark_date=today,
+                    benchmark_attempt=benchmark_attempt,
+                    epoch_id=evaluation_epoch,
+                    window_hash=window.window_hash,
+                    manifest_hash=artifact.manifest_hash,
+                    completed_icp_count=len(baseline_progress_rows),
+                    selected_icp_count=total_icps,
+                    row_count=max(
+                        1,
+                        int(self.config.scoring_worker_total_workers or 1),
+                    ),
+                )
             if batch_execution and not legacy_v1_enabled():
                 _require_v2_baseline_receipt_capacity(total_icps)
             _record_private_baseline_stage(

--- a/tests/test_physical_v2_staging.py
+++ b/tests/test_physical_v2_staging.py
@@ -1030,9 +1030,31 @@ def test_full_workflow_fetches_exact_bundle_head_then_binds_canonical_main():
         '/usr/bin/python3.11 -I -m venv "$host_venv"'
         in source
     )
-    runtime_package = source.index("host_bootstrap_step=runtime-package")
+    container_runtime_package = source.index(
+        "host_bootstrap_step=container-runtime-package"
+    )
+    container_runtime_identity = source.index(
+        "host_bootstrap_step=container-runtime-identity"
+    )
+    container_runtime_service = source.index(
+        "host_bootstrap_step=container-runtime-service"
+    )
+    venv_absence = source.index("host_bootstrap_step=venv-absence")
+    python_runtime_package = source.index("host_bootstrap_step=runtime-package")
     venv_create = source.index("host_bootstrap_step=venv-create")
-    assert runtime_package < venv_create
+    assert (
+        container_runtime_package
+        < container_runtime_identity
+        < container_runtime_service
+        < venv_absence
+        < python_runtime_package
+        < venv_create
+    )
+    assert "if [ ! -x /usr/bin/docker ]; then" in source
+    assert "sudo -n /usr/bin/dnf -q -y install docker" in source
+    assert "/usr/bin/rpm -qf /usr/bin/docker" in source
+    assert "sudo -n /usr/bin/systemctl start docker.service" in source
+    assert "sudo -n /usr/bin/docker info" in source
     assert "python3.11-pip-wheel" not in source
     assert "GIT_CONFIG_NOSYSTEM=1" in source
     assert "git clone" not in source
@@ -1096,6 +1118,9 @@ def test_full_bootstrap_diagnostic_exposes_only_a_bounded_substage():
         ROOT / ".github/workflows/physical-v2-staging.yml"
     ).read_text(encoding="utf-8")
     allowed = {
+        "container-runtime-package",
+        "container-runtime-identity",
+        "container-runtime-service",
         "venv-absence",
         "runtime-package",
         "venv-create",

--- a/tests/test_production_parity_bootstrap_evidence.py
+++ b/tests/test_production_parity_bootstrap_evidence.py
@@ -5,6 +5,7 @@ import json
 import os
 from pathlib import Path
 import shlex
+import shutil
 import subprocess
 import sys
 
@@ -847,6 +848,7 @@ def _run_rendered_ssm(
     metadata_bundle_sha256: str | None = None,
     metadata_bundle_size_bytes: str | None = None,
     metadata_raw_json: str | None = None,
+    docker_preinstalled: bool = True,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     controller_bundle_bytes = (
         CANDIDATE_BUNDLE_BYTES
@@ -978,13 +980,38 @@ case "$operation" in
   mkdir) exec mkdir "$@" ;;
   chown) exit 0 ;;
   */dnf) exec "$operation" "$@" ;;
+  */docker|*/systemctl) exec "$operation" "$@" ;;
   *) exit 2 ;;
 esac
 """,
         encoding="utf-8",
     )
     dnf_stub = fake_bin / "dnf"
-    dnf_stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    dnf_stub.write_text(
+        """#!/bin/sh
+set -eu
+case " $* " in
+  *" docker "*)
+    cp "$DOCKER_STUB_TEMPLATE" "$DOCKER_STUB_PATH"
+    chmod 700 "$DOCKER_STUB_PATH"
+    ;;
+esac
+exit 0
+""",
+        encoding="utf-8",
+    )
+    docker_template = fake_bin / "docker-template"
+    docker_template.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    docker_stub = fake_bin / "docker"
+    if docker_preinstalled:
+        shutil.copyfile(docker_template, docker_stub)
+    rpm_stub = fake_bin / "rpm"
+    rpm_stub.write_text(
+        "#!/bin/sh\nprintf '%s\\n' docker-25.0.13-test\n",
+        encoding="utf-8",
+    )
+    systemctl_stub = fake_bin / "systemctl"
+    systemctl_stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     stat_stub = fake_bin / "stat"
     stat_stub.write_text(
         """#!/usr/bin/env python3
@@ -1035,11 +1062,16 @@ else:
         git_stub,
         sudo_stub,
         dnf_stub,
+        docker_template,
+        rpm_stub,
+        systemctl_stub,
         stat_stub,
         sha256sum_stub,
         host_python,
     ):
         executable.chmod(0o700)
+    if docker_preinstalled:
+        docker_stub.chmod(0o700)
 
     early_root = tmp_path / "missing-early-parent"
     work_root = tmp_path / "work"
@@ -1067,6 +1099,9 @@ else:
     )
     command = command.replace("/usr/bin/git", str(git_stub))
     command = command.replace("/usr/bin/dnf", str(dnf_stub))
+    command = command.replace("/usr/bin/docker", str(docker_stub))
+    command = command.replace("/usr/bin/rpm", str(rpm_stub))
+    command = command.replace("/usr/bin/systemctl", str(systemctl_stub))
     command = command.replace("/usr/bin/env -i", "/usr/bin/env")
     if stage is not None:
         assert category is not None
@@ -1108,6 +1143,8 @@ else:
         "GIT_CALLS": str(git_calls),
         "HOST_PYTHON_CALLS": str(host_python_calls),
         "METADATA_RAW_JSON": metadata_raw_json,
+        "DOCKER_STUB_TEMPLATE": str(docker_template),
+        "DOCKER_STUB_PATH": str(docker_stub),
         "PROVIDER_SECRET": "must-never-enter-evidence",
     }
     result = subprocess.run(
@@ -1173,6 +1210,17 @@ def test_rendered_ssm_preserves_success_and_uploads_host_evidence(
     assert not list((tmp_path / "work").glob("candidate-bundle-binding.*"))
     assert result.stdout == ""
     assert result.stderr == ""
+
+
+def test_rendered_ssm_installs_missing_container_runtime(tmp_path: Path) -> None:
+    result, capture = _run_rendered_ssm(
+        tmp_path,
+        docker_preinstalled=False,
+    )
+
+    assert result.returncode == 0
+    assert (tmp_path / "bin" / "docker").is_file()
+    assert json.loads(capture.read_text(encoding="utf-8"))["status"] == "passed"
 
 
 def test_rendered_ssm_builds_isolated_candidate_controller_before_entrypoint(

--- a/tests/test_scoring_worker_fixes.py
+++ b/tests/test_scoring_worker_fixes.py
@@ -2151,6 +2151,88 @@ async def test_any_worker_owner_requires_fleet_lease_until_baseline_ready(
     assert ready["proceed"] is True
     assert [int(call["worker_index"]) for call in profile_calls] == [7]
 
+    profile_calls.clear()
+    forced = await worker._run_lease_held_recovery_and_preflight(
+        {"paused": False, "reason": ""},
+        force_full_fleet_measurement=True,
+    )
+    assert forced == {
+        "proceed": False,
+        "reason": "provider_preflight_full_fleet_owner_pending",
+        "verdicts": [],
+    }
+    assert profile_calls == []
+
+
+@pytest.mark.asyncio
+async def test_exact_checkpoint_replay_is_bounded_and_concurrent():
+    barrier = threading.Barrier(2, timeout=2.0)
+    calls: list[dict[str, object]] = []
+
+    class Runner:
+        def run_icp(self, **kwargs):  # noqa: ANN003
+            barrier.wait()
+            calls.append(dict(kwargs))
+
+    progress_rows = [{"icp_ref": "icp-a"}, {"icp_ref": "icp-b"}]
+    attempt_ledger = [
+        {
+            "icp_ref": "icp-a",
+            "retry_round": 0,
+            "result_row": {
+                sw._OFFICIAL_BASELINE_CHECKPOINT_FIELD: {"checkpoint": "a"}
+            },
+        },
+        {
+            "icp_ref": "icp-b",
+            "retry_round": 1,
+            "result_row": {
+                sw._OFFICIAL_BASELINE_CHECKPOINT_FIELD: {"checkpoint": "b"}
+            },
+        },
+    ]
+
+    replayed = await sw._replay_exact_baseline_checkpoints(
+        runner=Runner(),
+        benchmark_items=[
+            {"icp_ref": "icp-a", "icp": {"max_companies": 2}},
+            {"icp_ref": "icp-b", "icp": {"max_companies": 3}},
+        ],
+        progress_rows=progress_rows,
+        attempt_ledger=attempt_ledger,
+        max_concurrency=2,
+    )
+
+    assert replayed == 2
+    by_ref = {str(call["icp_ref"]): call for call in calls}
+    assert set(by_ref) == {"icp-a", "icp-b"}
+    assert by_ref["icp-a"]["target_count"] == 2
+    assert by_ref["icp-a"]["attempt_ordinal"] == 0
+    assert by_ref["icp-b"]["target_count"] == 3
+    assert by_ref["icp-b"]["attempt_ordinal"] == 1
+
+
+def test_full_fleet_preflight_freshness_requires_every_live_measurement(
+    monkeypatch,
+):
+    worker = object.__new__(sw.ResearchLabGatewayScoringWorker)
+    worker.config = SimpleNamespace(scoring_worker_total_workers=2)
+    worker._baseline_profile_preflight_monotonic_at = {0: 100.0, 1: 101.0}
+    monkeypatch.setattr(sw, "_baseline_preflight_monotonic", lambda: 150.0)
+    monkeypatch.setattr(
+        sw,
+        "provider_preflight_settings",
+        lambda: {"ttl_seconds": 600.0},
+    )
+
+    assert worker._baseline_full_fleet_preflight_is_fresh() is True
+    worker._baseline_profile_preflight_monotonic_at.pop(1)
+    assert worker._baseline_full_fleet_preflight_is_fresh() is False
+    worker._baseline_profile_preflight_monotonic_at[1] = 151.0
+    assert worker._baseline_full_fleet_preflight_is_fresh() is False
+    worker._baseline_profile_preflight_monotonic_at[1] = -500.0
+    assert worker._baseline_full_fleet_preflight_is_fresh() is False
+
 
 @pytest.mark.asyncio
 async def test_forced_owned_preflight_records_only_complete_fleet(monkeypatch):
@@ -2214,6 +2296,63 @@ async def test_forced_owned_preflight_records_only_complete_fleet(monkeypatch):
 
     assert failed["proceed"] is False
     assert worker._baseline_profile_preflight_monotonic_at == {}
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_restore_forces_fresh_owned_fleet_measurement(
+    monkeypatch,
+):
+    worker = object.__new__(sw.ResearchLabGatewayScoringWorker)
+    worker.worker_ref = "baseline-worker"
+    worker.config = SimpleNamespace(
+        private_baseline_rebenchmark_enabled=True,
+        scoring_worker_index=0,
+        scoring_worker_total_workers=2,
+    )
+    worker._lease_holder_ref = "baseline-lease-holder"
+    worker._holds_maintenance_lease = False
+    worker._is_private_baseline_owner = lambda: True
+    worker._baseline_profile_preflight_monotonic_at = {0: 1.0, 1: 1.0}
+    calls: list[dict[str, object]] = []
+
+    async def lease_acquired(**_kwargs):
+        return True
+
+    async def no_recovery_work():
+        return None
+
+    async def owned_preflight(**kwargs):  # noqa: ANN003
+        calls.append(dict(kwargs))
+        return {"proceed": True, "verdicts": []}
+
+    class Heartbeat:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def start(self):
+            pass
+
+        def ensure_held(self):
+            pass
+
+        async def stop(self):
+            pass
+
+    monkeypatch.setattr(sw, "try_acquire_maintenance_lease", lease_acquired)
+    monkeypatch.setattr(sw, "MaintenanceLeaseHeartbeat", Heartbeat)
+    worker._recover_stale_candidate_claims = no_recovery_work
+    worker._alert_stuck_candidates = no_recovery_work
+    worker._requeue_quarantined_candidates = no_recovery_work
+    worker._run_owned_provider_preflight = owned_preflight
+
+    result = await worker._run_lease_held_recovery_and_preflight(
+        {"paused": False, "reason": ""},
+        force_full_fleet_measurement=True,
+    )
+
+    assert result["proceed"] is True
+    assert len(calls) == 1
+    assert calls[0]["force_measurement"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed
- replay independent closed ICP checkpoints concurrently instead of serially
- reacquire a real full-fleet provider preflight after replay before new paid work
- bootstrap Docker on disposable Production Parity Full hosts when the AMI lacks it

## Why
The live rebenchmark repeatedly spent about 95 minutes replaying ten closed checkpoints, then recycled because its provider proof had expired before the first new ICP. Production Parity Full separately failed before candidate execution because the disposable host lacked Docker.

## Safety
- preserves exact checkpoint replay and fail-closed checkpoint validation
- does not extend or fabricate preflight freshness
- requires the maintenance lease for the forced full-fleet measurement
- leaves scoring, persistence, retry budgets, Supabase, assignments, and weight submission semantics unchanged

## Focused evidence
- 238 recovery/model-runner tests passed
- 180 parity/bootstrap tests passed
- syntax, diff, and silent-sentinel checks passed
