### PR TITLE
Bind SOURCE_ADD Leg 1 to accepted provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Choose **Submit API Source** in the miner menu and enter:
 
 Do not submit API keys or other secrets. The gateway reviews the source and tests the API; an operator adds any required credential after submission.
 
+#### Auto Research
+
 How it works:
 
 1. The miner securely provides an OpenRouter API key and management key.

--- a/gateway/research_lab/api.py
+++ b/gateway/research_lab/api.py
@@ -158,6 +158,7 @@ from .store import (
 )
 from gateway.research_lab.provider_evidence_proxy import (
     ProviderRegistryEntry,
+    reserved_builtin_provider_domains_sync,
     reserved_builtin_provider_ids_sync,
     validate_provider_registry_entries,
 )
@@ -171,6 +172,7 @@ from research_lab.source_add_execution import intake_source_add_submission
 from research_lab.source_add_identity import (
     SOURCE_ADD_IDENTITY_VERSION,
     legacy_source_identity_hash,
+    normalize_source_add_domain,
     source_identity_alias_hashes_from_metadata,
     source_identity_hash_from_metadata,
 )
@@ -726,6 +728,23 @@ async def submit_research_lab_source_adapter(payload: ResearchLabSourceAdapterSu
         )
 
     source_metadata = payload.source_metadata.model_dump(mode="json")
+    try:
+        current_model_domains = await asyncio.to_thread(
+            reserved_builtin_provider_domains_sync
+        )
+    except Exception as exc:
+        logger.warning(
+            "SOURCE_ADD_BUILTIN_CATALOG_UNAVAILABLE type=%s",
+            type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="SOURCE_ADD workflow temporarily unavailable",
+        ) from exc
+    if normalize_source_add_domain(
+        str(source_metadata.get("api_base_url") or "")
+    ) in current_model_domains:
+        raise HTTPException(status_code=409, detail=ALREADY_SUBMITTED_DETAIL)
     declared_domains = (
         payload.manifest.get("declared_base_domains")
         if isinstance(payload.manifest, Mapping)

--- a/gateway/research_lab/config.py
+++ b/gateway/research_lab/config.py
@@ -857,6 +857,7 @@ class ResearchLabGatewayConfig:
     source_add_sandbox_image: str = "python:3.11-slim"
     source_add_trial_timeout_seconds: int = 300
     source_add_leg1_alpha_percent: float = 1.0
+    # Zero disables Leg 2 without disabling measured functional Leg 1 rewards.
     source_add_leg2_alpha_percent: float = 5.0
     source_add_acceptance_floor_yield: float = 0.10
     source_add_max_concurrent_per_hotkey: int = 3
@@ -1847,6 +1848,9 @@ class ResearchLabGatewayConfig:
                 "dispatcher_enabled": self.source_add_dispatcher_enabled,
                 "functional_probes_enabled": self.source_add_functional_probes_enabled,
                 "functional_rewards_enabled": self.source_add_functional_rewards_enabled,
+                "leg1_alpha_percent": self.source_add_leg1_alpha_percent,
+                "leg2_alpha_percent": self.source_add_leg2_alpha_percent,
+                "reward_epochs": self.lab_reward_epochs,
                 "max_concurrent_per_hotkey": self.source_add_max_concurrent_per_hotkey,
                 "max_per_day_per_hotkey": self.source_add_max_per_day_per_hotkey,
                 "max_per_30d_per_hotkey": self.source_add_max_per_30d_per_hotkey,

--- a/gateway/research_lab/config.py
+++ b/gateway/research_lab/config.py
@@ -857,8 +857,8 @@ class ResearchLabGatewayConfig:
     source_add_sandbox_image: str = "python:3.11-slim"
     source_add_trial_timeout_seconds: int = 300
     source_add_leg1_alpha_percent: float = 1.0
-    # Zero disables Leg 2 without disabling measured functional Leg 1 rewards.
-    source_add_leg2_alpha_percent: float = 5.0
+    # Leg 2 is opt-in. Zero leaves measured functional Leg 1 rewards enabled.
+    source_add_leg2_alpha_percent: float = 0.0
     source_add_acceptance_floor_yield: float = 0.10
     source_add_max_concurrent_per_hotkey: int = 3
     source_add_max_per_day_per_hotkey: int = 5
@@ -1519,7 +1519,7 @@ class ResearchLabGatewayConfig:
                 0.0, _float("RESEARCH_LAB_SOURCE_ADD_LEG1_ALPHA_PERCENT", 1.0)
             ),
             source_add_leg2_alpha_percent=max(
-                0.0, _float("RESEARCH_LAB_SOURCE_ADD_LEG2_ALPHA_PERCENT", 5.0)
+                0.0, _float("RESEARCH_LAB_SOURCE_ADD_LEG2_ALPHA_PERCENT", 0.0)
             ),
             source_add_acceptance_floor_yield=max(
                 0.0, _float("RESEARCH_LAB_SOURCE_ADD_ACCEPTANCE_FLOOR_YIELD", 0.10)

--- a/gateway/research_lab/promotion.py
+++ b/gateway/research_lab/promotion.py
@@ -4027,6 +4027,11 @@ class ResearchLabPromotionController:
     ) -> dict[str, Any]:
         if not getattr(self.config, "source_add_rewards_enabled", False):
             return {"source_add_reward_status": "disabled"}
+        leg2_alpha_percent = float(
+            getattr(self.config, "source_add_leg2_alpha_percent", 5.0)
+        )
+        if leg2_alpha_percent <= 0.0:
+            return {"source_add_reward_status": "disabled"}
         status = str(champion_reward_status.get("champion_reward_status") or "")
         if status not in {"created", "already_created"}:
             return {
@@ -4174,7 +4179,7 @@ class ResearchLabPromotionController:
                     "provision_ref": str(matched_row.get("provision_ref") or ""),
                 },
                 existing_rewards=reward_rows,
-                alpha_percent=float(getattr(self.config, "source_add_leg2_alpha_percent", 5.0) or 5.0),
+                alpha_percent=leg2_alpha_percent,
                 reward_epochs=int(getattr(self.config, "lab_reward_epochs", 20) or 20),
             )
             blockers: list[str] = []
@@ -4207,10 +4212,7 @@ class ResearchLabPromotionController:
                             "trigger_evidence": dict(leg2.trigger_evidence or {}),
                             "judge_result": dict(judge_result),
                             "existing_rewards": list(reward_rows),
-                            "alpha_percent": float(
-                                getattr(self.config, "source_add_leg2_alpha_percent", 5.0)
-                                or 5.0
-                            ),
+                            "alpha_percent": leg2_alpha_percent,
                             "reward_epochs": int(
                                 getattr(self.config, "lab_reward_epochs", 20) or 20
                             ),

--- a/gateway/research_lab/promotion.py
+++ b/gateway/research_lab/promotion.py
@@ -4028,7 +4028,7 @@ class ResearchLabPromotionController:
         if not getattr(self.config, "source_add_rewards_enabled", False):
             return {"source_add_reward_status": "disabled"}
         leg2_alpha_percent = float(
-            getattr(self.config, "source_add_leg2_alpha_percent", 5.0)
+            getattr(self.config, "source_add_leg2_alpha_percent", 0.0)
         )
         if leg2_alpha_percent <= 0.0:
             return {"source_add_reward_status": "disabled"}

--- a/gateway/research_lab/provider_evidence_proxy.py
+++ b/gateway/research_lab/provider_evidence_proxy.py
@@ -69,6 +69,7 @@ from research_lab.eval.provider_evidence_cache import (
     canonical_request_fingerprint,
     load_evidence_cache,
 )
+from research_lab.source_add_identity import normalize_source_add_domain
 from gateway.research_lab.provider_capabilities import (
     EffectiveProviderCapabilities,
     LiveTextModelCatalog,
@@ -551,6 +552,31 @@ def reserved_builtin_provider_ids_sync(path: str = "") -> set[str]:
         for item in capabilities.providers
         if str(item.get("origin") or "") == "builtin"
     }
+
+
+def reserved_builtin_provider_domains_sync(path: str = "") -> set[str]:
+    """API hosts already supplied by the exact built-in provider catalog."""
+
+    static_entries = _load_static_provider_registry(path)
+    domains = {
+        normalize_source_add_domain(entry.base_url)
+        for entry in static_entries
+        if normalize_source_add_domain(entry.base_url)
+    }
+    _entries, capabilities = load_provider_registry_with_capabilities(
+        path,
+        strict_remote=True,
+    )
+    domains.update(
+        domain
+        for item in capabilities.providers
+        if str(item.get("origin") or "") == "builtin"
+        for domain in (
+            normalize_source_add_domain(str(item.get("base_url") or "")),
+        )
+        if domain
+    )
+    return domains
 
 
 def _key_split_enabled(override: bool | None = None) -> bool:

--- a/gateway/research_lab/source_add_workflow.py
+++ b/gateway/research_lab/source_add_workflow.py
@@ -470,8 +470,6 @@ async def _process_functional_probe(
         result=result,
         outcome=outcome,
     )
-    receipt_hash = str(functional_attempt["receipt_hash"])
-    business_hash = str(functional_attempt["business_artifact_hash"])
     status = str(result["result_status"])
     workflow_result = dict(result)
     if status == "retryable" and _retry_allowed(
@@ -492,8 +490,6 @@ async def _process_functional_probe(
             ),
         )
 
-    reward_intent = {}
-    next_work = {}
     release_identity = False
     stage = {
         "passed": "functional_probe_passed",
@@ -504,26 +500,6 @@ async def _process_functional_probe(
     }[status]
     if status == "failed":
         release_identity = True
-    if status == "passed":
-        intent_id = source_add_reward_intent_id(
-            str(current["submission_id"]), str(current["adapter_id"])
-        )
-        reward_work_id = source_add_work_id(
-            str(current["submission_id"]), "leg1_reward", intent_id
-        )
-        reward_intent = {
-            "intent_id": intent_id,
-            "miner_hotkey": str(current["miner_hotkey"]),
-            "functional_receipt_hash": receipt_hash,
-            "business_artifact_hash": business_hash,
-        }
-        next_work = {
-            "work_id": reward_work_id,
-            "work_kind": "leg1_reward",
-            "priority": 30,
-            "job_doc": {"intent_id": intent_id, "attempt_ref": attempt_ref},
-        }
-        stage = "leg1_queued"
     response = await _finish_work(
         work,
         disposition="complete",
@@ -533,8 +509,6 @@ async def _process_functional_probe(
         precheck_doc=dict(current.get("precheck_doc") or {}),
         result_doc=workflow_result,
         functional_attempt=functional_attempt,
-        next_work=next_work,
-        reward_intent=reward_intent,
         release_identity=release_identity,
     )
     logger.info(
@@ -597,8 +571,56 @@ async def _process_provisioning_smoke(
     smoke_attempt["attempt_number"] = attempt_number
     status = str(result.get("result_status") or "")
     if status == "passed":
+        functional = await select_one(
+            "research_lab_source_add_functional_probe_current",
+            filters=(("submission_id", str(current["submission_id"])),),
+        )
+        if (
+            not isinstance(functional, Mapping)
+            or str(functional.get("result_status") or "") != "passed"
+            or str(functional.get("adapter_id") or "")
+            != str(current["adapter_id"])
+        ):
+            raise SourceAddWorkflowError(
+                "SOURCE_ADD provisioning functional proof is missing"
+            )
+        functional_result = functional.get("result_doc")
+        functional_receipt_hash = str(functional.get("receipt_hash") or "")
+        functional_artifact_hash = str(
+            functional.get("business_artifact_hash") or ""
+        )
+        if (
+            not isinstance(functional_result, Mapping)
+            or not _HASH_RE.fullmatch(functional_receipt_hash)
+            or functional_artifact_hash
+            != sha256_json(dict(functional_result))
+        ):
+            raise SourceAddWorkflowError(
+                "SOURCE_ADD provisioning functional proof differs"
+            )
+        intent_id = source_add_reward_intent_id(
+            str(current["submission_id"]), str(current["adapter_id"])
+        )
+        reward_work_id = source_add_work_id(
+            str(current["submission_id"]), "leg1_reward", intent_id
+        )
+        reward_intent = {
+            "intent_id": intent_id,
+            "miner_hotkey": str(current["miner_hotkey"]),
+            "functional_receipt_hash": functional_receipt_hash,
+            "business_artifact_hash": functional_artifact_hash,
+        }
+        next_work = {
+            "work_id": reward_work_id,
+            "work_kind": "leg1_reward",
+            "priority": 30,
+            "job_doc": {
+                "intent_id": intent_id,
+                "attempt_ref": str(functional.get("attempt_ref") or ""),
+            },
+        }
         finalized = await _rpc(
-            "research_lab_source_add_finalize_provision_smoke",
+            "research_lab_source_add_finalize_provision_smoke_v2",
             {
                 "p_work_id": str(work["work_id"]),
                 "p_lease_token": str(work["lease_token"]),
@@ -606,6 +628,8 @@ async def _process_provisioning_smoke(
                 "p_catalog_row": dict(catalog_row),
                 "p_provision_row": dict(provision_row),
                 "p_smoke_attempt": smoke_attempt,
+                "p_reward_intent": reward_intent,
+                "p_next_work": next_work,
             },
         )
         final_status = str(finalized.get("status") or "")
@@ -682,6 +706,86 @@ def _functional_attempt_doc(
     }
 
 
+async def _load_leg1_approval_evidence(
+    *,
+    current: Mapping[str, Any],
+    functional: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    submission_id = str(current.get("submission_id") or "")
+    adapter_id = str(current.get("adapter_id") or "")
+    miner_hotkey = str(current.get("miner_hotkey") or "")
+    accepted_rows = await select_many(
+        "research_lab_source_add_submissions",
+        filters=(("submission_id", submission_id), ("stage", "accepted")),
+        order_by=(("seq", True),),
+        limit=2,
+    )
+    provision = await select_one(
+        "research_lab_source_add_provisioning_current",
+        filters=(("adapter_id", adapter_id),),
+    )
+    smoke = await select_one(
+        "research_lab_source_add_provisioning_smoke_current",
+        filters=(("submission_id", submission_id),),
+    )
+    catalog = await select_one(
+        "research_lab_source_catalog",
+        filters=(("adapter_id", adapter_id),),
+    )
+    if (
+        len(accepted_rows) != 1
+        or not isinstance(provision, Mapping)
+        or not isinstance(smoke, Mapping)
+        or not isinstance(catalog, Mapping)
+    ):
+        raise SourceAddWorkflowError(
+            "SOURCE_ADD Leg 1 final approval evidence is missing"
+        )
+    accepted = accepted_rows[0]
+    if (
+        str(accepted.get("adapter_id") or "") != adapter_id
+        or str(accepted.get("miner_hotkey") or "") != miner_hotkey
+        or str(accepted.get("precheck_status") or "")
+        != "provenance_precheck_passed"
+        or str(provision.get("submission_id") or "") != submission_id
+        or str(provision.get("adapter_id") or "") != adapter_id
+        or str(provision.get("miner_hotkey") or "") != miner_hotkey
+        or str(provision.get("provision_status") or "")
+        != "provisioned_autoresearch_eligible"
+        or str(smoke.get("submission_id") or "") != submission_id
+        or str(smoke.get("adapter_id") or "") != adapter_id
+        or str(smoke.get("evaluation_mode") or "") != "provisioning_smoke"
+        or str(smoke.get("result_status") or "") != "passed"
+        or str(smoke.get("config_ref") or "")
+        != str(functional.get("config_ref") or "")
+        or str(catalog.get("catalog_id") or "")
+        != str(provision.get("catalog_id") or "")
+        or str(catalog.get("miner_ref") or "") != miner_hotkey
+        or str(catalog.get("registry_provider_id") or "")
+        != str(provision.get("registry_provider_id") or "")
+    ):
+        raise SourceAddWorkflowError(
+            "SOURCE_ADD Leg 1 final approval evidence differs"
+        )
+    smoke_result = smoke.get("result_doc")
+    smoke_receipt_hash = str(smoke.get("receipt_hash") or "")
+    smoke_artifact_hash = str(smoke.get("business_artifact_hash") or "")
+    if (
+        not isinstance(smoke_result, Mapping)
+        or not _HASH_RE.fullmatch(smoke_receipt_hash)
+        or smoke_artifact_hash != sha256_json(dict(smoke_result))
+    ):
+        raise SourceAddWorkflowError(
+            "SOURCE_ADD Leg 1 provisioning smoke proof differs"
+        )
+    return {
+        "accepted": dict(accepted),
+        "catalog": dict(catalog),
+        "provision": dict(provision),
+        "smoke": dict(smoke),
+    }
+
+
 async def _process_leg1_reward(
     work: Mapping[str, Any], *, config: ResearchLabGatewayConfig
 ) -> dict[str, Any]:
@@ -743,11 +847,25 @@ async def _process_leg1_reward(
         raise SourceAddWorkflowError("SOURCE_ADD reward intent proof differs")
     from gateway.research_lab.attested_v2_store import load_business_artifact_graph_v2
 
-    graph = await load_business_artifact_graph_v2(
+    functional_graph = await load_business_artifact_graph_v2(
         artifact_kind="source_add_functional_probe",
         artifact_ref=str(functional.get("attempt_ref") or ""),
         artifact_hash=business_hash,
     )
+    approval = await _load_leg1_approval_evidence(
+        current=current,
+        functional=functional,
+    )
+    smoke = approval["smoke"]
+    smoke_result = dict(smoke["result_doc"])
+    smoke_receipt_hash = str(smoke["receipt_hash"])
+    smoke_business_hash = str(smoke["business_artifact_hash"])
+    smoke_graph = await load_business_artifact_graph_v2(
+        artifact_kind="source_add_provisioning_smoke",
+        artifact_ref=str(smoke.get("attempt_ref") or ""),
+        artifact_hash=smoke_business_hash,
+    )
+    provision = approval["provision"]
     current_epoch, _block, _source = await resolve_research_lab_evaluation_epoch(
         getattr(config, "evaluation_epoch", 0)
     )
@@ -760,6 +878,19 @@ async def _process_leg1_reward(
         "functional_probe_result_hash": sha256_json(dict(functional_result)),
         "evaluator_version": str(functional_result.get("evaluator_version") or ""),
         "route_hash": str(functional_result.get("route_hash") or ""),
+        "provisioning_smoke_passed": True,
+        "provisioning_smoke_attempt_ref": str(smoke.get("attempt_ref") or ""),
+        "provisioning_smoke_receipt_hash": smoke_receipt_hash,
+        "provisioning_smoke_business_artifact_hash": smoke_business_hash,
+        "provisioning_smoke_result_hash": sha256_json(smoke_result),
+        "submission_id": str(current["submission_id"]),
+        "final_acceptance_stage": "accepted",
+        "provision_ref": str(provision.get("provision_ref") or ""),
+        "catalog_id": str(provision.get("catalog_id") or ""),
+        "registry_provider_id": str(
+            provision.get("registry_provider_id") or ""
+        ),
+        "provision_status": "provisioned_autoresearch_eligible",
     }
     existing_rewards = []
     existing = await select_one(
@@ -790,12 +921,16 @@ async def _process_leg1_reward(
             "alpha_percent": float(config.source_add_leg1_alpha_percent),
             "reward_epochs": int(config.lab_reward_epochs),
             "functional_probe_result": dict(functional_result),
+            "provisioning_smoke_result": smoke_result,
+            "accepted_submission": approval["accepted"],
+            "provision": provision,
+            "catalog": approval["catalog"],
             "trigger_evidence": trigger,
         },
         expected_result={"decision_kind": "source_add_leg1", "reward": leg1.to_dict()},
         artifact_kind="source_add_reward_decision",
         artifact_ref=leg1.reward_ref,
-        parent_graphs=(graph,),
+        parent_graphs=(functional_graph, smoke_graph),
     )
     decision_receipt = authority.get("execution_receipt") or authority.get("receipt")
     if not isinstance(decision_receipt, Mapping):

--- a/gateway/tee/coordinator_executor_v2.py
+++ b/gateway/tee/coordinator_executor_v2.py
@@ -851,6 +851,50 @@ class CoordinatorExecutorV2:
             graphs = list(context.external_receipt_authority_graphs())
         except ExecutionJobV2Error as exc:
             raise ValueError("reward decision parent authority is invalid") from exc
+        decision_payload = payload.get("decision_payload")
+        if not isinstance(decision_payload, Mapping):
+            raise ValueError("reward decision input is invalid")
+        if kind == "source_add_leg1":
+            functional = decision_payload.get("functional_probe_result")
+            smoke = decision_payload.get("provisioning_smoke_result")
+            roots = []
+            for graph in graphs:
+                root_hash = str(graph.get("root_receipt_hash") or "")
+                root = next(
+                    (
+                        receipt
+                        for receipt in graph.get("receipts") or ()
+                        if isinstance(receipt, Mapping)
+                        and receipt.get("receipt_hash") == root_hash
+                    ),
+                    None,
+                )
+                if not isinstance(root, Mapping):
+                    raise ValueError("reward decision parent purpose is invalid")
+                roots.append((root_hash, root))
+            if (
+                not isinstance(functional, Mapping)
+                or not isinstance(smoke, Mapping)
+                or len(graphs) != 2
+                or len(context.parent_receipt_hashes) != 2
+                or len(set(context.parent_receipt_hashes)) != 2
+                or {root_hash for root_hash, _root in roots}
+                != set(context.parent_receipt_hashes)
+                or any(
+                    root.get("purpose")
+                    != "research_lab.source_add_functional_probe.v2"
+                    for _root_hash, root in roots
+                )
+                or {str(root.get("output_root") or "") for _root_hash, root in roots}
+                != {
+                    sha256_json(dict(functional)),
+                    sha256_json(dict(smoke)),
+                }
+            ):
+                raise ValueError(
+                    "SOURCE_ADD Leg 1 requires exact functional and smoke parents"
+                )
+            return
         if len(graphs) != 1 or len(context.parent_receipt_hashes) != 1:
             raise ValueError("reward decision requires exactly one parent graph")
         graph = graphs[0]
@@ -867,16 +911,11 @@ class CoordinatorExecutorV2:
             or root_hash not in context.parent_receipt_hashes
         ):
             raise ValueError("reward decision parent purpose is invalid")
-        decision_payload = payload.get("decision_payload")
-        if not isinstance(decision_payload, Mapping):
-            raise ValueError("reward decision input is invalid")
         bound_result = None
         if kind == "champion":
             promotion_decision = decision_payload.get("promotion_decision")
             if isinstance(promotion_decision, Mapping):
                 bound_result = {"decision": dict(promotion_decision)}
-        elif kind == "source_add_leg1":
-            bound_result = decision_payload.get("functional_probe_result")
         elif kind == "source_add_leg2":
             bound_result = decision_payload.get("judge_result")
         elif kind == "reimbursement":

--- a/gateway/tee/coordinator_reward_source_v2.py
+++ b/gateway/tee/coordinator_reward_source_v2.py
@@ -118,29 +118,35 @@ class CoordinatorRewardSourceV2:
         )
         if kind == "source_add_leg1":
             functional = decision.get("functional_probe_result")
+            smoke_result = decision.get("provisioning_smoke_result")
             if (
                 not isinstance(functional, Mapping)
                 or functional.get("result_status") != "passed"
+                or not isinstance(smoke_result, Mapping)
+                or smoke_result.get("result_status") != "passed"
+                or smoke_result.get("evaluation_mode") != "provisioning_smoke"
             ):
                 raise CoordinatorRewardSourceV2Error(
-                    "SOURCE_ADD Leg 1 functional result is invalid"
+                    "SOURCE_ADD Leg 1 measured results are invalid"
                 )
             submission_id = str(functional.get("submission_id") or "")
-            submission_rows = self._read(
-                "source_add_submission_by_id",
+            accepted_rows = self._read(
+                "source_add_accepted_submission_by_id",
                 {"submission_id": submission_id},
                 context,
             )
-            if len(submission_rows) != 1:
+            if len(accepted_rows) != 1:
                 raise CoordinatorRewardSourceV2Error(
-                    "SOURCE_ADD submission owner is missing or ambiguous"
+                    "SOURCE_ADD accepted submission is missing or ambiguous"
                 )
-            submission = submission_rows[0]
+            accepted = accepted_rows[0]
             if (
-                str(submission.get("adapter_id") or "") != adapter_id
-                or str(submission.get("miner_hotkey") or "")
+                str(accepted.get("submission_id") or "") != submission_id
+                or str(accepted.get("adapter_id") or "") != adapter_id
+                or str(accepted.get("miner_hotkey") or "")
                 != str(decision.get("miner_ref") or "")
-                or str(submission.get("precheck_status") or "")
+                or str(accepted.get("stage") or "") != "accepted"
+                or str(accepted.get("precheck_status") or "")
                 != "provenance_precheck_passed"
             ):
                 raise CoordinatorRewardSourceV2Error(
@@ -156,66 +162,155 @@ class CoordinatorRewardSourceV2:
                     "SOURCE_ADD functional result is missing or ambiguous"
                 )
             measured = functional_rows[0]
+            smoke_rows = self._read(
+                "source_add_provisioning_smoke_by_submission",
+                {"submission_id": submission_id},
+                context,
+            )
+            provision_rows = self._read(
+                "source_add_provisioning_by_adapter",
+                {"adapter_id": adapter_id},
+                context,
+            )
+            catalog_rows = self._read(
+                "source_add_catalog_by_adapter",
+                {"adapter_id": adapter_id},
+                context,
+            )
+            if (
+                len(smoke_rows) != 1
+                or len(provision_rows) != 1
+                or len(catalog_rows) != 1
+            ):
+                raise CoordinatorRewardSourceV2Error(
+                    "SOURCE_ADD Leg 1 approval evidence is missing or ambiguous"
+                )
+            measured_smoke = smoke_rows[0]
+            provision = provision_rows[0]
+            catalog = catalog_rows[0]
             if (
                 str(measured.get("adapter_id") or "") != adapter_id
                 or str(measured.get("result_status") or "") != "passed"
                 or dict(measured.get("result_doc") or {}) != dict(functional)
+                or str(measured_smoke.get("submission_id") or "")
+                != submission_id
+                or str(measured_smoke.get("adapter_id") or "") != adapter_id
+                or str(measured_smoke.get("evaluation_mode") or "")
+                != "provisioning_smoke"
+                or str(measured_smoke.get("result_status") or "") != "passed"
+                or str(measured_smoke.get("config_ref") or "")
+                != str(measured.get("result_doc", {}).get("config_ref") or "")
+                or dict(measured_smoke.get("result_doc") or {})
+                != dict(smoke_result)
+                or str(provision.get("submission_id") or "") != submission_id
+                or str(provision.get("adapter_id") or "") != adapter_id
+                or str(provision.get("miner_hotkey") or "")
+                != str(decision.get("miner_ref") or "")
+                or str(provision.get("provision_status") or "")
+                != "provisioned_autoresearch_eligible"
+                or str(catalog.get("catalog_id") or "")
+                != str(provision.get("catalog_id") or "")
+                or str(catalog.get("adapter_id") or "") != adapter_id
+                or str(catalog.get("miner_ref") or "")
+                != str(decision.get("miner_ref") or "")
+                or str(catalog.get("registry_provider_id") or "")
+                != str(provision.get("registry_provider_id") or "")
             ):
                 raise CoordinatorRewardSourceV2Error(
-                    "SOURCE_ADD Leg 1 functional result differs from measured state"
+                    "SOURCE_ADD Leg 1 approval evidence differs from measured state"
                 )
             try:
                 graphs = list(context.external_receipt_authority_graphs())
             except ExecutionJobV2Error as exc:
                 raise CoordinatorRewardSourceV2Error(
-                    "SOURCE_ADD Leg 1 functional parent is invalid"
+                    "SOURCE_ADD Leg 1 measured parents are invalid"
                 ) from exc
-            if len(graphs) != 1:
-                raise CoordinatorRewardSourceV2Error(
-                    "SOURCE_ADD Leg 1 requires one functional parent"
-                )
-            graph = graphs[0]
-            root_hash = str(graph.get("root_receipt_hash") or "")
-            root = next(
-                (
-                    item
-                    for item in graph.get("receipts") or ()
-                    if isinstance(item, Mapping)
-                    and item.get("receipt_hash") == root_hash
-                ),
-                None,
-            )
+            functional_receipt_hash = str(measured.get("receipt_hash") or "")
+            smoke_receipt_hash = str(measured_smoke.get("receipt_hash") or "")
+            expected_parents = {functional_receipt_hash, smoke_receipt_hash}
+            graphs_by_root = {
+                str(graph.get("root_receipt_hash") or ""): graph
+                for graph in graphs
+            }
             if (
-                not isinstance(root, Mapping)
-                or root.get("purpose")
-                != "research_lab.source_add_functional_probe.v2"
-                or root.get("output_root") != sha256_json(dict(functional))
-                or tuple(context.parent_receipt_hashes) != (root_hash,)
-                or str(measured.get("receipt_hash") or "") != root_hash
+                len(graphs) != 2
+                or len(expected_parents) != 2
+                or set(context.parent_receipt_hashes) != expected_parents
+                or set(graphs_by_root) != expected_parents
             ):
                 raise CoordinatorRewardSourceV2Error(
-                    "SOURCE_ADD Leg 1 functional receipt differs from measured state"
+                    "SOURCE_ADD Leg 1 requires functional and smoke parents"
+                )
+            parent_roots = {}
+            for root_hash, graph in graphs_by_root.items():
+                parent_roots[root_hash] = next(
+                    (
+                        item
+                        for item in graph.get("receipts") or ()
+                        if isinstance(item, Mapping)
+                        and item.get("receipt_hash") == root_hash
+                    ),
+                    None,
+                )
+            functional_root = parent_roots.get(functional_receipt_hash)
+            smoke_root = parent_roots.get(smoke_receipt_hash)
+            functional_result_hash = sha256_json(dict(functional))
+            smoke_result_hash = sha256_json(dict(smoke_result))
+            if (
+                not isinstance(functional_root, Mapping)
+                or not isinstance(smoke_root, Mapping)
+                or functional_root.get("purpose")
+                != "research_lab.source_add_functional_probe.v2"
+                or smoke_root.get("purpose")
+                != "research_lab.source_add_functional_probe.v2"
+                or functional_root.get("output_root") != functional_result_hash
+                or smoke_root.get("output_root") != smoke_result_hash
+                or str(measured.get("business_artifact_hash") or "")
+                != functional_result_hash
+                or str(measured_smoke.get("business_artifact_hash") or "")
+                != smoke_result_hash
+            ):
+                raise CoordinatorRewardSourceV2Error(
+                    "SOURCE_ADD Leg 1 measured receipts differ from durable state"
                 )
             trigger = decision.get("trigger_evidence")
             expected_trigger = {
                 "functional_probe_passed": True,
                 "attempt_ref": str(measured.get("attempt_ref") or ""),
-                "functional_probe_receipt_hash": root_hash,
+                "functional_probe_receipt_hash": functional_receipt_hash,
                 "business_artifact_hash": str(
                     measured.get("business_artifact_hash") or ""
                 ),
-                "functional_probe_result_hash": sha256_json(dict(functional)),
+                "functional_probe_result_hash": functional_result_hash,
                 "evaluator_version": str(functional.get("evaluator_version") or ""),
                 "route_hash": str(functional.get("route_hash") or ""),
+                "provisioning_smoke_passed": True,
+                "provisioning_smoke_attempt_ref": str(
+                    measured_smoke.get("attempt_ref") or ""
+                ),
+                "provisioning_smoke_receipt_hash": smoke_receipt_hash,
+                "provisioning_smoke_business_artifact_hash": str(
+                    measured_smoke.get("business_artifact_hash") or ""
+                ),
+                "provisioning_smoke_result_hash": smoke_result_hash,
+                "submission_id": submission_id,
+                "final_acceptance_stage": "accepted",
+                "provision_ref": str(provision.get("provision_ref") or ""),
+                "catalog_id": str(provision.get("catalog_id") or ""),
+                "registry_provider_id": str(
+                    provision.get("registry_provider_id") or ""
+                ),
+                "provision_status": "provisioned_autoresearch_eligible",
             }
             if not isinstance(trigger, Mapping) or dict(trigger) != expected_trigger:
                 raise CoordinatorRewardSourceV2Error(
-                    "SOURCE_ADD Leg 1 trigger differs from measured functional proof"
+                    "SOURCE_ADD Leg 1 trigger differs from measured approval proof"
                 )
-            if not str(measured.get("business_artifact_hash") or ""):
-                raise CoordinatorRewardSourceV2Error(
-                    "SOURCE_ADD Leg 1 business artifact link is missing"
-                )
+            decision["functional_probe_result"] = dict(functional)
+            decision["provisioning_smoke_result"] = dict(smoke_result)
+            decision["accepted_submission"] = dict(accepted)
+            decision["provision"] = dict(provision)
+            decision["catalog"] = dict(catalog)
         else:
             judge_result = decision.get("judge_result")
             if not isinstance(judge_result, Mapping):

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1,5 +1,5 @@
 {
-  "baseline_commit": "e1e356d1de564582f4180312d94cf92ddcfc18bf",
+  "baseline_commit": "cce709bcca9c295ebfa87c4ab68aa379ec0cf90c",
   "entries": [
     {
       "ast_sha256": "sha256:9366486b15b75d5a2a299caacc86b70e706f1c9bccf99721d18fedc375824e55",
@@ -1572,7 +1572,7 @@
       "symbol": "PRIVATE_MODEL_EXACT_GIT_SHA_RE"
     },
     {
-      "ast_sha256": "sha256:e25a5393c1d00d53924db53cd37462371afbfb844830195af458a9c71c3ab201",
+      "ast_sha256": "sha256:a39e940b1f20642a99701df55572ff741029e53d5d8ca155bffde66a89838aa4",
       "path": "gateway/research_lab/promotion.py",
       "symbol": "ResearchLabPromotionController._maybe_create_source_add_implementation_rewards"
     },
@@ -2877,12 +2877,12 @@
       "symbol": "build_source_add_sandbox_runner"
     },
     {
-      "ast_sha256": "sha256:eb58f58a3cff3bd9f0503ce0fd0150e46766dfd3d5da2fbfe6055156b34d953f",
+      "ast_sha256": "sha256:759e6f59131ff195fe157523162a378d3951e71c1a119215dc6ec721843b49c3",
       "path": "gateway/research_lab/source_add_workflow.py",
       "symbol": "_process_functional_probe"
     },
     {
-      "ast_sha256": "sha256:c7107427c91a081ab7c5795a5ef8609742b7f6cf88f44e490b9f37836490bf0e",
+      "ast_sha256": "sha256:b2cf79fa54af839115f4e6f6c3b4c65ff7cfc740be4d45d421f0d7f012b1aa6c",
       "path": "gateway/research_lab/source_add_workflow.py",
       "symbol": "_process_leg1_reward"
     },
@@ -3332,7 +3332,7 @@
       "symbol": "attest_subnet_epoch_cutover_v2"
     },
     {
-      "ast_sha256": "sha256:d338417e221382280fd23696f7b1dab8f47931b040249c85431fc75e6a04d0ec",
+      "ast_sha256": "sha256:ca8faf17c0ecb0cb4ba7447636fb642bc6f47f8ed22f1df31644e0abf25cbd20",
       "path": "gateway/tee/coordinator_executor_v2.py",
       "symbol": "CoordinatorExecutorV2"
     },
@@ -3342,7 +3342,7 @@
       "symbol": "CoordinatorLegacySettlementSourceV2"
     },
     {
-      "ast_sha256": "sha256:01ee1910dda0550468e613f49d1933a63226b4c7455415e761352e71dd531ec2",
+      "ast_sha256": "sha256:dcc2474e43278eaaf95ef037bc56fd88f9bb7f116c4a5b1813dc7f457c0882c8",
       "path": "gateway/tee/coordinator_reward_source_v2.py",
       "symbol": "CoordinatorRewardSourceV2"
     },
@@ -5577,7 +5577,7 @@
       "symbol": "validate_source_add_sealed_job_envelope_v2"
     },
     {
-      "ast_sha256": "sha256:010f745bc0d1341476f56f18d0df211e55828c120736cf4783a5af2fe900b15e",
+      "ast_sha256": "sha256:e5507549277fb52720e4da3687be6bfa531328fcbdb45ebde9f08616967f7ace",
       "path": "gateway/tee/supabase_source_v2.py",
       "symbol": "QUERY_POLICIES"
     },
@@ -5587,7 +5587,7 @@
       "symbol": "SupabaseSourceReaderV2"
     },
     {
-      "ast_sha256": "sha256:50693093114c6ba1097db715e2344424a6eaa24acddf3ab6db2b24c838ab08cc",
+      "ast_sha256": "sha256:b2d047ada36da5a1f4b4df918767d499b56b0d9bec2043e3a1d346c7df57042f",
       "path": "gateway/tee/supabase_source_v2.py",
       "symbol": "_filters"
     },
@@ -8217,7 +8217,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:67d2c0589d04580d2d31ddb9d12f7ede3494c0fe424c86b7fa4c97a21f9bf88d",
-  "protected_source_commit": "e1e356d1de564582f4180312d94cf92ddcfc18bf",
+  "manifest_hash": "sha256:3e1433ca1206154e00cffa7320a96ac2163a81e676cf063673eb5a1c1a25f947",
+  "protected_source_commit": "cce709bcca9c295ebfa87c4ab68aa379ec0cf90c",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/gateway/tee/reward_executor_v2.py
+++ b/gateway/tee/reward_executor_v2.py
@@ -320,7 +320,14 @@ def _source_add(kind: str, value: Mapping[str, Any]) -> Dict[str, Any]:
     expected = common | (
         {"trigger_evidence", "judge_result"}
         if kind == "source_add_leg2"
-        else {"functional_probe_result", "trigger_evidence"}
+        else {
+            "functional_probe_result",
+            "provisioning_smoke_result",
+            "accepted_submission",
+            "provision",
+            "catalog",
+            "trigger_evidence",
+        }
     )
     if set(value) != expected:
         raise RewardExecutorV2Error("SOURCE_ADD reward fields are invalid")
@@ -338,15 +345,70 @@ def _source_add(kind: str, value: Mapping[str, Any]) -> Dict[str, Any]:
     }
     if kind == "source_add_leg1":
         functional_probe = value.get("functional_probe_result")
+        provisioning_smoke = value.get("provisioning_smoke_result")
+        accepted = value.get("accepted_submission")
+        provision = value.get("provision")
+        catalog = value.get("catalog")
         trigger = value.get("trigger_evidence")
         if (
             not isinstance(functional_probe, Mapping)
             or functional_probe.get("result_status") != "passed"
+            or not isinstance(provisioning_smoke, Mapping)
+            or provisioning_smoke.get("evaluation_mode") != "provisioning_smoke"
+            or provisioning_smoke.get("result_status") != "passed"
+            or not isinstance(accepted, Mapping)
+            or accepted.get("stage") != "accepted"
+            or accepted.get("precheck_status")
+            != "provenance_precheck_passed"
+            or not isinstance(provision, Mapping)
+            or provision.get("provision_status")
+            != "provisioned_autoresearch_eligible"
+            or not isinstance(catalog, Mapping)
             or not isinstance(trigger, Mapping)
             or trigger.get("functional_probe_passed") is not True
+            or trigger.get("provisioning_smoke_passed") is not True
         ):
             raise RewardExecutorV2Error(
-                "SOURCE_ADD Leg 1 functional result is invalid"
+                "SOURCE_ADD Leg 1 approval evidence is invalid"
+            )
+        submission_id = str(functional_probe.get("submission_id") or "")
+        adapter_id = str(value.get("adapter_id") or "")
+        miner_ref = str(value.get("miner_ref") or "")
+        if (
+            not submission_id
+            or str(functional_probe.get("adapter_id") or "") != adapter_id
+            or str(provisioning_smoke.get("submission_id") or "")
+            != submission_id
+            or str(provisioning_smoke.get("adapter_id") or "") != adapter_id
+            or str(provisioning_smoke.get("config_ref") or "")
+            != str(functional_probe.get("config_ref") or "")
+            or str(accepted.get("submission_id") or "") != submission_id
+            or str(accepted.get("adapter_id") or "") != adapter_id
+            or str(accepted.get("miner_hotkey") or "") != miner_ref
+            or str(provision.get("submission_id") or "") != submission_id
+            or str(provision.get("adapter_id") or "") != adapter_id
+            or str(provision.get("miner_hotkey") or "") != miner_ref
+            or str(catalog.get("catalog_id") or "")
+            != str(provision.get("catalog_id") or "")
+            or str(catalog.get("adapter_id") or "") != adapter_id
+            or str(catalog.get("miner_ref") or "") != miner_ref
+            or str(catalog.get("registry_provider_id") or "")
+            != str(provision.get("registry_provider_id") or "")
+            or trigger.get("submission_id") != submission_id
+            or trigger.get("final_acceptance_stage") != "accepted"
+            or trigger.get("functional_probe_result_hash")
+            != sha256_json(dict(functional_probe))
+            or trigger.get("provisioning_smoke_result_hash")
+            != sha256_json(dict(provisioning_smoke))
+            or trigger.get("provision_ref") != provision.get("provision_ref")
+            or trigger.get("catalog_id") != provision.get("catalog_id")
+            or trigger.get("registry_provider_id")
+            != provision.get("registry_provider_id")
+            or trigger.get("provision_status")
+            != "provisioned_autoresearch_eligible"
+        ):
+            raise RewardExecutorV2Error(
+                "SOURCE_ADD Leg 1 approval evidence differs"
             )
         reward = create_leg1_reward(
             miner_ref=str(value.get("miner_ref") or ""),

--- a/gateway/tee/supabase_schema_preflight_v2.py
+++ b/gateway/tee/supabase_schema_preflight_v2.py
@@ -406,6 +406,20 @@ REQUIRED_SUPABASE_V2_SCHEMA = (
     ),
     (
         "scripts/96-research-lab-source-add-functional-workflow.sql",
+        "research_lab_source_add_submissions",
+        (
+            "submission_id",
+            "adapter_id",
+            "miner_hotkey",
+            "stage",
+            "seq",
+            "precheck_status",
+            "source_identity_hash",
+            "source_identity_version",
+        ),
+    ),
+    (
+        "scripts/96-research-lab-source-add-functional-workflow.sql",
         "research_lab_source_add_submission_current",
         (
             "submission_id",
@@ -480,8 +494,10 @@ REQUIRED_SUPABASE_V2_SCHEMA = (
             "evaluation_mode",
             "config_ref",
             "result_status",
+            "route_hash",
             "receipt_hash",
             "business_artifact_hash",
+            "result_doc",
         ),
     ),
     (
@@ -1047,6 +1063,14 @@ REQUIRED_SUPABASE_V2_RPCS = (
     (
         "scripts/145-research-lab-source-add-admission-control.sql",
         "research_lab_source_add_admission_control_contract_v1",
+    ),
+    (
+        "scripts/167-research-lab-source-add-post-accept-leg1.sql",
+        "research_lab_source_add_finalize_provision_smoke_v2",
+    ),
+    (
+        "scripts/167-research-lab-source-add-post-accept-leg1.sql",
+        "research_lab_source_add_post_accept_leg1_contract_v1",
     ),
     (
         "scripts/153-research-lab-private-model-lineage-generation.sql",

--- a/gateway/tee/supabase_source_v2.py
+++ b/gateway/tee/supabase_source_v2.py
@@ -254,6 +254,18 @@ QUERY_POLICIES = {
         max_pages=1,
         limit=2,
     ),
+    "source_add_accepted_submission_by_id": SupabaseQueryV2(
+        policy_id="source_add_accepted_submission_by_id",
+        table="research_lab_source_add_submissions",
+        select=(
+            "submission_id,adapter_id,miner_hotkey,stage,precheck_status,"
+            "source_identity_hash,source_identity_version,seq"
+        ),
+        parameter_names=("submission_id",),
+        max_pages=1,
+        order="seq.desc",
+        limit=2,
+    ),
     "source_add_probe_config_by_submission": SupabaseQueryV2(
         policy_id="source_add_probe_config_by_submission",
         table="research_lab_source_add_probe_config_current",
@@ -277,6 +289,18 @@ QUERY_POLICIES = {
         max_pages=1,
         limit=2,
     ),
+    "source_add_provisioning_smoke_by_submission": SupabaseQueryV2(
+        policy_id="source_add_provisioning_smoke_by_submission",
+        table="research_lab_source_add_provisioning_smoke_current",
+        select=(
+            "attempt_ref,submission_id,adapter_id,evaluation_mode,config_ref,"
+            "result_status,route_hash,receipt_hash,business_artifact_hash,"
+            "result_doc,created_at"
+        ),
+        parameter_names=("submission_id",),
+        max_pages=1,
+        limit=2,
+    ),
     "source_add_leg1_events_since": SupabaseQueryV2(
         policy_id="source_add_leg1_events_since",
         table="research_lab_source_add_reward_events",
@@ -295,6 +319,17 @@ QUERY_POLICIES = {
         parameter_names=("adapter_id",),
         max_pages=1,
         order="adapter_id.asc",
+        limit=2,
+    ),
+    "source_add_catalog_by_adapter": SupabaseQueryV2(
+        policy_id="source_add_catalog_by_adapter",
+        table="research_lab_source_catalog",
+        select=(
+            "catalog_id,adapter_id,miner_ref,registry_provider_id,"
+            "source_identity_hash"
+        ),
+        parameter_names=("adapter_id",),
+        max_pages=1,
         limit=2,
     ),
     "source_add_provisioning_eligible": SupabaseQueryV2(
@@ -945,8 +980,10 @@ def _filters(policy: SupabaseQueryV2, parameters: Mapping[str, Any]) -> Sequence
         )
     if policy.policy_id in {
         "source_add_submission_by_id",
+        "source_add_accepted_submission_by_id",
         "source_add_probe_config_by_submission",
         "source_add_functional_probe_by_submission",
+        "source_add_provisioning_smoke_by_submission",
     }:
         submission_id = _identifier(parameters["submission_id"], "submission_id")
         if not re.fullmatch(r"source_add_submission:[0-9a-f]{16}", submission_id):
@@ -954,6 +991,8 @@ def _filters(policy: SupabaseQueryV2, parameters: Mapping[str, Any]) -> Sequence
         filters = [("submission_id", "eq.%s" % submission_id)]
         if policy.policy_id == "source_add_probe_config_by_submission":
             filters.append(("config_status", "eq.active"))
+        if policy.policy_id == "source_add_accepted_submission_by_id":
+            filters.append(("stage", "eq.accepted"))
         return tuple(filters)
     if policy.policy_id == "source_add_leg1_events_since":
         day_start = _identifier(parameters["day_start"], "day_start")
@@ -966,14 +1005,20 @@ def _filters(policy: SupabaseQueryV2, parameters: Mapping[str, Any]) -> Sequence
             ),
             ("created_at", "gte.%s" % day_start),
         )
-    if policy.policy_id == "source_add_provisioning_by_adapter":
-        return (
+    if policy.policy_id in {
+        "source_add_provisioning_by_adapter",
+        "source_add_catalog_by_adapter",
+    }:
+        filters = [
             (
                 "adapter_id",
                 "eq.%s" % _identifier(parameters["adapter_id"], "adapter_id"),
-            ),
-            ("provision_status", "eq.provisioned_autoresearch_eligible"),
-        )
+            )
+        ]
+        if policy.policy_id == "source_add_catalog_by_adapter":
+            return tuple(filters)
+        filters.append(("provision_status", "eq.provisioned_autoresearch_eligible"))
+        return tuple(filters)
     if policy.policy_id in {
         "source_add_provisioning_eligible",
         "provider_registry_recent",

--- a/research_lab/source_add_rewards.py
+++ b/research_lab/source_add_rewards.py
@@ -4,8 +4,9 @@ Supersedes the P1.5 USD trial-yield bounty bands. Both legs are fixed-term
 emission streams within a separate, first-priority SOURCE_ADD allocation:
 
 - **Leg 1 — functional source submission**: 1% of miner emissions ×
-  ``RESEARCH_LAB_REWARD_EPOCHS`` (20), created only after a measured V2
-  functional probe passes. Flat, one per adapter, ever.
+  ``RESEARCH_LAB_REWARD_EPOCHS`` (20), created only after operator acceptance,
+  eligible provisioning, and measured V2 functional and smoke probes pass.
+  Flat, one per adapter, ever.
 - **Leg 2 — implementation rider**: +5% × 20 epochs to the ADAPTER OWNER,
   created alongside the implementing merge's champion grant only when the
   LLM final judge decides the already-winning change was helped by a known
@@ -158,7 +159,7 @@ def create_leg1_reward(
     state: str = SourceAddRewardState.ACTIVE.value,
     trigger_evidence: Mapping[str, Any] | None = None,
 ) -> SourceAddRewardRecord | None:
-    """Create the measured-functional-source leg. One per adapter, ever.
+    """Create the accepted, provisioned, measured-source leg. One per adapter.
 
     Queue policy is normal FIFO on the allocation rails: pass
     ``state="queued"`` when the lab cap cannot pay right now, exactly like

--- a/scripts/167-research-lab-source-add-post-accept-leg1.sql
+++ b/scripts/167-research-lab-source-add-post-accept-leg1.sql
@@ -1,0 +1,495 @@
+-- Create SOURCE_ADD Leg 1 only after accepted, smoke-tested provisioning.
+--
+-- Historical stopped-forward rewards remain immutable. The triggers below
+-- apply to new intents/work/rewards, while the V2 finalizer atomically turns a
+-- successful provisioning smoke into exactly one queued Leg 1 decision.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+
+CREATE OR REPLACE FUNCTION public.enforce_research_lab_source_add_leg1_intent_after_acceptance()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM public.research_lab_source_add_functional_probe_current functional
+        JOIN public.research_lab_source_add_provisioning_current provision
+          ON provision.submission_id = functional.submission_id
+         AND provision.adapter_id = functional.adapter_id
+        JOIN public.research_lab_source_add_provisioning_smoke_current smoke
+          ON smoke.submission_id = provision.submission_id
+         AND smoke.adapter_id = provision.adapter_id
+        JOIN public.research_lab_source_catalog catalog
+          ON catalog.catalog_id = provision.catalog_id
+         AND catalog.adapter_id = provision.adapter_id
+        WHERE functional.submission_id = NEW.submission_id
+          AND functional.adapter_id = NEW.adapter_id
+          AND functional.result_status = 'passed'
+          AND functional.receipt_hash = NEW.functional_receipt_hash
+          AND functional.business_artifact_hash = NEW.business_artifact_hash
+          AND smoke.result_status = 'passed'
+          AND smoke.evaluation_mode = 'provisioning_smoke'
+          AND smoke.config_ref = functional.config_ref
+          AND provision.miner_hotkey = NEW.miner_hotkey
+          AND provision.provision_status = 'provisioned_autoresearch_eligible'
+          AND catalog.miner_ref = NEW.miner_hotkey
+          AND catalog.registry_provider_id = provision.registry_provider_id
+          AND EXISTS (
+              SELECT 1
+              FROM public.research_lab_source_add_submissions accepted
+              WHERE accepted.submission_id = NEW.submission_id
+                AND accepted.adapter_id = NEW.adapter_id
+                AND accepted.miner_hotkey = NEW.miner_hotkey
+                AND accepted.stage = 'accepted'
+                AND accepted.precheck_status = 'provenance_precheck_passed'
+          )
+          AND EXISTS (
+              SELECT 1
+              FROM public.research_lab_attested_execution_receipts_v2 receipt
+              JOIN public.research_lab_attested_business_artifact_links_v2 link
+                ON link.receipt_hash = receipt.receipt_hash
+              WHERE receipt.receipt_hash = functional.receipt_hash
+                AND receipt.role = 'gateway_coordinator'
+                AND receipt.purpose = 'research_lab.source_add_functional_probe.v2'
+                AND receipt.receipt_status = 'succeeded'
+                AND receipt.output_root = functional.business_artifact_hash
+                AND link.artifact_kind = 'source_add_functional_probe'
+                AND link.artifact_ref = functional.attempt_ref
+                AND link.artifact_hash = functional.business_artifact_hash
+          )
+          AND EXISTS (
+              SELECT 1
+              FROM public.research_lab_attested_execution_receipts_v2 receipt
+              JOIN public.research_lab_attested_business_artifact_links_v2 link
+                ON link.receipt_hash = receipt.receipt_hash
+              WHERE receipt.receipt_hash = smoke.receipt_hash
+                AND receipt.role = 'gateway_coordinator'
+                AND receipt.purpose = 'research_lab.source_add_functional_probe.v2'
+                AND receipt.receipt_status = 'succeeded'
+                AND receipt.output_root = smoke.business_artifact_hash
+                AND link.artifact_kind = 'source_add_provisioning_smoke'
+                AND link.artifact_ref = smoke.attempt_ref
+                AND link.artifact_hash = smoke.business_artifact_hash
+          )
+    ) THEN
+        RAISE EXCEPTION 'SOURCE_ADD Leg 1 requires accepted eligible provisioning'
+            USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_source_add_leg1_intent_after_acceptance
+    ON public.research_lab_source_add_reward_intents;
+CREATE TRIGGER trg_source_add_leg1_intent_after_acceptance
+    BEFORE INSERT ON public.research_lab_source_add_reward_intents
+    FOR EACH ROW EXECUTE FUNCTION public.enforce_research_lab_source_add_leg1_intent_after_acceptance();
+
+CREATE OR REPLACE FUNCTION public.enforce_research_lab_source_add_leg1_work_after_acceptance()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+    IF NEW.work_kind = 'leg1_reward' AND NOT EXISTS (
+        SELECT 1
+        FROM public.research_lab_source_add_reward_intents intent
+        JOIN public.research_lab_source_add_functional_probe_current functional
+          ON functional.submission_id = intent.submission_id
+         AND functional.adapter_id = intent.adapter_id
+        JOIN public.research_lab_source_add_provisioning_current provision
+          ON provision.submission_id = intent.submission_id
+         AND provision.adapter_id = intent.adapter_id
+         AND provision.miner_hotkey = intent.miner_hotkey
+        JOIN public.research_lab_source_add_provisioning_smoke_current smoke
+          ON smoke.submission_id = provision.submission_id
+         AND smoke.adapter_id = provision.adapter_id
+        WHERE intent.intent_id = NEW.job_doc->>'intent_id'
+          AND intent.submission_id = NEW.submission_id
+          AND intent.adapter_id = NEW.adapter_id
+          AND functional.result_status = 'passed'
+          AND functional.receipt_hash = intent.functional_receipt_hash
+          AND functional.business_artifact_hash = intent.business_artifact_hash
+          AND NEW.job_doc = jsonb_build_object(
+              'intent_id', intent.intent_id,
+              'attempt_ref', functional.attempt_ref
+          )
+          AND provision.provision_status = 'provisioned_autoresearch_eligible'
+          AND smoke.result_status = 'passed'
+          AND smoke.evaluation_mode = 'provisioning_smoke'
+          AND EXISTS (
+              SELECT 1
+              FROM public.research_lab_source_add_submissions accepted
+              WHERE accepted.submission_id = intent.submission_id
+                AND accepted.adapter_id = intent.adapter_id
+                AND accepted.miner_hotkey = intent.miner_hotkey
+                AND accepted.stage = 'accepted'
+                AND accepted.precheck_status = 'provenance_precheck_passed'
+          )
+    ) THEN
+        RAISE EXCEPTION 'SOURCE_ADD Leg 1 work requires accepted eligible provisioning'
+            USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_source_add_leg1_work_after_acceptance
+    ON public.research_lab_source_add_work_items;
+CREATE TRIGGER trg_source_add_leg1_work_after_acceptance
+    BEFORE INSERT ON public.research_lab_source_add_work_items
+    FOR EACH ROW EXECUTE FUNCTION public.enforce_research_lab_source_add_leg1_work_after_acceptance();
+
+CREATE OR REPLACE FUNCTION public.bind_research_lab_source_add_leg1_catalog()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    v_catalog_id TEXT;
+BEGIN
+    IF NEW.leg <> 1 THEN
+        RETURN NEW;
+    END IF;
+    SELECT provision.catalog_id INTO v_catalog_id
+    FROM public.research_lab_source_add_reward_intents intent
+    JOIN public.research_lab_source_add_functional_probe_current functional
+      ON functional.submission_id = intent.submission_id
+     AND functional.adapter_id = intent.adapter_id
+    JOIN public.research_lab_source_add_provisioning_current provision
+      ON provision.submission_id = intent.submission_id
+     AND provision.adapter_id = intent.adapter_id
+     AND provision.miner_hotkey = intent.miner_hotkey
+    JOIN public.research_lab_source_add_provisioning_smoke_current smoke
+      ON smoke.submission_id = provision.submission_id
+     AND smoke.adapter_id = provision.adapter_id
+    JOIN public.research_lab_source_catalog catalog
+      ON catalog.catalog_id = provision.catalog_id
+     AND catalog.adapter_id = provision.adapter_id
+     AND catalog.miner_ref = provision.miner_hotkey
+    WHERE intent.adapter_id = NEW.adapter_id
+      AND intent.miner_hotkey = NEW.miner_hotkey
+      AND intent.intent_status = 'leased'
+      AND functional.result_status = 'passed'
+      AND functional.receipt_hash = intent.functional_receipt_hash
+      AND functional.business_artifact_hash = intent.business_artifact_hash
+      AND smoke.result_status = 'passed'
+      AND smoke.evaluation_mode = 'provisioning_smoke'
+      AND smoke.config_ref = functional.config_ref
+      AND provision.provision_status = 'provisioned_autoresearch_eligible'
+      AND catalog.registry_provider_id = provision.registry_provider_id
+      AND NEW.trigger_evidence_doc->>'functional_probe_passed' = 'true'
+      AND NEW.trigger_evidence_doc->>'attempt_ref' = functional.attempt_ref
+      AND NEW.trigger_evidence_doc->>'functional_probe_receipt_hash' = functional.receipt_hash
+      AND NEW.trigger_evidence_doc->>'business_artifact_hash' = functional.business_artifact_hash
+      AND NEW.trigger_evidence_doc->>'functional_probe_result_hash' = functional.business_artifact_hash
+      AND NEW.trigger_evidence_doc->>'evaluator_version' = functional.result_doc->>'evaluator_version'
+      AND NEW.trigger_evidence_doc->>'route_hash' = functional.route_hash
+      AND NEW.trigger_evidence_doc->>'provisioning_smoke_passed' = 'true'
+      AND NEW.trigger_evidence_doc->>'provisioning_smoke_attempt_ref' = smoke.attempt_ref
+      AND NEW.trigger_evidence_doc->>'provisioning_smoke_receipt_hash' = smoke.receipt_hash
+      AND NEW.trigger_evidence_doc->>'provisioning_smoke_business_artifact_hash' = smoke.business_artifact_hash
+      AND NEW.trigger_evidence_doc->>'provisioning_smoke_result_hash' = smoke.business_artifact_hash
+      AND NEW.trigger_evidence_doc->>'submission_id' = intent.submission_id
+      AND NEW.trigger_evidence_doc->>'final_acceptance_stage' = 'accepted'
+      AND NEW.trigger_evidence_doc->>'provision_ref' = provision.provision_ref
+      AND NEW.trigger_evidence_doc->>'catalog_id' = provision.catalog_id
+      AND NEW.trigger_evidence_doc->>'registry_provider_id' = provision.registry_provider_id
+      AND NEW.trigger_evidence_doc->>'provision_status' = 'provisioned_autoresearch_eligible'
+      AND EXISTS (
+          SELECT 1
+          FROM public.research_lab_source_add_submissions accepted
+          WHERE accepted.submission_id = intent.submission_id
+            AND accepted.adapter_id = intent.adapter_id
+            AND accepted.miner_hotkey = intent.miner_hotkey
+            AND accepted.stage = 'accepted'
+            AND accepted.precheck_status = 'provenance_precheck_passed'
+      )
+      AND EXISTS (
+          SELECT 1
+          FROM public.research_lab_attested_execution_receipts_v2 decision
+          JOIN public.research_lab_attested_business_artifact_links_v2 link
+            ON link.receipt_hash = decision.receipt_hash
+          WHERE decision.role = 'gateway_coordinator'
+            AND decision.purpose = 'research_lab.reward_decision.v2'
+            AND decision.receipt_status = 'succeeded'
+            AND link.artifact_kind = 'source_add_reward_decision'
+            AND link.artifact_ref = NEW.reward_ref
+            AND link.artifact_hash = decision.output_root
+            AND pg_catalog.jsonb_typeof(decision.receipt_doc->'parent_receipt_hashes') = 'array'
+            AND pg_catalog.jsonb_array_length(decision.receipt_doc->'parent_receipt_hashes') = 2
+            AND decision.receipt_doc->'parent_receipt_hashes' ? functional.receipt_hash
+            AND decision.receipt_doc->'parent_receipt_hashes' ? smoke.receipt_hash
+            AND (SELECT COUNT(*)
+                 FROM public.research_lab_attested_receipt_edges_v2 edge
+                 WHERE edge.child_receipt_hash = decision.receipt_hash) = 2
+            AND EXISTS (
+                SELECT 1
+                FROM public.research_lab_attested_receipt_edges_v2 edge
+                WHERE edge.child_receipt_hash = decision.receipt_hash
+                  AND edge.parent_receipt_hash = functional.receipt_hash
+            )
+            AND EXISTS (
+                SELECT 1
+                FROM public.research_lab_attested_receipt_edges_v2 edge
+                WHERE edge.child_receipt_hash = decision.receipt_hash
+                  AND edge.parent_receipt_hash = smoke.receipt_hash
+            )
+      );
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'SOURCE_ADD Leg 1 approval or receipt graph differs'
+            USING ERRCODE = '55000';
+    END IF;
+    IF NEW.catalog_id IS NOT NULL AND NEW.catalog_id <> v_catalog_id THEN
+        RAISE EXCEPTION 'SOURCE_ADD Leg 1 catalog binding differs'
+            USING ERRCODE = '55000';
+    END IF;
+    NEW.catalog_id := v_catalog_id;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_source_add_leg1_catalog_binding
+    ON public.research_lab_source_add_reward_obligations;
+CREATE TRIGGER trg_source_add_leg1_catalog_binding
+    BEFORE INSERT ON public.research_lab_source_add_reward_obligations
+    FOR EACH ROW EXECUTE FUNCTION public.bind_research_lab_source_add_leg1_catalog();
+
+CREATE OR REPLACE FUNCTION public.research_lab_source_add_finalize_provision_smoke_v2(
+    p_work_id TEXT,
+    p_lease_token UUID,
+    p_submission_id TEXT,
+    p_catalog_row JSONB,
+    p_provision_row JSONB,
+    p_smoke_attempt JSONB,
+    p_reward_intent JSONB,
+    p_next_work JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    v_work public.research_lab_source_add_work_items%ROWTYPE;
+    v_result JSONB;
+    v_current RECORD;
+    v_probe public.research_lab_source_add_functional_probe_attempts%ROWTYPE;
+    v_intent public.research_lab_source_add_reward_intents%ROWTYPE;
+    v_next public.research_lab_source_add_work_items%ROWTYPE;
+    v_seq INTEGER;
+BEGIN
+    IF COALESCE(jsonb_typeof(p_reward_intent), '') <> 'object'
+       OR COALESCE(jsonb_typeof(p_next_work), '') <> 'object'
+       OR p_reward_intent->>'intent_id' !~ '^source_add_reward_intent:[0-9a-f]{16}$'
+       OR p_reward_intent->>'functional_receipt_hash' !~ '^sha256:[0-9a-f]{64}$'
+       OR p_reward_intent->>'business_artifact_hash' !~ '^sha256:[0-9a-f]{64}$'
+       OR btrim(COALESCE(p_reward_intent->>'miner_hotkey', '')) = ''
+       OR p_reward_intent <> jsonb_build_object(
+           'intent_id', p_reward_intent->>'intent_id',
+           'miner_hotkey', p_reward_intent->>'miner_hotkey',
+           'functional_receipt_hash', p_reward_intent->>'functional_receipt_hash',
+           'business_artifact_hash', p_reward_intent->>'business_artifact_hash'
+       )
+       OR p_next_work->>'work_id' !~ '^source_add_work:[0-9a-f]{16}$'
+       OR p_next_work->>'work_kind' <> 'leg1_reward'
+       OR p_next_work->>'priority' <> '30'
+       OR p_next_work <> jsonb_build_object(
+           'work_id', p_next_work->>'work_id',
+           'work_kind', 'leg1_reward',
+           'priority', 30,
+           'job_doc', jsonb_build_object(
+               'intent_id', p_reward_intent->>'intent_id',
+               'attempt_ref', p_next_work->'job_doc'->>'attempt_ref'
+           )
+       )
+       OR p_next_work->'job_doc'->>'attempt_ref' !~ '^source_add_probe_attempt:[0-9a-f]{16}$' THEN
+        RAISE EXCEPTION 'SOURCE_ADD post-acceptance Leg 1 input is invalid';
+    END IF;
+    SELECT * INTO v_work
+    FROM public.research_lab_source_add_work_items
+    WHERE work_id = p_work_id
+    FOR UPDATE;
+    IF NOT FOUND OR v_work.work_status <> 'leased'
+       OR v_work.work_kind <> 'provisioning_smoke'
+       OR v_work.lease_token IS DISTINCT FROM p_lease_token THEN
+        RETURN jsonb_build_object('status', 'lease_lost');
+    END IF;
+    IF v_work.submission_id <> p_submission_id
+       OR p_smoke_attempt->>'work_id' <> p_work_id
+       OR COALESCE((p_smoke_attempt->>'attempt_number')::INTEGER, 0)
+          <> v_work.attempt_count THEN
+        RAISE EXCEPTION 'SOURCE_ADD provisioning smoke lease binding differs';
+    END IF;
+    v_result := public.research_lab_source_add_finalize_provision(
+        p_submission_id,
+        p_catalog_row,
+        p_provision_row,
+        p_smoke_attempt
+    );
+    IF v_result->>'status' IN ('provisioned', 'already_provisioned') THEN
+        SELECT * INTO v_current
+        FROM public.research_lab_source_add_submission_current
+        WHERE submission_id = p_submission_id;
+        SELECT * INTO v_probe
+        FROM public.research_lab_source_add_functional_probe_current
+        WHERE submission_id = p_submission_id;
+        IF v_current.submission_id IS NULL
+           OR v_current.stage <> 'accepted'
+           OR v_current.adapter_id <> v_work.adapter_id
+           OR v_current.miner_hotkey <> p_reward_intent->>'miner_hotkey'
+           OR v_probe.attempt_ref IS NULL
+           OR v_probe.adapter_id <> v_work.adapter_id
+           OR v_probe.result_status <> 'passed'
+           OR v_probe.receipt_hash <> p_reward_intent->>'functional_receipt_hash'
+           OR v_probe.business_artifact_hash <> p_reward_intent->>'business_artifact_hash'
+           OR v_probe.attempt_ref <> p_next_work->'job_doc'->>'attempt_ref' THEN
+            RAISE EXCEPTION 'SOURCE_ADD post-acceptance Leg 1 proof differs';
+        END IF;
+
+        INSERT INTO public.research_lab_source_add_reward_intents (
+            intent_id, submission_id, adapter_id, miner_hotkey, intent_status,
+            functional_receipt_hash, business_artifact_hash
+        ) VALUES (
+            p_reward_intent->>'intent_id', p_submission_id, v_work.adapter_id,
+            p_reward_intent->>'miner_hotkey', 'queued',
+            p_reward_intent->>'functional_receipt_hash',
+            p_reward_intent->>'business_artifact_hash'
+        ) ON CONFLICT (adapter_id, leg) DO NOTHING;
+        SELECT * INTO v_intent
+        FROM public.research_lab_source_add_reward_intents
+        WHERE adapter_id = v_work.adapter_id AND leg = 1;
+        IF NOT FOUND OR v_intent.intent_id <> p_reward_intent->>'intent_id'
+           OR v_intent.submission_id <> p_submission_id
+           OR v_intent.miner_hotkey <> p_reward_intent->>'miner_hotkey'
+           OR v_intent.functional_receipt_hash <> p_reward_intent->>'functional_receipt_hash'
+           OR v_intent.business_artifact_hash <> p_reward_intent->>'business_artifact_hash' THEN
+            RAISE EXCEPTION 'SOURCE_ADD post-acceptance reward intent idempotency differs';
+        END IF;
+
+        SELECT * INTO v_next
+        FROM public.research_lab_source_add_work_items
+        WHERE submission_id = p_submission_id AND work_kind = 'leg1_reward';
+        IF FOUND THEN
+            IF v_next.work_id <> p_next_work->>'work_id'
+               OR v_next.adapter_id <> v_work.adapter_id
+               OR v_next.job_doc <> p_next_work->'job_doc' THEN
+                RAISE EXCEPTION 'SOURCE_ADD post-acceptance work idempotency differs';
+            END IF;
+        ELSE
+            INSERT INTO public.research_lab_source_add_work_items (
+                work_id, submission_id, adapter_id, work_kind, work_status,
+                priority, job_doc
+            ) VALUES (
+                p_next_work->>'work_id', p_submission_id, v_work.adapter_id,
+                'leg1_reward', 'queued', 30, p_next_work->'job_doc'
+            );
+        END IF;
+
+        SELECT COALESCE(MAX(seq), -1) + 1 INTO v_seq
+        FROM public.research_lab_source_add_submissions
+        WHERE submission_id = p_submission_id;
+        INSERT INTO public.research_lab_source_add_submissions (
+            submission_id, adapter_id, miner_hotkey, stage, seq, submission_doc,
+            precheck_status, precheck_doc, source_identity_hash,
+            source_identity_version
+        ) VALUES (
+            p_submission_id, v_current.adapter_id, v_current.miner_hotkey,
+            'leg1_queued', v_seq,
+            v_current.submission_doc || jsonb_build_object('stage', 'leg1_queued'),
+            v_current.precheck_status, v_current.precheck_doc,
+            v_current.source_identity_hash, v_current.source_identity_version
+        );
+        v_result := v_result || jsonb_build_object(
+            'leg1_status', 'queued',
+            'intent_id', p_reward_intent->>'intent_id',
+            'work_id', p_next_work->>'work_id'
+        );
+    END IF;
+    UPDATE public.research_lab_source_add_work_items
+    SET work_status = 'completed',
+        result_doc = v_result,
+        completed_at = NOW(),
+        lease_token = NULL,
+        leased_by = '',
+        lease_expires_at = NULL,
+        job_doc = job_doc
+            - 'provider_execution_state'
+            - 'provider_execution_attempt'
+            - 'provider_execution_started_at'
+            - 'provider_execution_recovery',
+        updated_at = NOW()
+    WHERE work_id = p_work_id;
+    RETURN v_result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.research_lab_source_add_post_accept_leg1_contract_v1()
+RETURNS JSONB
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+    SELECT jsonb_build_object(
+        'schema_version', 'leadpoet.source_add_post_accept_leg1_contract.v1',
+        'intent_trigger_enabled', COALESCE((
+            SELECT trigger.tgenabled IN ('O', 'A')
+            FROM pg_catalog.pg_trigger trigger
+            WHERE trigger.tgrelid = 'public.research_lab_source_add_reward_intents'::REGCLASS
+              AND trigger.tgname = 'trg_source_add_leg1_intent_after_acceptance'
+              AND NOT trigger.tgisinternal
+        ), FALSE),
+        'work_trigger_enabled', COALESCE((
+            SELECT trigger.tgenabled IN ('O', 'A')
+            FROM pg_catalog.pg_trigger trigger
+            WHERE trigger.tgrelid = 'public.research_lab_source_add_work_items'::REGCLASS
+              AND trigger.tgname = 'trg_source_add_leg1_work_after_acceptance'
+              AND NOT trigger.tgisinternal
+        ), FALSE),
+        'reward_trigger_enabled', COALESCE((
+            SELECT trigger.tgenabled IN ('O', 'A')
+            FROM pg_catalog.pg_trigger trigger
+            WHERE trigger.tgrelid = 'public.research_lab_source_add_reward_obligations'::REGCLASS
+              AND trigger.tgname = 'trg_source_add_leg1_catalog_binding'
+              AND NOT trigger.tgisinternal
+        ), FALSE),
+        'finalizer_present', pg_catalog.to_regprocedure(
+            'public.research_lab_source_add_finalize_provision_smoke_v2(text,uuid,text,jsonb,jsonb,jsonb,jsonb,jsonb)'
+        ) IS NOT NULL
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.enforce_research_lab_source_add_leg1_intent_after_acceptance()
+    FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.enforce_research_lab_source_add_leg1_work_after_acceptance()
+    FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.bind_research_lab_source_add_leg1_catalog()
+    FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.research_lab_source_add_finalize_provision_smoke_v2(
+    TEXT, UUID, TEXT, JSONB, JSONB, JSONB, JSONB, JSONB
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.research_lab_source_add_post_accept_leg1_contract_v1()
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.research_lab_source_add_finalize_provision_smoke_v2(
+    TEXT, UUID, TEXT, JSONB, JSONB, JSONB, JSONB, JSONB
+) TO service_role;
+GRANT EXECUTE ON FUNCTION public.research_lab_source_add_post_accept_leg1_contract_v1()
+    TO service_role;
+
+COMMENT ON FUNCTION public.research_lab_source_add_finalize_provision_smoke_v2(
+    TEXT, UUID, TEXT, JSONB, JSONB, JSONB, JSONB, JSONB
+) IS 'Atomically accepts eligible SOURCE_ADD provisioning and queues receipt-bound Leg 1.';
+COMMENT ON FUNCTION public.research_lab_source_add_post_accept_leg1_contract_v1() IS
+    'Read-only release contract for post-acceptance SOURCE_ADD Leg 1 enforcement.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/tests/test_config_fixes.py
+++ b/tests/test_config_fixes.py
@@ -205,6 +205,8 @@ def test_source_add_status_defaults_enabled_and_env_gated(clean_env):
     assert config.source_add_dispatcher_enabled is True
     assert config.source_add_functional_probes_enabled is True
     assert config.source_add_functional_rewards_enabled is True
+    assert config.source_add_leg1_alpha_percent == 1.0
+    assert config.source_add_leg2_alpha_percent == 5.0
     assert config.source_add_max_per_day_per_hotkey == 5
     assert not hasattr(config, "source_add_leg2_expiry_months")
     assert not hasattr(config, "source_add_ablation_required")
@@ -216,6 +218,9 @@ def test_source_add_status_defaults_enabled_and_env_gated(clean_env):
     assert status["source_add"]["dispatcher_enabled"] is True
     assert status["source_add"]["functional_probes_enabled"] is True
     assert status["source_add"]["functional_rewards_enabled"] is True
+    assert status["source_add"]["leg1_alpha_percent"] == 1.0
+    assert status["source_add"]["leg2_alpha_percent"] == 5.0
+    assert status["source_add"]["reward_epochs"] == 20
     assert status["source_add"]["max_per_day_per_hotkey"] == 5
 
     clean_env.setenv("RESEARCH_LAB_SOURCE_ADD_ENABLED", "false")
@@ -223,6 +228,7 @@ def test_source_add_status_defaults_enabled_and_env_gated(clean_env):
     clean_env.setenv("RESEARCH_LAB_SOURCE_ADD_DISPATCHER_ENABLED", "false")
     clean_env.setenv("RESEARCH_LAB_SOURCE_ADD_FUNCTIONAL_PROBES_ENABLED", "false")
     clean_env.setenv("RESEARCH_LAB_SOURCE_ADD_FUNCTIONAL_REWARDS_ENABLED", "false")
+    clean_env.setenv("RESEARCH_LAB_SOURCE_ADD_LEG2_ALPHA_PERCENT", "0")
     config = ResearchLabGatewayConfig.from_env()
     status = config.public_status()
     assert config.source_add_enabled is False
@@ -230,12 +236,14 @@ def test_source_add_status_defaults_enabled_and_env_gated(clean_env):
     assert config.source_add_dispatcher_enabled is False
     assert config.source_add_functional_probes_enabled is False
     assert config.source_add_functional_rewards_enabled is False
+    assert config.source_add_leg2_alpha_percent == 0.0
     assert status["source_add_enabled"] is False
     assert status["source_add"]["enabled"] is False
     assert status["source_add"]["rewards_enabled"] is False
     assert status["source_add"]["dispatcher_enabled"] is False
     assert status["source_add"]["functional_probes_enabled"] is False
     assert status["source_add"]["functional_rewards_enabled"] is False
+    assert status["source_add"]["leg2_alpha_percent"] == 0.0
 
 
 def test_source_add_work_lease_covers_three_probe_deadline(clean_env):

--- a/tests/test_config_fixes.py
+++ b/tests/test_config_fixes.py
@@ -206,7 +206,7 @@ def test_source_add_status_defaults_enabled_and_env_gated(clean_env):
     assert config.source_add_functional_probes_enabled is True
     assert config.source_add_functional_rewards_enabled is True
     assert config.source_add_leg1_alpha_percent == 1.0
-    assert config.source_add_leg2_alpha_percent == 5.0
+    assert config.source_add_leg2_alpha_percent == 0.0
     assert config.source_add_max_per_day_per_hotkey == 5
     assert not hasattr(config, "source_add_leg2_expiry_months")
     assert not hasattr(config, "source_add_ablation_required")
@@ -219,7 +219,7 @@ def test_source_add_status_defaults_enabled_and_env_gated(clean_env):
     assert status["source_add"]["functional_probes_enabled"] is True
     assert status["source_add"]["functional_rewards_enabled"] is True
     assert status["source_add"]["leg1_alpha_percent"] == 1.0
-    assert status["source_add"]["leg2_alpha_percent"] == 5.0
+    assert status["source_add"]["leg2_alpha_percent"] == 0.0
     assert status["source_add"]["reward_epochs"] == 20
     assert status["source_add"]["max_per_day_per_hotkey"] == 5
 

--- a/tests/test_coordinator_executor_v2.py
+++ b/tests/test_coordinator_executor_v2.py
@@ -51,17 +51,22 @@ from leadpoet_canonical.weight_authority_v2 import (
 from research_lab.eval.promotion_metric import promotion_improvement_metric
 
 
-def test_reward_ancestry_accepts_checkpointed_source_add_parent() -> None:
+def test_reward_ancestry_accepts_checkpointed_source_add_parents() -> None:
     parent_hash = "sha256:" + "1" * 64
+    smoke_parent_hash = "sha256:" + "2" * 64
     functional_result = {
         "schema_version": "leadpoet.source_add_functional_probe_result.v2",
         "result_status": "passed",
+    }
+    smoke_result = {
+        **functional_result,
+        "evaluation_mode": "provisioning_smoke",
     }
     context = ExecutionContextV2(
         job_id="reward:test",
         purpose="research_lab.reward_decision.v2",
         epoch_id=100,
-        parent_receipt_hashes=(parent_hash,),
+        parent_receipt_hashes=(parent_hash, smoke_parent_hash),
         external_ancestry_proofs=[
             {
                 "certificate": {
@@ -80,7 +85,23 @@ def test_reward_ancestry_accepts_checkpointed_source_add_parent() -> None:
                         "output_root": sha256_json(functional_result),
                     }
                 ],
-            }
+            },
+            {
+                "certificate": {
+                    "claim": {
+                        "lineage_id": "gateway:test",
+                        "output_root_receipt_hash": smoke_parent_hash,
+                    }
+                },
+                "disclosed_boot_identities": [],
+                "disclosed_receipts": [
+                    {
+                        "receipt_hash": smoke_parent_hash,
+                        "purpose": "research_lab.source_add_functional_probe.v2",
+                        "output_root": sha256_json(smoke_result),
+                    }
+                ],
+            },
         ],
     )
 
@@ -89,6 +110,7 @@ def test_reward_ancestry_accepts_checkpointed_source_add_parent() -> None:
             "decision_kind": "source_add_leg1",
             "decision_payload": {
                 "functional_probe_result": functional_result,
+                "provisioning_smoke_result": smoke_result,
             },
         },
         context,
@@ -97,11 +119,17 @@ def test_reward_ancestry_accepts_checkpointed_source_add_parent() -> None:
 
 def test_reward_ancestry_rejects_checkpointed_parent_output_mismatch() -> None:
     parent_hash = "sha256:" + "1" * 64
+    smoke_parent_hash = "sha256:" + "3" * 64
+    functional_result = {"result_status": "passed"}
+    smoke_result = {
+        "evaluation_mode": "provisioning_smoke",
+        "result_status": "passed",
+    }
     context = ExecutionContextV2(
         job_id="reward:test",
         purpose="research_lab.reward_decision.v2",
         epoch_id=100,
-        parent_receipt_hashes=(parent_hash,),
+        parent_receipt_hashes=(parent_hash, smoke_parent_hash),
         external_ancestry_proofs=[
             {
                 "certificate": {
@@ -120,16 +148,33 @@ def test_reward_ancestry_rejects_checkpointed_parent_output_mismatch() -> None:
                         "output_root": "sha256:" + "2" * 64,
                     }
                 ],
-            }
+            },
+            {
+                "certificate": {
+                    "claim": {
+                        "lineage_id": "gateway:test",
+                        "output_root_receipt_hash": smoke_parent_hash,
+                    }
+                },
+                "disclosed_boot_identities": [],
+                "disclosed_receipts": [
+                    {
+                        "receipt_hash": smoke_parent_hash,
+                        "purpose": "research_lab.source_add_functional_probe.v2",
+                        "output_root": sha256_json(smoke_result),
+                    }
+                ],
+            },
         ],
     )
 
-    with pytest.raises(ValueError, match="parent output differs"):
+    with pytest.raises(ValueError, match="exact functional and smoke parents"):
         CoordinatorExecutorV2._validate_reward_ancestry(
             {
                 "decision_kind": "source_add_leg1",
                 "decision_payload": {
-                    "functional_probe_result": {"result_status": "passed"},
+                    "functional_probe_result": functional_result,
+                    "provisioning_smoke_result": smoke_result,
                 },
             },
             context,

--- a/tests/test_coordinator_reward_source_v2.py
+++ b/tests/test_coordinator_reward_source_v2.py
@@ -15,6 +15,7 @@ SUBMISSION_ID = "source_add_submission:1234567890abcdef"
 HASH = "sha256:" + "a" * 64
 FUNCTIONAL_RECEIPT_HASH = "sha256:" + "b" * 64
 JUDGE_RECEIPT_HASH = "sha256:" + "c" * 64
+SMOKE_RECEIPT_HASH = "sha256:" + "d" * 64
 
 
 class FakeReader:
@@ -78,6 +79,11 @@ def _context(
         "purpose": "research_lab.source_add_functional_probe.v2",
         "output_root": sha256_json(functional),
     }
+    smoke_receipt = {
+        "receipt_hash": SMOKE_RECEIPT_HASH,
+        "purpose": "research_lab.source_add_functional_probe.v2",
+        "output_root": sha256_json(_smoke_result()),
+    }
     judge_receipt = {
         "receipt_hash": JUDGE_RECEIPT_HASH,
         "role": "gateway_scoring",
@@ -93,7 +99,7 @@ def _context(
             (JUDGE_RECEIPT_HASH,)
             if with_judge_parent
             else (
-                (FUNCTIONAL_RECEIPT_HASH,)
+                (FUNCTIONAL_RECEIPT_HASH, SMOKE_RECEIPT_HASH)
                 if with_functional_parent or with_functional_proof
                 else ()
             )
@@ -111,7 +117,11 @@ def _context(
                     {
                         "root_receipt_hash": FUNCTIONAL_RECEIPT_HASH,
                         "receipts": [functional_receipt],
-                    }
+                    },
+                    {
+                        "root_receipt_hash": SMOKE_RECEIPT_HASH,
+                        "receipts": [smoke_receipt],
+                    },
                 ]
                 if with_functional_parent
                 else []
@@ -128,7 +138,17 @@ def _context(
                     },
                     "disclosed_boot_identities": [],
                     "disclosed_receipts": [functional_receipt],
-                }
+                },
+                {
+                    "certificate": {
+                        "claim": {
+                            "lineage_id": "gateway:test",
+                            "output_root_receipt_hash": SMOKE_RECEIPT_HASH,
+                        }
+                    },
+                    "disclosed_boot_identities": [],
+                    "disclosed_receipts": [smoke_receipt],
+                },
             ]
             if with_functional_proof
             else []
@@ -161,6 +181,60 @@ def _functional_row():
     }
 
 
+def _smoke_result():
+    return {
+        **_functional_result(),
+        "evaluation_mode": "provisioning_smoke",
+        "route_hash": "sha256:" + "e" * 64,
+    }
+
+
+def _smoke_row():
+    smoke = _smoke_result()
+    return {
+        "attempt_ref": "source_add_probe_attempt:fedcba0987654321",
+        "submission_id": SUBMISSION_ID,
+        "adapter_id": "adapter:test",
+        "evaluation_mode": "provisioning_smoke",
+        "config_ref": smoke["config_ref"],
+        "result_status": "passed",
+        "receipt_hash": SMOKE_RECEIPT_HASH,
+        "business_artifact_hash": sha256_json(smoke),
+        "result_doc": smoke,
+    }
+
+
+def _accepted_row(*, miner_hotkey: str = "miner"):
+    return {
+        "submission_id": SUBMISSION_ID,
+        "adapter_id": "adapter:test",
+        "miner_hotkey": miner_hotkey,
+        "stage": "accepted",
+        "precheck_status": "provenance_precheck_passed",
+    }
+
+
+def _provision_row(*, miner_hotkey: str = "miner"):
+    return {
+        "provision_ref": "source_add_provision:1234567890abcdef",
+        "catalog_id": "source_catalog:1234567890abcdef",
+        "submission_id": SUBMISSION_ID,
+        "adapter_id": "adapter:test",
+        "miner_hotkey": miner_hotkey,
+        "registry_provider_id": "provider:test",
+        "provision_status": "provisioned_autoresearch_eligible",
+    }
+
+
+def _catalog_row(*, miner_hotkey: str = "miner"):
+    return {
+        "catalog_id": "source_catalog:1234567890abcdef",
+        "adapter_id": "adapter:test",
+        "miner_ref": miner_hotkey,
+        "registry_provider_id": "provider:test",
+    }
+
+
 def _functional_trigger():
     functional = _functional_result()
     measured = _functional_row()
@@ -172,6 +246,56 @@ def _functional_trigger():
         "functional_probe_result_hash": sha256_json(functional),
         "evaluator_version": functional["evaluator_version"],
         "route_hash": functional["route_hash"],
+        "provisioning_smoke_passed": True,
+        "provisioning_smoke_attempt_ref": _smoke_row()["attempt_ref"],
+        "provisioning_smoke_receipt_hash": SMOKE_RECEIPT_HASH,
+        "provisioning_smoke_business_artifact_hash": _smoke_row()[
+            "business_artifact_hash"
+        ],
+        "provisioning_smoke_result_hash": sha256_json(_smoke_result()),
+        "submission_id": SUBMISSION_ID,
+        "final_acceptance_stage": "accepted",
+        "provision_ref": _provision_row()["provision_ref"],
+        "catalog_id": _provision_row()["catalog_id"],
+        "registry_provider_id": _provision_row()["registry_provider_id"],
+        "provision_status": "provisioned_autoresearch_eligible",
+    }
+
+
+def _leg1_rows(*, miner_hotkey: str = "miner", rewards=None):
+    return {
+        "source_add_rewards_by_adapter": list(rewards or ()),
+        "source_add_accepted_submission_by_id": [
+            _accepted_row(miner_hotkey=miner_hotkey)
+        ],
+        "source_add_functional_probe_by_submission": [_functional_row()],
+        "source_add_provisioning_smoke_by_submission": [_smoke_row()],
+        "source_add_provisioning_by_adapter": [
+            _provision_row(miner_hotkey=miner_hotkey)
+        ],
+        "source_add_catalog_by_adapter": [
+            _catalog_row(miner_hotkey=miner_hotkey)
+        ],
+    }
+
+
+def _leg1_payload(*, miner_ref: str = "miner"):
+    return {
+        "decision_kind": "source_add_leg1",
+        "decision_payload": {
+            "adapter_id": "adapter:test",
+            "miner_ref": miner_ref,
+            "start_epoch": 101,
+            "existing_rewards": [],
+            "alpha_percent": 1.0,
+            "reward_epochs": 20,
+            "functional_probe_result": _functional_result(),
+            "provisioning_smoke_result": _smoke_result(),
+            "accepted_submission": _accepted_row(),
+            "provision": _provision_row(),
+            "catalog": _catalog_row(),
+            "trigger_evidence": _functional_trigger(),
+        },
     }
 
 
@@ -254,39 +378,17 @@ def test_leg1_replaces_host_reward_rows_with_authenticated_rows():
             "current_reward_status": "active",
         }
     ]
-    reader = FakeReader(
-        {
-            "source_add_rewards_by_adapter": authenticated,
-            "source_add_submission_by_id": [
-                {
-                    "submission_id": SUBMISSION_ID,
-                    "adapter_id": "adapter:test",
-                    "miner_hotkey": "miner",
-                    "precheck_status": "provenance_precheck_passed",
-                }
-            ],
-            "source_add_functional_probe_by_submission": [_functional_row()],
-        }
-    )
+    reader = FakeReader(_leg1_rows(rewards=authenticated))
     resolver = CoordinatorRewardSourceV2(
         reader=reader,
         chain_source=FakeChain(),
         config_supplier=_config,
         clock=lambda: datetime(2026, 7, 10, 12, tzinfo=timezone.utc),
     )
-    payload = {
-        "decision_kind": "source_add_leg1",
-        "decision_payload": {
-            "adapter_id": "adapter:test",
-            "miner_ref": "miner",
-            "start_epoch": 101,
-            "existing_rewards": [{"adapter_id": "forged", "leg": 1}],
-            "alpha_percent": 1.0,
-            "reward_epochs": 20,
-            "functional_probe_result": _functional_result(),
-            "trigger_evidence": _functional_trigger(),
-        },
-    }
+    payload = _leg1_payload()
+    payload["decision_payload"]["existing_rewards"] = [
+        {"adapter_id": "forged", "leg": 1}
+    ]
 
     resolved = resolver.resolve(
         payload=payload,
@@ -296,26 +398,16 @@ def test_leg1_replaces_host_reward_rows_with_authenticated_rows():
     assert resolved["decision_payload"]["existing_rewards"] == authenticated
     assert reader.calls == [
         ("source_add_rewards_by_adapter", {"adapter_id": "adapter:test"}),
-        ("source_add_submission_by_id", {"submission_id": SUBMISSION_ID}),
+        ("source_add_accepted_submission_by_id", {"submission_id": SUBMISSION_ID}),
         ("source_add_functional_probe_by_submission", {"submission_id": SUBMISSION_ID}),
+        ("source_add_provisioning_smoke_by_submission", {"submission_id": SUBMISSION_ID}),
+        ("source_add_provisioning_by_adapter", {"adapter_id": "adapter:test"}),
+        ("source_add_catalog_by_adapter", {"adapter_id": "adapter:test"}),
     ]
 
 
 def test_leg1_accepts_checkpointed_functional_parent_proof():
-    reader = FakeReader(
-        {
-            "source_add_rewards_by_adapter": [],
-            "source_add_submission_by_id": [
-                {
-                    "submission_id": SUBMISSION_ID,
-                    "adapter_id": "adapter:test",
-                    "miner_hotkey": "miner",
-                    "precheck_status": "provenance_precheck_passed",
-                }
-            ],
-            "source_add_functional_probe_by_submission": [_functional_row()],
-        }
-    )
+    reader = FakeReader(_leg1_rows())
     resolver = CoordinatorRewardSourceV2(
         reader=reader,
         chain_source=FakeChain(),
@@ -323,19 +415,7 @@ def test_leg1_accepts_checkpointed_functional_parent_proof():
     )
 
     resolved = resolver.resolve(
-        payload={
-            "decision_kind": "source_add_leg1",
-            "decision_payload": {
-                "adapter_id": "adapter:test",
-                "miner_ref": "miner",
-                "start_epoch": 101,
-                "existing_rewards": [],
-                "alpha_percent": 1.0,
-                "reward_epochs": 20,
-                "functional_probe_result": _functional_result(),
-                "trigger_evidence": _functional_trigger(),
-            },
-        },
+        payload=_leg1_payload(),
         context=_context(with_functional_proof=True),
     )
 
@@ -474,41 +554,17 @@ def test_source_add_migration_reconstructs_reward_and_measured_submission():
 
 
 def test_leg1_daily_cap_is_not_rechecked_outside_atomic_slot_transaction():
-    reader = FakeReader(
-        {
-            "source_add_rewards_by_adapter": [],
-            "source_add_submission_by_id": [
-                {
-                    "submission_id": SUBMISSION_ID,
-                    "adapter_id": "adapter:test",
-                    "miner_hotkey": "miner",
-                    "precheck_status": "provenance_precheck_passed",
-                }
-            ],
-            "source_add_functional_probe_by_submission": [_functional_row()],
-            "source_add_leg1_events_since": [
-                {"reward_ref": "reward-%d" % index} for index in range(10)
-            ],
-        }
-    )
+    rows = _leg1_rows()
+    rows["source_add_leg1_events_since"] = [
+        {"reward_ref": "reward-%d" % index} for index in range(10)
+    ]
+    reader = FakeReader(rows)
     resolver = CoordinatorRewardSourceV2(
         reader=reader,
         chain_source=FakeChain(),
         config_supplier=_config,
     )
-    payload = {
-        "decision_kind": "source_add_leg1",
-        "decision_payload": {
-            "adapter_id": "adapter:test",
-            "miner_ref": "miner",
-            "start_epoch": 101,
-            "existing_rewards": [],
-            "alpha_percent": 1.0,
-            "reward_epochs": 20,
-            "functional_probe_result": _functional_result(),
-            "trigger_evidence": _functional_trigger(),
-        },
-    }
+    payload = _leg1_payload()
 
     resolved = resolver.resolve(
         payload=payload,
@@ -630,37 +686,13 @@ def test_leg2_requires_authenticated_adapter_owner():
 
 
 def test_leg1_rejects_host_substituted_miner():
-    reader = FakeReader(
-        {
-            "source_add_rewards_by_adapter": [],
-            "source_add_submission_by_id": [
-                {
-                    "submission_id": SUBMISSION_ID,
-                    "adapter_id": "adapter:test",
-                    "miner_hotkey": "real-owner",
-                    "precheck_status": "provenance_precheck_passed",
-                }
-            ],
-        }
-    )
+    reader = FakeReader(_leg1_rows(miner_hotkey="real-owner"))
     resolver = CoordinatorRewardSourceV2(
         reader=reader,
         chain_source=FakeChain(),
         config_supplier=_config,
     )
-    payload = {
-        "decision_kind": "source_add_leg1",
-        "decision_payload": {
-            "adapter_id": "adapter:test",
-            "miner_ref": "forged-owner",
-            "start_epoch": 101,
-            "existing_rewards": [],
-            "alpha_percent": 1.0,
-            "reward_epochs": 20,
-            "functional_probe_result": _functional_result(),
-            "trigger_evidence": _functional_trigger(),
-        },
-    }
+    payload = _leg1_payload(miner_ref="forged-owner")
     with pytest.raises(CoordinatorRewardSourceV2Error, match="owner or status"):
         resolver.resolve(
             payload=payload,

--- a/tests/test_coordinator_source_add_v2.py
+++ b/tests/test_coordinator_source_add_v2.py
@@ -698,8 +698,14 @@ async def test_leg1_reward_requires_parent_output_and_exact_purpose():
         "reason_codes": ["bounded_json_data_response"],
         "probe_summaries": [],
     }
+    smoke = {
+        **functional,
+        "evaluation_mode": "provisioning_smoke",
+        "route_hash": "sha256:" + "c" * 64,
+    }
     root_hash = HASH_A
-    graph = {
+    smoke_root_hash = "sha256:" + "d" * 64
+    functional_graph = {
         "root_receipt_hash": root_hash,
         "receipts": [
             {
@@ -709,12 +715,22 @@ async def test_leg1_reward_requires_parent_output_and_exact_purpose():
             }
         ],
     }
+    smoke_graph = {
+        "root_receipt_hash": smoke_root_hash,
+        "receipts": [
+            {
+                "receipt_hash": smoke_root_hash,
+                "purpose": "research_lab.source_add_functional_probe.v2",
+                "output_root": sha256_json(smoke),
+            }
+        ],
+    }
     context = ExecutionContextV2(
         job_id="reward-job",
         purpose="research_lab.reward_decision.v2",
         epoch_id=10,
-        parent_receipt_hashes=(root_hash,),
-        external_receipt_graphs=[graph],
+        parent_receipt_hashes=(root_hash, smoke_root_hash),
+        external_receipt_graphs=[functional_graph, smoke_graph],
     )
     payload = {
         "decision_kind": "source_add_leg1",
@@ -726,9 +742,40 @@ async def test_leg1_reward_requires_parent_output_and_exact_purpose():
             "alpha_percent": 1.0,
             "reward_epochs": 20,
             "functional_probe_result": functional,
+            "provisioning_smoke_result": smoke,
+            "accepted_submission": {
+                "submission_id": functional["submission_id"],
+                "adapter_id": functional["adapter_id"],
+                "miner_hotkey": "miner-hotkey",
+                "stage": "accepted",
+                "precheck_status": "provenance_precheck_passed",
+            },
+            "provision": {
+                "provision_ref": "source_add_provision:1234567890abcdef",
+                "catalog_id": "source_catalog:1234567890abcdef",
+                "submission_id": functional["submission_id"],
+                "adapter_id": functional["adapter_id"],
+                "miner_hotkey": "miner-hotkey",
+                "registry_provider_id": "provider:example",
+                "provision_status": "provisioned_autoresearch_eligible",
+            },
+            "catalog": {
+                "catalog_id": "source_catalog:1234567890abcdef",
+                "adapter_id": functional["adapter_id"],
+                "miner_ref": "miner-hotkey",
+                "registry_provider_id": "provider:example",
+            },
             "trigger_evidence": {
                 "functional_probe_passed": True,
                 "functional_probe_result_hash": sha256_json(functional),
+                "provisioning_smoke_passed": True,
+                "provisioning_smoke_result_hash": sha256_json(smoke),
+                "submission_id": functional["submission_id"],
+                "final_acceptance_stage": "accepted",
+                "provision_ref": "source_add_provision:1234567890abcdef",
+                "catalog_id": "source_catalog:1234567890abcdef",
+                "registry_provider_id": "provider:example",
+                "provision_status": "provisioned_autoresearch_eligible",
             },
         },
     }
@@ -744,7 +791,7 @@ async def test_leg1_reward_requires_parent_output_and_exact_purpose():
     assert outcome.output["reward"]["leg"] == 1
 
     context.external_receipt_graphs[0]["receipts"][0]["output_root"] = HASH_B
-    with pytest.raises(ValueError, match="parent output"):
+    with pytest.raises(ValueError, match="exact functional and smoke parents"):
         await executor(OP_RESEARCH_LAB_REWARD_DECISION, payload, context)
 
 

--- a/tests/test_promotion_fixes.py
+++ b/tests/test_promotion_fixes.py
@@ -4328,6 +4328,25 @@ def _source_add_attribution_bundle() -> dict[str, Any]:
     }
 
 
+@pytest.mark.asyncio
+async def test_source_add_leg2_zero_alpha_disables_before_attribution(store):
+    config = _source_add_reward_config()
+    config.source_add_leg2_alpha_percent = 0.0
+    controller = ResearchLabPromotionController(config, worker_ref="test-worker")
+
+    result = await controller._maybe_create_source_add_implementation_rewards(
+        candidate={"candidate_id": "candidate-leg1-only"},
+        score_bundle_row={"score_bundle_id": "score-leg1-only"},
+        score_bundle=_source_add_attribution_bundle(),
+        improvement_points=2.0,
+        threshold=1.0,
+        champion_reward_status={"champion_reward_status": "created"},
+    )
+
+    assert result == {"source_add_reward_status": "disabled"}
+    assert store.reward_obligation_writes == []
+
+
 def _install_source_add_v2_judge(
     monkeypatch,
     judge,

--- a/tests/test_provider_evidence_proxy.py
+++ b/tests/test_provider_evidence_proxy.py
@@ -17,6 +17,7 @@ from gateway.research_lab.provider_evidence_proxy import (
     ProviderUsageLedger,
     load_provider_registry,
     provider_registry_hash,
+    reserved_builtin_provider_domains_sync,
     resolve_provider_credential,
     seed_provider_registry,
     serve_evidence_proxy,
@@ -55,6 +56,54 @@ class TestRegistryValidation:
         assert by_id["or"].auth_kind == "bearer"
         assert by_id["deepline"].base_url == "https://code.deepline.com"
         assert by_id["deepline"].auth_kind == "bearer"
+
+    def test_reserved_builtin_domains_cover_exact_seed_hosts(self, monkeypatch):
+        calls = []
+
+        def load_capabilities(_path="", *, strict_remote=False):
+            calls.append(strict_remote)
+            return [], type(
+                "Capabilities",
+                (),
+                {
+                    "providers": (
+                        {
+                            "origin": "builtin",
+                            "base_url": "https://private-provider.example/api",
+                        },
+                    )
+                },
+            )()
+
+        monkeypatch.setattr(
+            proxy_module,
+            "load_provider_registry_with_capabilities",
+            load_capabilities,
+        )
+
+        assert reserved_builtin_provider_domains_sync() == {
+            "api.exa.ai",
+            "api.scrapingdog.com",
+            "code.deepline.com",
+            "openrouter.ai",
+            "private-provider.example",
+        }
+        assert calls == [True]
+
+    def test_reserved_builtin_domains_fail_closed_when_catalog_is_unavailable(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            proxy_module,
+            "load_provider_registry_with_capabilities",
+            lambda _path="", **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("unavailable")
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="unavailable"):
+            reserved_builtin_provider_domains_sync()
 
     def test_duplicate_ids_rejected(self):
         entries = seed_provider_registry() + [seed_provider_registry()[0]]

--- a/tests/test_reward_executor_v2.py
+++ b/tests/test_reward_executor_v2.py
@@ -33,6 +33,78 @@ def test_leg2_reward_rejects_nonapproving_signed_judge():
         execute_reward_decision_v2(payload)
 
 
+def test_leg1_reward_requires_accepted_provisioned_smoke_evidence():
+    functional = {
+        "submission_id": "source_add_submission:1234567890abcdef",
+        "adapter_id": "adapter:test",
+        "config_ref": "source_add_probe_config:1234567890abcdef",
+        "evaluation_mode": "functional_probe",
+        "result_status": "passed",
+    }
+    smoke = {
+        **functional,
+        "evaluation_mode": "provisioning_smoke",
+    }
+    provision = {
+        "provision_ref": "source_add_provision:1234567890abcdef",
+        "catalog_id": "source_catalog:1234567890abcdef",
+        "submission_id": functional["submission_id"],
+        "adapter_id": "adapter:test",
+        "miner_hotkey": "miner",
+        "registry_provider_id": "provider:test",
+        "provision_status": "provisioned_autoresearch_eligible",
+    }
+    payload = {
+        "decision_kind": "source_add_leg1",
+        "decision_payload": {
+            "adapter_id": "adapter:test",
+            "miner_ref": "miner",
+            "start_epoch": 101,
+            "existing_rewards": [],
+            "alpha_percent": 1.0,
+            "reward_epochs": 20,
+            "functional_probe_result": functional,
+            "provisioning_smoke_result": smoke,
+            "accepted_submission": {
+                "submission_id": functional["submission_id"],
+                "adapter_id": "adapter:test",
+                "miner_hotkey": "miner",
+                "stage": "accepted",
+                "precheck_status": "provenance_precheck_passed",
+            },
+            "provision": provision,
+            "catalog": {
+                "catalog_id": provision["catalog_id"],
+                "adapter_id": "adapter:test",
+                "miner_ref": "miner",
+                "registry_provider_id": provision["registry_provider_id"],
+            },
+            "trigger_evidence": {
+                "functional_probe_passed": True,
+                "functional_probe_result_hash": sha256_json(functional),
+                "provisioning_smoke_passed": True,
+                "provisioning_smoke_result_hash": sha256_json(smoke),
+                "submission_id": functional["submission_id"],
+                "final_acceptance_stage": "accepted",
+                "provision_ref": provision["provision_ref"],
+                "catalog_id": provision["catalog_id"],
+                "registry_provider_id": provision["registry_provider_id"],
+                "provision_status": "provisioned_autoresearch_eligible",
+            },
+        },
+    }
+
+    result = execute_reward_decision_v2(payload)
+
+    assert result["decision_kind"] == "source_add_leg1"
+    assert result["reward"]["leg"] == 1
+    payload["decision_payload"]["accepted_submission"]["stage"] = (
+        "functional_probe_passed"
+    )
+    with pytest.raises(RewardExecutorV2Error, match="approval evidence is invalid"):
+        execute_reward_decision_v2(payload)
+
+
 def test_reward_row_projection_hashes_change_for_payout_field_mutation():
     champion = {
         "champion_reward_id": "champion:1",

--- a/tests/test_source_add_admission_control_sql.py
+++ b/tests/test_source_add_admission_control_sql.py
@@ -67,6 +67,7 @@ def test_restart_preflight_requires_complete_source_add_v2_schema():
         if declared_migration == migration
     }
     assert relations == {
+        "research_lab_source_add_submissions",
         "research_lab_source_add_submission_current",
         "research_lab_source_add_control",
         "research_lab_source_add_work_items",

--- a/tests/test_source_add_catalog_provisioning.py
+++ b/tests/test_source_add_catalog_provisioning.py
@@ -237,6 +237,7 @@ async def test_submission_delegates_identity_and_limits_to_atomic_rpc(monkeypatc
         "_enforce_research_lab_submission_rate_limit",
         lambda *_args, **_kwargs: _async_none(),
     )
+    monkeypatch.setattr(api, "reserved_builtin_provider_domains_sync", lambda: set())
     observed = {}
 
     async def fake_rpc(name, params):
@@ -308,6 +309,7 @@ async def test_duplicate_submission_response_is_exact_and_private(monkeypatch):
         "_enforce_research_lab_submission_rate_limit",
         lambda *_args, **_kwargs: _async_none(),
     )
+    monkeypatch.setattr(api, "reserved_builtin_provider_domains_sync", lambda: set())
     async def duplicate_rpc(*_args, **_kwargs):
         return {"status": "duplicate"}
 
@@ -326,6 +328,145 @@ async def test_duplicate_submission_response_is_exact_and_private(monkeypatch):
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.detail == "Already submitted"
+
+
+@pytest.mark.asyncio
+async def test_current_builtin_provider_is_rejected_generically_before_admission(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        api.ResearchLabGatewayConfig,
+        "from_env",
+        staticmethod(
+            lambda: SimpleNamespace(
+                api_enabled=True,
+                production_writes_enabled=True,
+                miner_submissions_enabled=True,
+                source_add_enabled=True,
+                source_add_max_concurrent_per_hotkey=3,
+                source_add_max_per_day_per_hotkey=5,
+                source_add_max_per_30d_per_hotkey=10,
+            )
+        ),
+    )
+    monkeypatch.setattr(api, "_verify_signed_miner", lambda _payload: _async_none())
+    from gateway.research_lab import maintenance
+
+    monkeypatch.setattr(
+        maintenance, "is_scoring_maintenance_paused", lambda *a, **k: _async_none()
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "is_autoresearch_maintenance_paused",
+        lambda *a, **k: _async_none(),
+    )
+    monkeypatch.setattr(
+        api,
+        "source_add_control_state",
+        lambda *a, **k: _async_value({"paused": False, "status": "active"}),
+    )
+    monkeypatch.setattr(
+        api,
+        "_enforce_research_lab_submission_rate_limit",
+        lambda *_args, **_kwargs: _async_none(),
+    )
+    monkeypatch.setattr(
+        api,
+        "reserved_builtin_provider_domains_sync",
+        lambda: {"openrouter.ai"},
+    )
+
+    async def fail_rpc(*_args, **_kwargs):
+        raise AssertionError("built-in provider rejection must not persist")
+
+    monkeypatch.setattr(api, "_source_add_rpc", fail_rpc)
+    payload = ResearchLabSourceAdapterSubmissionRequest(
+        miner_hotkey="miner-hotkey-value",
+        signature="signature-value-123",
+        timestamp=int(time.time()),
+        idempotency_key="source-submit-openrouter-1",
+        manifest=_manifest_doc(
+            source_name="OpenRouter",
+            declared_base_domains=["attacker-declared.example"],
+        ),
+        source_metadata=_source_metadata_doc(
+            api_base_url="https://openrouter.ai/api/v1",
+            documentation_url="https://openrouter.ai/docs/quickstart",
+            auth_type="bearer",
+        ),
+    )
+
+    with pytest.raises(api.HTTPException) as exc_info:
+        await api.submit_research_lab_source_adapter(payload)
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "Already submitted"
+
+
+@pytest.mark.asyncio
+async def test_builtin_provider_catalog_failure_blocks_admission(monkeypatch):
+    monkeypatch.setattr(
+        api.ResearchLabGatewayConfig,
+        "from_env",
+        staticmethod(
+            lambda: SimpleNamespace(
+                api_enabled=True,
+                production_writes_enabled=True,
+                miner_submissions_enabled=True,
+                source_add_enabled=True,
+                source_add_max_concurrent_per_hotkey=3,
+                source_add_max_per_day_per_hotkey=5,
+                source_add_max_per_30d_per_hotkey=10,
+            )
+        ),
+    )
+    monkeypatch.setattr(api, "_verify_signed_miner", lambda _payload: _async_none())
+    from gateway.research_lab import maintenance
+
+    monkeypatch.setattr(
+        maintenance,
+        "is_scoring_maintenance_paused",
+        lambda *a, **k: _async_none(),
+    )
+    monkeypatch.setattr(
+        maintenance,
+        "is_autoresearch_maintenance_paused",
+        lambda *a, **k: _async_none(),
+    )
+    monkeypatch.setattr(
+        api,
+        "source_add_control_state",
+        lambda *a, **k: _async_value({"paused": False, "status": "active"}),
+    )
+    monkeypatch.setattr(
+        api,
+        "_enforce_research_lab_submission_rate_limit",
+        lambda *_args, **_kwargs: _async_none(),
+    )
+    monkeypatch.setattr(
+        api,
+        "reserved_builtin_provider_domains_sync",
+        lambda: (_ for _ in ()).throw(RuntimeError("catalog unavailable")),
+    )
+
+    async def fail_rpc(*_args, **_kwargs):
+        raise AssertionError("catalog failure must not persist")
+
+    monkeypatch.setattr(api, "_source_add_rpc", fail_rpc)
+    payload = ResearchLabSourceAdapterSubmissionRequest(
+        miner_hotkey="miner-hotkey-value",
+        signature="signature-value-123",
+        timestamp=int(time.time()),
+        idempotency_key="source-submit-catalog-failure-1",
+        manifest=_manifest_doc(),
+        source_metadata=_source_metadata_doc(),
+    )
+
+    with pytest.raises(api.HTTPException) as exc_info:
+        await api.submit_research_lab_source_adapter(payload)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "SOURCE_ADD workflow temporarily unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/test_source_add_end_to_end_postgres.py
+++ b/tests/test_source_add_end_to_end_postgres.py
@@ -25,6 +25,7 @@ MIGRATIONS = (
     "86-research-lab-attested-v2-authority.sql",
     "96-research-lab-source-add-functional-workflow.sql",
     "145-research-lab-source-add-admission-control.sql",
+    "167-research-lab-source-add-post-accept-leg1.sql",
 )
 DOCKER = shutil.which("docker")
 pytestmark = pytest.mark.skipif(DOCKER is None, reason="Docker is unavailable")
@@ -249,6 +250,7 @@ def _seed_receipt(
     job_id: str,
     output_root: str,
     sequence: int,
+    parent_receipt_hashes: tuple[str, ...] = (),
 ) -> None:
     marker = "%064x" % (sequence + 20)
     cursor.execute(
@@ -264,7 +266,7 @@ def _seed_receipt(
             %s, 'leadpoet.attested_execution_receipt.v2',
             'gateway_coordinator', %s, %s, 700, %s, %s, %s, %s, %s, %s,
             %s, %s, %s, %s, %s, %s, 'succeeded', NULL, %s, %s,
-            '{}'::JSONB, NOW()
+            %s::JSONB, NOW()
         )
         """,
         (
@@ -285,6 +287,7 @@ def _seed_receipt(
             "sha256:" + "2" * 64,
             "c" * 64,
             "d" * 128,
+            _json({"parent_receipt_hashes": sorted(parent_receipt_hashes)}),
         ),
     )
 
@@ -304,6 +307,19 @@ def _seed_business_link(
         ) VALUES (%s, %s, %s, %s)
         """,
         (receipt_hash, artifact_kind, artifact_ref, artifact_hash),
+    )
+
+
+def _seed_receipt_edge(
+    cursor, *, child_receipt_hash: str, parent_receipt_hash: str
+) -> None:
+    cursor.execute(
+        """
+        INSERT INTO public.research_lab_attested_receipt_edges_v2 (
+            child_receipt_hash, parent_receipt_hash
+        ) VALUES (%s, %s)
+        """,
+        (child_receipt_hash, parent_receipt_hash),
     )
 
 
@@ -356,6 +372,17 @@ def test_source_add_complete_database_workflow(database):
         )
         assert contract["control_row_present"] is True
         assert contract["trigger_enabled"] is True
+        post_accept_contract = _scalar(
+            cursor,
+            "SELECT public.research_lab_source_add_post_accept_leg1_contract_v1()",
+        )
+        assert post_accept_contract == {
+            "schema_version": "leadpoet.source_add_post_accept_leg1_contract.v1",
+            "intent_trigger_enabled": True,
+            "work_trigger_enabled": True,
+            "reward_trigger_enabled": True,
+            "finalizer_present": True,
+        }
         assert _scalar(
             cursor,
             "SELECT public.research_lab_source_add_claim_work('paused-worker', 180)",
@@ -469,39 +496,40 @@ def test_source_add_complete_database_workflow(database):
         assert _finish_work(
             cursor,
             work=functional,
-            stage="leg1_queued",
+            stage="functional_probe_passed",
             submission_doc=record_doc,
             precheck_status="provenance_precheck_passed",
             functional_attempt=functional_attempt,
-            reward_intent={
-                "intent_id": REWARD_INTENT,
-                "miner_hotkey": MINER_HOTKEY,
-                "functional_receipt_hash": FUNCTIONAL_RECEIPT,
-                "business_artifact_hash": FUNCTIONAL_ARTIFACT,
-            },
-            next_work={
-                "work_id": REWARD_WORK,
-                "work_kind": "leg1_reward",
-                "priority": 30,
-                "job_doc": {"intent_id": REWARD_INTENT},
-            },
         )["status"] == "completed"
-
-        reward_work = _scalar(
+        assert _scalar(
             cursor,
             "SELECT public.research_lab_source_add_claim_work('postgres-e2e', 180)",
-        )["work"]
-        assert reward_work["work_kind"] == "leg1_reward"
-        slot = _scalar(
+        )["status"] == "empty"
+        assert _scalar(
             cursor,
-            """
-            SELECT public.research_lab_source_add_reserve_leg1_slot(
-                %s, %s, %s::UUID, 10, 300
+            "SELECT COUNT(*) FROM public.research_lab_source_add_reward_intents",
+        ) == 0
+        with pytest.raises(
+            psycopg2.errors.ObjectNotInPrerequisiteState,
+            match="requires accepted eligible provisioning",
+        ):
+            cursor.execute(
+                """
+                INSERT INTO public.research_lab_source_add_reward_intents (
+                    intent_id, submission_id, adapter_id, miner_hotkey,
+                    intent_status, functional_receipt_hash,
+                    business_artifact_hash
+                ) VALUES (%s, %s, %s, %s, 'queued', %s, %s)
+                """,
+                (
+                    REWARD_INTENT,
+                    SUBMISSION_ID,
+                    ADAPTER_ID,
+                    MINER_HOTKEY,
+                    FUNCTIONAL_RECEIPT,
+                    FUNCTIONAL_ARTIFACT,
+                ),
             )
-            """,
-            (REWARD_INTENT, REWARD_WORK, reward_work["lease_token"]),
-        )
-        assert slot["status"] == "reserved"
 
         _seed_boot_identity(cursor)
         _seed_receipt(
@@ -519,60 +547,6 @@ def test_source_add_complete_database_workflow(database):
             artifact_ref=FUNCTIONAL_ATTEMPT,
             artifact_hash=FUNCTIONAL_ARTIFACT,
         )
-        _seed_receipt(
-            cursor,
-            receipt_hash=DECISION_RECEIPT,
-            purpose="research_lab.reward_decision.v2",
-            job_id="source-add-reward-postgres-e2e",
-            output_root=DECISION_ARTIFACT,
-            sequence=2,
-        )
-        _seed_business_link(
-            cursor,
-            receipt_hash=DECISION_RECEIPT,
-            artifact_kind="source_add_reward_decision",
-            artifact_ref=REWARD_REF,
-            artifact_hash=DECISION_ARTIFACT,
-        )
-        trigger = {
-            "functional_probe_passed": True,
-            "attempt_ref": FUNCTIONAL_ATTEMPT,
-            "functional_probe_receipt_hash": FUNCTIONAL_RECEIPT,
-            "business_artifact_hash": FUNCTIONAL_ARTIFACT,
-            "functional_probe_result_hash": FUNCTIONAL_ARTIFACT,
-            "evaluator_version": result_doc["evaluator_version"],
-            "route_hash": ROUTE_HASH,
-        }
-        finalized = _scalar(
-            cursor,
-            """
-            SELECT public.research_lab_source_add_finalize_leg1(
-                %s, %s, %s::UUID, %s::UUID, 10, %s::JSONB, %s::JSONB
-            )
-            """,
-            (
-                REWARD_INTENT,
-                REWARD_WORK,
-                reward_work["lease_token"],
-                slot["slot_lease_token"],
-                _json(
-                    {
-                        "reward_ref": REWARD_REF,
-                        "reward_kind": "source_acceptance",
-                        "alpha_percent": 1.0,
-                        "reward_epochs": 20,
-                        "start_epoch": 701,
-                        "state": "active",
-                        "trigger_evidence_doc": trigger,
-                        "public_label": "SOURCE_ADD Leg 1",
-                        "decision_receipt_hash": DECISION_RECEIPT,
-                        "decision_artifact_hash": DECISION_ARTIFACT,
-                    }
-                ),
-                _json(record_doc),
-            ),
-        )
-        assert finalized == {"status": "created", "reward_ref": REWARD_REF}
 
         catalog_row = {
             "catalog_id": CATALOG_ID,
@@ -706,8 +680,9 @@ def test_source_add_complete_database_workflow(database):
         smoke_finalized = _scalar(
             cursor,
             """
-            SELECT public.research_lab_source_add_finalize_provision_smoke(
-                %s, %s::UUID, %s, %s::JSONB, %s::JSONB, %s::JSONB
+            SELECT public.research_lab_source_add_finalize_provision_smoke_v2(
+                %s, %s::UUID, %s, %s::JSONB, %s::JSONB, %s::JSONB,
+                %s::JSONB, %s::JSONB
             )
             """,
             (
@@ -717,9 +692,158 @@ def test_source_add_complete_database_workflow(database):
                 _json(catalog_row),
                 _json(eligible_row),
                 _json(smoke_attempt),
+                _json(
+                    {
+                        "intent_id": REWARD_INTENT,
+                        "miner_hotkey": MINER_HOTKEY,
+                        "functional_receipt_hash": FUNCTIONAL_RECEIPT,
+                        "business_artifact_hash": FUNCTIONAL_ARTIFACT,
+                    }
+                ),
+                _json(
+                    {
+                        "work_id": REWARD_WORK,
+                        "work_kind": "leg1_reward",
+                        "priority": 30,
+                        "job_doc": {
+                            "intent_id": REWARD_INTENT,
+                            "attempt_ref": FUNCTIONAL_ATTEMPT,
+                        },
+                    }
+                ),
             ),
         )
         assert smoke_finalized["status"] == "provisioned"
+        assert smoke_finalized["leg1_status"] == "queued"
+        assert smoke_finalized["intent_id"] == REWARD_INTENT
+        assert smoke_finalized["work_id"] == REWARD_WORK
+        assert _scalar(
+            cursor,
+            """
+            SELECT COUNT(*) FROM public.research_lab_source_add_submissions
+            WHERE submission_id = %s AND stage = 'accepted'
+            """,
+            (SUBMISSION_ID,),
+        ) == 1
+
+        reward_work = _scalar(
+            cursor,
+            "SELECT public.research_lab_source_add_claim_work('postgres-e2e', 180)",
+        )["work"]
+        assert reward_work["work_kind"] == "leg1_reward"
+        slot = _scalar(
+            cursor,
+            """
+            SELECT public.research_lab_source_add_reserve_leg1_slot(
+                %s, %s, %s::UUID, 10, 300
+            )
+            """,
+            (REWARD_INTENT, REWARD_WORK, reward_work["lease_token"]),
+        )
+        assert slot["status"] == "reserved"
+
+        _seed_receipt(
+            cursor,
+            receipt_hash=DECISION_RECEIPT,
+            purpose="research_lab.reward_decision.v2",
+            job_id="source-add-reward-postgres-e2e",
+            output_root=DECISION_ARTIFACT,
+            sequence=2,
+            parent_receipt_hashes=(FUNCTIONAL_RECEIPT, SMOKE_RECEIPT),
+        )
+        _seed_receipt_edge(
+            cursor,
+            child_receipt_hash=DECISION_RECEIPT,
+            parent_receipt_hash=FUNCTIONAL_RECEIPT,
+        )
+        _seed_business_link(
+            cursor,
+            receipt_hash=DECISION_RECEIPT,
+            artifact_kind="source_add_reward_decision",
+            artifact_ref=REWARD_REF,
+            artifact_hash=DECISION_ARTIFACT,
+        )
+        trigger = {
+            "functional_probe_passed": True,
+            "attempt_ref": FUNCTIONAL_ATTEMPT,
+            "functional_probe_receipt_hash": FUNCTIONAL_RECEIPT,
+            "business_artifact_hash": FUNCTIONAL_ARTIFACT,
+            "functional_probe_result_hash": FUNCTIONAL_ARTIFACT,
+            "evaluator_version": result_doc["evaluator_version"],
+            "route_hash": ROUTE_HASH,
+            "provisioning_smoke_passed": True,
+            "provisioning_smoke_attempt_ref": SMOKE_ATTEMPT,
+            "provisioning_smoke_receipt_hash": SMOKE_RECEIPT,
+            "provisioning_smoke_business_artifact_hash": SMOKE_ARTIFACT,
+            "provisioning_smoke_result_hash": SMOKE_ARTIFACT,
+            "submission_id": SUBMISSION_ID,
+            "final_acceptance_stage": "accepted",
+            "provision_ref": eligible_row["provision_ref"],
+            "catalog_id": CATALOG_ID,
+            "registry_provider_id": REGISTRY_PROVIDER_ID,
+            "provision_status": "provisioned_autoresearch_eligible",
+        }
+        reward_doc = {
+            "reward_ref": REWARD_REF,
+            "reward_kind": "source_acceptance",
+            "alpha_percent": 1.0,
+            "reward_epochs": 20,
+            "start_epoch": 701,
+            "state": "active",
+            "trigger_evidence_doc": trigger,
+            "public_label": "SOURCE_ADD Leg 1",
+            "decision_receipt_hash": DECISION_RECEIPT,
+            "decision_artifact_hash": DECISION_ARTIFACT,
+        }
+        with pytest.raises(
+            psycopg2.errors.ObjectNotInPrerequisiteState,
+            match="approval or receipt graph differs",
+        ):
+            cursor.execute(
+                """
+                SELECT public.research_lab_source_add_finalize_leg1(
+                    %s, %s, %s::UUID, %s::UUID, 10, %s::JSONB, %s::JSONB
+                )
+                """,
+                (
+                    REWARD_INTENT,
+                    REWARD_WORK,
+                    reward_work["lease_token"],
+                    slot["slot_lease_token"],
+                    _json(reward_doc),
+                    _json(record_doc),
+                ),
+            )
+        assert _scalar(
+            cursor,
+            "SELECT COUNT(*) FROM public.research_lab_source_add_reward_obligations",
+        ) == 0
+        assert _scalar(
+            cursor,
+            "SELECT intent_status FROM public.research_lab_source_add_reward_intents",
+        ) == "leased"
+        _seed_receipt_edge(
+            cursor,
+            child_receipt_hash=DECISION_RECEIPT,
+            parent_receipt_hash=SMOKE_RECEIPT,
+        )
+        finalized = _scalar(
+            cursor,
+            """
+            SELECT public.research_lab_source_add_finalize_leg1(
+                %s, %s, %s::UUID, %s::UUID, 10, %s::JSONB, %s::JSONB
+            )
+            """,
+            (
+                REWARD_INTENT,
+                REWARD_WORK,
+                reward_work["lease_token"],
+                slot["slot_lease_token"],
+                _json(reward_doc),
+                _json(record_doc),
+            ),
+        )
+        assert finalized == {"status": "created", "reward_ref": REWARD_REF}
 
         summary = _scalar(
             cursor,
@@ -756,6 +880,10 @@ def test_source_add_complete_database_workflow(database):
                 'reward_count', (
                     SELECT COUNT(*) FROM public.research_lab_source_add_reward_obligations
                     WHERE adapter_id = %s AND leg = 1
+                ),
+                'reward_catalog_id', (
+                    SELECT catalog_id FROM public.research_lab_source_add_reward_obligations
+                    WHERE adapter_id = %s AND leg = 1
                 )
             )
             """,
@@ -768,10 +896,11 @@ def test_source_add_complete_database_workflow(database):
                 ADAPTER_ID,
                 SUBMISSION_ID,
                 ADAPTER_ID,
+                ADAPTER_ID,
             ),
         )
         assert summary == {
-            "stage": "accepted",
+            "stage": "leg1_created",
             "probe": "passed",
             "smoke": "passed",
             "reward_status": "active",
@@ -779,6 +908,7 @@ def test_source_add_complete_database_workflow(database):
             "provision_status": "provisioned_autoresearch_eligible",
             "completed_work": 4,
             "reward_count": 1,
+            "reward_catalog_id": CATALOG_ID,
         }
         assert _scalar(
             cursor,

--- a/tests/test_source_add_intake_leg1_reward.py
+++ b/tests/test_source_add_intake_leg1_reward.py
@@ -454,7 +454,7 @@ async def test_documentation_fetch_retries_only_transient_statuses(
 
 
 @pytest.mark.asyncio
-async def test_exact_functional_pass_queues_one_leg1_intent(monkeypatch):
+async def test_exact_functional_pass_records_proof_without_early_leg1(monkeypatch):
     config_ref = "source_add_probe_config:0123456789abcdef"
     result_doc = {
         "schema_version": "leadpoet.source_add_functional_probe_result.v2",
@@ -508,15 +508,10 @@ async def test_exact_functional_pass_queues_one_leg1_intent(monkeypatch):
 
     await workflow._process_functional_probe(_leased_work("functional_probe"), config=_config())
 
-    assert finished["stage"] == "leg1_queued"
+    assert finished["stage"] == "functional_probe_passed"
     assert finished["functional_attempt"]["receipt_hash"] == receipt_hash
-    assert finished["reward_intent"] == {
-        "intent_id": workflow.source_add_reward_intent_id(SUBMISSION_ID, ADAPTER_ID),
-        "miner_hotkey": MINER_HOTKEY,
-        "functional_receipt_hash": receipt_hash,
-        "business_artifact_hash": sha256_json(result_doc),
-    }
-    assert finished["next_work"]["work_kind"] == "leg1_reward"
+    assert "reward_intent" not in finished
+    assert "next_work" not in finished
 
 
 @pytest.mark.asyncio
@@ -691,9 +686,14 @@ async def test_reward_worker_exception_never_dead_letters(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_leg1_finalization_binds_reward_decision_receipt(monkeypatch):
+    config_ref = "source_add_probe_config:0123456789abcdef"
     functional_result = {
         "schema_version": "leadpoet.source_add_functional_probe_result.v2",
         "evaluator_version": "leadpoet.source_add_functional_probe_evaluator.v2.1",
+        "submission_id": SUBMISSION_ID,
+        "adapter_id": ADAPTER_ID,
+        "config_ref": config_ref,
+        "evaluation_mode": "functional_probe",
         "result_status": "passed",
         "route_hash": "sha256:" + "2" * 64,
     }
@@ -701,7 +701,18 @@ async def test_leg1_finalization_binds_reward_decision_receipt(monkeypatch):
     functional_receipt = "sha256:" + "3" * 64
     decision_receipt = "sha256:" + "4" * 64
     decision_artifact = "sha256:" + "5" * 64
+    smoke_receipt = "sha256:" + "6" * 64
+    smoke_result = {
+        **functional_result,
+        "evaluation_mode": "provisioning_smoke",
+        "route_hash": "sha256:" + "7" * 64,
+    }
+    smoke_hash = sha256_json(smoke_result)
+    catalog_id = "source_catalog:0123456789abcdef"
+    provision_ref = "source_add_provision:0123456789abcdef"
+    registry_provider_id = "sourceadd_credible_api"
     finalized_payload = {}
+    authorized_payload = {}
 
     async def fake_select_one(table, **_kwargs):
         if table == "research_lab_source_add_reward_intents":
@@ -715,14 +726,53 @@ async def test_leg1_finalization_binds_reward_decision_receipt(monkeypatch):
                 "submission_id": SUBMISSION_ID,
                 "adapter_id": ADAPTER_ID,
                 "attempt_ref": "source_add_probe_attempt:0123456789abcdef",
+                "config_ref": config_ref,
                 "result_status": "passed",
                 "receipt_hash": functional_receipt,
                 "business_artifact_hash": functional_hash,
                 "result_doc": functional_result,
             }
+        if table == "research_lab_source_add_provisioning_current":
+            return {
+                "provision_ref": provision_ref,
+                "catalog_id": catalog_id,
+                "submission_id": SUBMISSION_ID,
+                "adapter_id": ADAPTER_ID,
+                "miner_hotkey": MINER_HOTKEY,
+                "registry_provider_id": registry_provider_id,
+                "provision_status": "provisioned_autoresearch_eligible",
+            }
+        if table == "research_lab_source_add_provisioning_smoke_current":
+            return {
+                "attempt_ref": "source_add_probe_attempt:fedcba9876543210",
+                "submission_id": SUBMISSION_ID,
+                "adapter_id": ADAPTER_ID,
+                "config_ref": config_ref,
+                "evaluation_mode": "provisioning_smoke",
+                "result_status": "passed",
+                "receipt_hash": smoke_receipt,
+                "business_artifact_hash": smoke_hash,
+                "result_doc": smoke_result,
+            }
+        if table == "research_lab_source_catalog":
+            return {
+                "catalog_id": catalog_id,
+                "adapter_id": ADAPTER_ID,
+                "miner_ref": MINER_HOTKEY,
+                "registry_provider_id": registry_provider_id,
+            }
         if table == "research_lab_source_add_reward_current":
             return None
         raise AssertionError(table)
+
+    async def fake_select_many(table, **_kwargs):
+        assert table == "research_lab_source_add_submissions"
+        return [
+            _submission_row(
+                stage="accepted",
+                precheck_status="provenance_precheck_passed",
+            )
+        ]
 
     async def fake_rpc(name, params):
         if name == "research_lab_source_add_reserve_leg1_slot":
@@ -738,7 +788,8 @@ async def test_leg1_finalization_binds_reward_decision_receipt(monkeypatch):
             }
         raise AssertionError(name)
 
-    async def fake_authorize(**_kwargs):
+    async def fake_authorize(**kwargs):
+        authorized_payload.update(kwargs)
         return {
             "status": "matched",
             "execution_receipt": {
@@ -753,6 +804,7 @@ async def test_leg1_finalization_binds_reward_decision_receipt(monkeypatch):
         lambda _sid: _async_value(_submission_row(stage="leg1_queued")),
     )
     monkeypatch.setattr(workflow, "select_one", fake_select_one)
+    monkeypatch.setattr(workflow, "select_many", fake_select_many)
     monkeypatch.setattr(workflow, "_rpc", fake_rpc)
     monkeypatch.setattr(workflow, "authorize_reward_decision_v2", fake_authorize)
     monkeypatch.setattr(
@@ -762,7 +814,15 @@ async def test_leg1_finalization_binds_reward_decision_receipt(monkeypatch):
     )
     monkeypatch.setattr(
         "gateway.research_lab.attested_v2_store.load_business_artifact_graph_v2",
-        lambda **_kwargs: _async_value({"root_receipt_hash": functional_receipt}),
+        lambda **kwargs: _async_value(
+            {
+                "root_receipt_hash": (
+                    functional_receipt
+                    if kwargs["artifact_kind"] == "source_add_functional_probe"
+                    else smoke_receipt
+                )
+            }
+        ),
     )
 
     result = await workflow._process_leg1_reward(
@@ -777,6 +837,13 @@ async def test_leg1_finalization_binds_reward_decision_receipt(monkeypatch):
     assert finalized_payload["p_reward"]["decision_receipt_hash"] == decision_receipt
     assert finalized_payload["p_reward"]["decision_artifact_hash"] == decision_artifact
     assert finalized_payload["p_reward"]["start_epoch"] == 701
+    trigger = finalized_payload["p_reward"]["trigger_evidence_doc"]
+    assert trigger["final_acceptance_stage"] == "accepted"
+    assert trigger["catalog_id"] == catalog_id
+    assert trigger["provisioning_smoke_receipt_hash"] == smoke_receipt
+    assert tuple(
+        graph["root_receipt_hash"] for graph in authorized_payload["parent_graphs"]
+    ) == (functional_receipt, smoke_receipt)
 
 
 @pytest.mark.asyncio

--- a/tests/test_source_add_post_accept_leg1_sql.py
+++ b/tests/test_source_add_post_accept_leg1_sql.py
@@ -1,0 +1,52 @@
+"""Fail-closed checks for post-acceptance SOURCE_ADD Leg 1."""
+
+from pathlib import Path
+
+from gateway.tee.supabase_schema_preflight_v2 import REQUIRED_SUPABASE_V2_RPCS
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = "scripts/167-research-lab-source-add-post-accept-leg1.sql"
+SQL = (ROOT / MIGRATION).read_text(encoding="utf-8")
+
+
+def test_post_accept_leg1_migration_is_additive_and_transactional() -> None:
+    assert SQL.startswith("-- Create SOURCE_ADD Leg 1 only after accepted")
+    assert "BEGIN;" in SQL
+    assert SQL.rstrip().endswith("COMMIT;")
+    assert "SET LOCAL lock_timeout = '5s'" in SQL
+    assert "DROP TABLE" not in SQL.upper()
+    assert "TRUNCATE" not in SQL.upper()
+    assert "UPDATE public.research_lab_source_add_reward_obligations" not in SQL
+
+
+def test_leg1_requires_acceptance_provisioning_and_both_receipt_parents() -> None:
+    for marker in (
+        "trg_source_add_leg1_intent_after_acceptance",
+        "trg_source_add_leg1_work_after_acceptance",
+        "trg_source_add_leg1_catalog_binding",
+        "accepted.stage = 'accepted'",
+        "accepted.precheck_status = 'provenance_precheck_passed'",
+        "provision.provision_status = 'provisioned_autoresearch_eligible'",
+        "smoke.evaluation_mode = 'provisioning_smoke'",
+        "smoke.result_status = 'passed'",
+        "edge.parent_receipt_hash = functional.receipt_hash",
+        "edge.parent_receipt_hash = smoke.receipt_hash",
+        "NEW.catalog_id := v_catalog_id",
+    ):
+        assert marker in SQL
+
+
+def test_post_accept_finalizer_is_restart_gated_and_service_role_only() -> None:
+    required = {
+        function
+        for migration, function in REQUIRED_SUPABASE_V2_RPCS
+        if migration == MIGRATION
+    }
+    assert required == {
+        "research_lab_source_add_finalize_provision_smoke_v2",
+        "research_lab_source_add_post_accept_leg1_contract_v1",
+    }
+    assert "FROM PUBLIC, anon, authenticated" in SQL
+    assert "TO service_role" in SQL
+    assert "NOTIFY pgrst, 'reload schema'" in SQL

--- a/tests/test_source_add_workflow.py
+++ b/tests/test_source_add_workflow.py
@@ -236,6 +236,15 @@ def _workflow_config() -> SimpleNamespace:
 async def test_provisioning_smoke_pass_finalizes_with_exact_work_lease(monkeypatch):
     work = _smoke_work()
     result = _smoke_result("passed")
+    functional_result = {
+        "schema_version": "leadpoet.source_add_functional_probe_result.v2",
+        "submission_id": work["submission_id"],
+        "adapter_id": work["adapter_id"],
+        "config_ref": work["job_doc"]["config_ref"],
+        "evaluation_mode": "functional_probe",
+        "result_status": "passed",
+        "route_hash": "sha256:" + "6" * 64,
+    }
 
     async def fake_load(_submission_id):
         return {
@@ -261,6 +270,17 @@ async def test_provisioning_smoke_pass_finalizes_with_exact_work_lease(monkeypat
             },
         }
 
+    async def fake_select_one(table, **_kwargs):
+        assert table == "research_lab_source_add_functional_probe_current"
+        return {
+            "attempt_ref": "source_add_probe_attempt:" + "c" * 16,
+            "adapter_id": work["adapter_id"],
+            "result_status": "passed",
+            "receipt_hash": "sha256:" + "7" * 64,
+            "business_artifact_hash": sha256_json(functional_result),
+            "result_doc": functional_result,
+        }
+
     observed = {}
 
     async def fake_rpc(name, params):
@@ -269,6 +289,7 @@ async def test_provisioning_smoke_pass_finalizes_with_exact_work_lease(monkeypat
         return {"status": "provisioned", "catalog_id": "source_catalog:" + "c" * 16}
 
     monkeypatch.setattr(source_add_workflow, "_load_submission", fake_load)
+    monkeypatch.setattr(source_add_workflow, "select_one", fake_select_one)
     monkeypatch.setattr(
         source_add_workflow,
         "_begin_provider_execution",
@@ -284,7 +305,7 @@ async def test_provisioning_smoke_pass_finalizes_with_exact_work_lease(monkeypat
     )
 
     assert response["status"] == "provisioned"
-    assert observed["name"] == "research_lab_source_add_finalize_provision_smoke"
+    assert observed["name"] == "research_lab_source_add_finalize_provision_smoke_v2"
     assert observed["params"]["p_work_id"] == work["work_id"]
     assert observed["params"]["p_lease_token"] == work["lease_token"]
     smoke = observed["params"]["p_smoke_attempt"]
@@ -293,6 +314,18 @@ async def test_provisioning_smoke_pass_finalizes_with_exact_work_lease(monkeypat
     assert smoke["evaluation_mode"] == "provisioning_smoke"
     assert smoke["receipt_hash"] == "sha256:" + "4" * 64
     assert smoke["business_artifact_hash"] == sha256_json(result)
+    assert observed["params"]["p_reward_intent"] == {
+        "intent_id": source_add_workflow.source_add_reward_intent_id(
+            work["submission_id"], work["adapter_id"]
+        ),
+        "miner_hotkey": "hk-owner",
+        "functional_receipt_hash": "sha256:" + "7" * 64,
+        "business_artifact_hash": sha256_json(functional_result),
+    }
+    assert observed["params"]["p_next_work"]["work_kind"] == "leg1_reward"
+    assert observed["params"]["p_next_work"]["job_doc"]["attempt_ref"] == (
+        "source_add_probe_attempt:" + "c" * 16
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- delay SOURCE_ADD Leg 1 until operator acceptance, eligible provisioning, and a passed provisioning smoke test
- bind reward authority to both functional and smoke V2 receipt parents and the accepted catalog row
- default production SOURCE_ADD to Leg 1-only and reject already-integrated provider origins
- keep miner README inputs concise and separate from Auto Research credentials

## Verification
- 262 SOURCE_ADD tests
- 154 focused SQL/enclave/worker tests
- 511 transport, rebenchmark, persistence, canonical bundle, and primary/audit weight regressions
- 24 protected workflow checks
- disposable PostgreSQL end-to-end contract