### PR TITLE
Preserve typed provider snapshot misses

### DIFF
--- a/gateway/tee/model_sandbox_v2.py
+++ b/gateway/tee/model_sandbox_v2.py
@@ -3748,6 +3748,9 @@ print(json.dumps({'schema_version': 'leadpoet.model_sandbox_self_test.v2', 'stat
             if EVIDENCE_MISS_SENTINEL in stderr:
                 fingerprint = stderr.rsplit(EVIDENCE_MISS_SENTINEL, 1)[-1].splitlines()[0]
                 raise SnapshotMiss("provider-evidence:" + fingerprint.strip())
+            if SNAPSHOT_MISS_SENTINEL in stderr:
+                request_key = stderr.rsplit(SNAPSHOT_MISS_SENTINEL, 1)[-1].splitlines()[0]
+                raise SnapshotMiss(request_key.strip())
             raise _runsc_model_sandbox_error(
                 stderr=stderr,
                 returncode=completed.returncode,

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1,5 +1,5 @@
 {
-  "baseline_commit": "48245904bafa94be1539a72633701c002d35b8cc",
+  "baseline_commit": "c8ffbc521da7529e7d795fc5fb572e65deb17d15",
   "entries": [
     {
       "ast_sha256": "sha256:9366486b15b75d5a2a299caacc86b70e706f1c9bccf99721d18fedc375824e55",
@@ -4512,7 +4512,7 @@
       "symbol": "RUNSC_FAILURE_CODES_V1"
     },
     {
-      "ast_sha256": "sha256:fa919799cca4b0a137eaac4b6861aa9e6cf5309f1e830e019a38af608527a8f2",
+      "ast_sha256": "sha256:7aa831029fcac4eb34c21aa0b94e642a7be2cab710c956099b513f62de9e4358",
       "path": "gateway/tee/model_sandbox_v2.py",
       "symbol": "RunscModelSandboxV2"
     },
@@ -8217,7 +8217,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:e390e1b9e7aa7f50562165a91f16f167315fa56b7709fa8b1095453849dc4235",
-  "protected_source_commit": "48245904bafa94be1539a72633701c002d35b8cc",
+  "manifest_hash": "sha256:6a036ac3d0f54b99d6633cc58ea165e49e137a797fd51fc11374069166a7905f",
+  "protected_source_commit": "c8ffbc521da7529e7d795fc5fb572e65deb17d15",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_model_sandbox_v2.py
+++ b/tests/test_model_sandbox_v2.py
@@ -2461,6 +2461,51 @@ def test_runsc_dev_provider_replay_preserves_typed_evidence_miss_after_marker(
         transport.restore()
 
 
+def test_runsc_dev_provider_replay_propagates_typed_snapshot_miss(tmp_path):
+    request_key = "exa|GET|api.exa.ai/search|abc"
+
+    def runner(command, **_kwargs):
+        if "run" in command:
+            return SimpleNamespace(
+                returncode=PRIVATE_RUNTIME_FAILURE_EXIT_CODE,
+                stdout="",
+                stderr=SNAPSHOT_MISS_SENTINEL + request_key + "\n",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    request = _request(tmp_path)
+    snapshots = tmp_path / "snapshots"
+    snapshots.mkdir()
+    transport = BrokeredProviderTransportV2(lambda _request: {})
+    sandbox = RunscModelSandboxV2(
+        config=_runtime(tmp_path),
+        transport=transport,
+        cgroup_parent="leadpoet-model",
+        process_runner=runner,
+    )
+    try:
+        with pytest.raises(SnapshotMiss, match="api.exa.ai/search"):
+            sandbox.execute_dev_provider_replay(
+                artifact_doc=request["artifact"],
+                source_bundle=request["source_bundle"],
+                module_name="research_lab_adapter",
+                callable_name="run_icp",
+                icp={"industry": "Software", "intent_signal": "Hiring"},
+                context={"dev_eval": True},
+                environment={},
+                credential_env_names=[],
+                provider_evidence_cache={
+                    "schema_version": EVIDENCE_CACHE_SCHEMA_VERSION,
+                    "entries": {},
+                },
+                snapshot_root=snapshots,
+                timeout_seconds=30,
+                job_id="dev-provider-replay-snapshot-miss",
+            )
+    finally:
+        transport.restore()
+
+
 @pytest.mark.parametrize("replay_kind", ("snapshot", "provider"))
 def test_runsc_dev_non_sentinel_failure_is_secret_safe_and_projected(
     tmp_path,


### PR DESCRIPTION
## Summary
- preserve strict snapshot misses as typed recovery signals in V2 provider replay
- add focused regression coverage
- refresh the protected sandbox workflow identity

## Verification
- 473 focused sandbox, dev-eval, scoring-recovery, restart, protected-workflow, and weight-readiness tests passed
- exact-main SOURCE_ADD suite: 257 passed

The change does not alter scoring semantics, reward policy, allocation, canonical bundle generation, or validator submission.