### PR TITLE
Refresh protected rebenchmark identity

### DIFF
--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1,5 +1,5 @@
 {
-  "baseline_commit": "c8ffbc521da7529e7d795fc5fb572e65deb17d15",
+  "baseline_commit": "e1e356d1de564582f4180312d94cf92ddcfc18bf",
   "entries": [
     {
       "ast_sha256": "sha256:9366486b15b75d5a2a299caacc86b70e706f1c9bccf99721d18fedc375824e55",
@@ -2572,7 +2572,7 @@
       "symbol": "ResearchLabGatewayScoringWorker._run_baseline_batch"
     },
     {
-      "ast_sha256": "sha256:6594a75589af2f5cb4f33c5f5453278a9ed2a37424728f544918e6e6bb98d469",
+      "ast_sha256": "sha256:46c69dc3a8b91fbffdd74c8ea4e27755b3893a841dea6dc808d5d8b5e21ef6cf",
       "path": "gateway/research_lab/scoring_worker.py",
       "symbol": "ResearchLabGatewayScoringWorker._run_baseline_batch_inner"
     },
@@ -8217,7 +8217,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:6a036ac3d0f54b99d6633cc58ea165e49e137a797fd51fc11374069166a7905f",
-  "protected_source_commit": "c8ffbc521da7529e7d795fc5fb572e65deb17d15",
+  "manifest_hash": "sha256:67d2c0589d04580d2d31ddb9d12f7ede3494c0fe424c86b7fa4c97a21f9bf88d",
+  "protected_source_commit": "e1e356d1de564582f4180312d94cf92ddcfc18bf",
   "schema_version": "leadpoet.protected_workflows.v2"
 }


### PR DESCRIPTION
## Summary
- refresh the protected AST identity for `_run_baseline_batch_inner` after PR #155
- preserve the fail-closed release boundary; no runtime behavior change

## Evidence
- exact attestation run `33298624494` identified only this protected workflow mismatch on the validator parent
- canonical manifest verifier passed
- `176 passed` across protected-workflow and scoring-worker regressions
- syntax and diff checks passed