### PR TITLE
Preempt stale rebenchmark model waves

### DIFF
--- a/gateway/research_lab/scoring_worker.py
+++ b/gateway/research_lab/scoring_worker.py
@@ -1529,6 +1529,18 @@ _BASELINE_WAVE_STALL_GRACE_SECONDS = 180.0
 _BASELINE_WAVE_STALL_EXIT_CODE = 75
 
 
+def _baseline_repo_head_watch_interval_seconds() -> float:
+    """Bounded cadence for preempting work after the model branch advances."""
+
+    try:
+        configured = float(
+            os.getenv("RESEARCH_LAB_BASELINE_REPO_HEAD_WATCH_SECONDS", "30")
+        )
+    except ValueError:
+        configured = 30.0
+    return min(300.0, max(5.0, configured))
+
+
 def _baseline_wave_stall_timeout_seconds(config: Any) -> float:
     """Bound one checkpoint-backed wave beyond its full measured deadline."""
 
@@ -4951,6 +4963,57 @@ class PrivateBaselineRepoHeadChanged(RuntimeError):
             f"repo_head={compact_ref(repo_main_sha)} "
             f"before_icp={item_index}/{total_icps}"
         )
+
+
+class _PrivateBaselineRepoHeadChangeSignal:
+    """Thread-safe handoff from the async repo watcher to model runner threads."""
+
+    def __init__(self, *, expected_git_sha: str) -> None:
+        self.expected_git_sha = str(expected_git_sha or "").strip()
+        self._changed = threading.Event()
+        self._state_lock = threading.Lock()
+        self._repo_main_sha = ""
+
+    def mark_changed(self, repo_main_sha: str) -> None:
+        normalized = str(repo_main_sha or "").strip()
+        if not normalized:
+            return
+        with self._state_lock:
+            self._repo_main_sha = normalized
+        self._changed.set()
+
+    def repo_main_sha(self) -> str:
+        if not self._changed.is_set():
+            return ""
+        with self._state_lock:
+            return self._repo_main_sha
+
+    def raise_if_changed(self, *, item_index: int, total_icps: int) -> None:
+        repo_main_sha = self.repo_main_sha()
+        if repo_main_sha:
+            raise PrivateBaselineRepoHeadChanged(
+                expected_git_sha=self.expected_git_sha,
+                repo_main_sha=repo_main_sha,
+                item_index=item_index,
+                total_icps=total_icps,
+            )
+
+    def wrap_progress_callback(
+        self,
+        callback: Callable[[], None] | None,
+        *,
+        item_index: int,
+        total_icps: int,
+    ) -> Callable[[], None]:
+        def _progress() -> None:
+            if callback is not None:
+                callback()
+            self.raise_if_changed(
+                item_index=item_index,
+                total_icps=total_icps,
+            )
+
+        return _progress
 
 
 # Known-terminal error classes: validation / malformed-candidate style failures
@@ -16004,6 +16067,43 @@ class ResearchLabGatewayScoringWorker:
             total_icps=total_icps,
         )
 
+    async def _watch_private_baseline_repo_head_change(
+        self,
+        *,
+        expected_git_sha: str,
+        benchmark_date: str,
+        total_icps: int,
+        signal: _PrivateBaselineRepoHeadChangeSignal,
+    ) -> None:
+        """Detect a new signed model release while an ICP wave is in flight."""
+
+        expected = str(expected_git_sha or "").strip()
+        if not expected:
+            return
+        poll_seconds = _baseline_repo_head_watch_interval_seconds()
+        while True:
+            await asyncio.sleep(poll_seconds)
+            try:
+                await self._ensure_private_baseline_repo_head_unchanged(
+                    expected_git_sha=expected,
+                    benchmark_date=benchmark_date,
+                    item_index=0,
+                    total_icps=total_icps,
+                )
+            except PrivateBaselineRepoHeadChanged as exc:
+                signal.mark_changed(exc.repo_main_sha)
+                return
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - keep watching after a transient control-plane failure
+                logger.warning(
+                    "research_lab_private_baseline_repo_head_watch_failed worker_ref=%s "
+                    "benchmark_date=%s error=%s",
+                    self.worker_ref,
+                    benchmark_date,
+                    _short_error(exc),
+                )
+
     async def _record_baseline_icp_traces(
         self,
         *,
@@ -17018,6 +17118,22 @@ class ResearchLabGatewayScoringWorker:
             max_workers=max(concurrency, self.config.private_baseline_retry_concurrency),
             thread_name_prefix="baseline-icp",
         )
+        repo_head_change_signal = _PrivateBaselineRepoHeadChangeSignal(
+            expected_git_sha=expected_repo_main_git_sha
+        )
+        repo_head_watch_task = (
+            asyncio.create_task(
+                self._watch_private_baseline_repo_head_change(
+                    expected_git_sha=expected_repo_main_git_sha,
+                    benchmark_date=benchmark_date,
+                    total_icps=total_icps,
+                    signal=repo_head_change_signal,
+                ),
+                name="private-baseline-repo-head-watch",
+            )
+            if str(expected_repo_main_git_sha or "").strip()
+            else None
+        )
         try:
             semaphore = asyncio.Semaphore(concurrency)
             persisted_attempt_indexes: set[int] = set()
@@ -17124,7 +17240,13 @@ class ResearchLabGatewayScoringWorker:
                             run_one(
                                 item_index,
                                 item,
-                                progress_callback=mark_wave_progress,
+                                progress_callback=(
+                                    repo_head_change_signal.wrap_progress_callback(
+                                        mark_wave_progress,
+                                        item_index=item_index,
+                                        total_icps=total_icps,
+                                    )
+                                ),
                             )
                             for item_index, item in wave
                         ),
@@ -17133,6 +17255,16 @@ class ResearchLabGatewayScoringWorker:
                 fatal = [entry for entry in settled if isinstance(entry, BaseException)]
                 if fatal:
                     raise fatal[0]
+                repo_head_change_signal.raise_if_changed(
+                    item_index=wave[-1][0],
+                    total_icps=total_icps,
+                )
+                await self._ensure_private_baseline_repo_head_unchanged(
+                    expected_git_sha=expected_repo_main_git_sha,
+                    benchmark_date=benchmark_date,
+                    item_index=wave[-1][0],
+                    total_icps=total_icps,
+                )
                 for entry in settled:
                     results[entry["_item_index"]] = entry
                 _record_private_baseline_stage(
@@ -17349,7 +17481,13 @@ class ResearchLabGatewayScoringWorker:
                             *(
                                 retry_one(
                                     item_index,
-                                    progress_callback=mark_wave_progress,
+                                    progress_callback=(
+                                        repo_head_change_signal.wrap_progress_callback(
+                                            mark_wave_progress,
+                                            item_index=item_index,
+                                            total_icps=total_icps,
+                                        )
+                                    ),
                                 )
                                 for item_index in wave_indexes
                             ),
@@ -17360,6 +17498,16 @@ class ResearchLabGatewayScoringWorker:
                     ]
                     if fatal:
                         raise fatal[0]
+                    repo_head_change_signal.raise_if_changed(
+                        item_index=wave_indexes[-1],
+                        total_icps=total_icps,
+                    )
+                    await self._ensure_private_baseline_repo_head_unchanged(
+                        expected_git_sha=expected_repo_main_git_sha,
+                        benchmark_date=benchmark_date,
+                        item_index=wave_indexes[-1],
+                        total_icps=total_icps,
+                    )
                     recovered = 0
                     for entry in retried:
                         if (
@@ -17461,6 +17609,10 @@ class ResearchLabGatewayScoringWorker:
                 },
             )
         finally:
+            if repo_head_watch_task is not None:
+                repo_head_watch_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await repo_head_watch_task
             executor.shutdown(wait=False, cancel_futures=True)
 
     async def _reusable_same_day_benchmark(

--- a/tests/test_scoring_worker_fixes.py
+++ b/tests/test_scoring_worker_fixes.py
@@ -2860,6 +2860,108 @@ async def test_private_baseline_repo_head_check_allows_same_sha(monkeypatch):
     assert sync_called is False
 
 
+def test_private_baseline_repo_head_change_signal_raises_at_progress_boundary():
+    base_progress = []
+    signal = sw._PrivateBaselineRepoHeadChangeSignal(expected_git_sha="old-sha")
+    progress = signal.wrap_progress_callback(
+        lambda: base_progress.append("progress"),
+        item_index=7,
+        total_icps=40,
+    )
+
+    progress()
+    signal.mark_changed("new-sha")
+
+    with pytest.raises(sw.PrivateBaselineRepoHeadChanged) as exc_info:
+        progress()
+
+    assert base_progress == ["progress", "progress"]
+    assert exc_info.value.expected_git_sha == "old-sha"
+    assert exc_info.value.repo_main_sha == "new-sha"
+    assert exc_info.value.item_index == 7
+    assert exc_info.value.total_icps == 40
+
+
+@pytest.mark.asyncio
+async def test_private_baseline_repo_head_watcher_retries_then_signals(monkeypatch):
+    worker = object.__new__(sw.ResearchLabGatewayScoringWorker)
+    worker.worker_ref = "baseline-worker"
+    signal = sw._PrivateBaselineRepoHeadChangeSignal(expected_git_sha="old-sha")
+    checks = 0
+
+    async def fake_ensure(**_kwargs):
+        nonlocal checks
+        checks += 1
+        if checks == 1:
+            raise RuntimeError("temporary control-plane failure")
+        raise sw.PrivateBaselineRepoHeadChanged(
+            expected_git_sha="old-sha",
+            repo_main_sha="new-sha",
+            item_index=0,
+            total_icps=40,
+        )
+
+    monkeypatch.setattr(sw, "_baseline_repo_head_watch_interval_seconds", lambda: 0.001)
+    worker._ensure_private_baseline_repo_head_unchanged = fake_ensure
+
+    await worker._watch_private_baseline_repo_head_change(
+        expected_git_sha="old-sha",
+        benchmark_date="2026-08-30",
+        total_icps=40,
+        signal=signal,
+    )
+
+    assert checks == 2
+    assert signal.repo_main_sha() == "new-sha"
+
+
+@pytest.mark.asyncio
+async def test_private_baseline_batch_preempts_inflight_model_at_progress_boundary(
+    monkeypatch,
+):
+    worker = object.__new__(sw.ResearchLabGatewayScoringWorker)
+    worker.worker_ref = "baseline-worker"
+    worker.config = SimpleNamespace(
+        private_baseline_concurrency=1,
+        private_baseline_retry_concurrency=1,
+        private_baseline_provider_retry_rounds=0,
+        scoring_worker_total_workers=1,
+    )
+    window = SimpleNamespace(
+        benchmark_items=[{"icp_ref": "icp-a", "icp_hash": "hash-a"}]
+    )
+
+    async def boundary(**_kwargs):
+        return None
+
+    async def fake_watch(*, signal, **_kwargs):
+        signal.mark_changed("new-sha")
+
+    async def fake_run_baseline_icp(*, progress_callback, **_kwargs):
+        await asyncio.sleep(0)
+        progress_callback()
+        raise AssertionError("repo-head progress boundary did not preempt")
+
+    monkeypatch.setattr(sw, "_enforce_baseline_wave_maintenance_boundary", boundary)
+    worker._watch_private_baseline_repo_head_change = fake_watch
+    worker._run_baseline_icp = fake_run_baseline_icp
+
+    with pytest.raises(sw.PrivateBaselineRepoHeadChanged) as exc_info:
+        await worker._run_baseline_batch_inner(
+            runner=object(),
+            retry_runner=object(),
+            scorer=object(),
+            window=window,
+            run_start=0.0,
+            expected_repo_main_git_sha="old-sha",
+            benchmark_date="2026-08-30",
+        )
+
+    assert exc_info.value.expected_git_sha == "old-sha"
+    assert exc_info.value.repo_main_sha == "new-sha"
+    assert exc_info.value.item_index == 1
+
+
 def _retry_test_runner(*, image_digest: str, scope: str):
     manifest_payload = {
         "model_artifact_hash": "sha256:" + "9" * 64,


### PR DESCRIPTION
## Summary
- watch the configured model branch once per active baseline batch
- stop stale ICP work only after a model action and its durable transition receipt complete
- recheck the branch at every settled first-pass and retry-wave boundary
- preserve model/scorer semantics and artifact-bound checkpoints

## Verification
- `python3 -m pytest -q tests/test_scoring_worker_fixes.py --disable-warnings --maxfail=1` (157 passed)
- `python3 -m py_compile gateway/research_lab/scoring_worker.py tests/test_scoring_worker_fixes.py`
- `git diff --check`