### PR TITLE
Declare Production Parity Full restart fallback context

### DIFF
--- a/scripts/run_production_parity_full_host.py
+++ b/scripts/run_production_parity_full_host.py
@@ -2858,6 +2858,7 @@ def run_full(
                 "VALIDATOR_V2_OFFLINE_ARTIFACT_ROOT": str(work / "offline-artifacts" / "validator-runtime"),
                 "GATEWAY_RESTART_LOCK_FILE": str(work / "gateway-restart.lock"),
                 "LEADPOET_DOCKER_OPERATION_LOCK_FILE": str(work / "docker-operation.lock"),
+                "GATEWAY_ACTIVE_RELEASE_FALLBACK_CONTEXT": "full-parity",
                 "GATEWAY_DEPLOY_COMMIT": candidate_sha,
                 "GATEWAY_PYTHON_BIN": sys.executable,
                 "GATEWAY_V2_RELEASE_BUCKET": ATTESTED_V2_RELEASE_BUCKET,

--- a/tests/test_production_parity.py
+++ b/tests/test_production_parity.py
@@ -3921,6 +3921,10 @@ def test_full_gateway_restart_reasserts_run_owned_path_authority():
     assert '"GATEWAY_V2_KMS_KEY_ID": ATTESTED_V2_KMS_KEY_ID' in full_source
     assert '"GATEWAY_PRIVATE_KEY_PATH": gateway_private_key_path' in full_source
     assert '"ARWEAVE_KEYFILE_PATH": arweave_keyfile_path' in full_source
+    assert (
+        '"GATEWAY_ACTIVE_RELEASE_FALLBACK_CONTEXT": "full-parity"'
+        in full_source
+    )
     assert '"GATEWAY_RESTART_GIT_SSH_COMMAND":' not in full_source
     assert "research_lab_private_model_deploy" not in full_source
 


### PR DESCRIPTION
## Scope

- Bind the exact disposable Production Parity Full gateway restart to the explicit `full-parity` active-release fallback context.
- Keep production and ordinary restart behavior unchanged.
- Add one static regression assertion for the required environment binding.

## Why

Production Parity Full restores a disposable production-shaped database clone whose active-release state is intentionally absent before the candidate restart. The canonical restart remains fail closed unless the already-supported fallback is explicitly scoped to Full parity.

## Focused gate

- Python compilation passed for the touched runner and regression file.
- The directly affected parity regression passed.
- `git diff --check` passed.
- No secrets or unrelated files are included.

GitHub Actions must pass before merge.