### PR TITLE
Recover allocation retries across restarts

### DIFF
--- a/gateway/research_lab/allocations.py
+++ b/gateway/research_lab/allocations.py
@@ -23,6 +23,7 @@ from gateway.research_lab.store import (
     _is_transient_store_error,
     create_research_lab_emission_allocation_snapshot,
     select_all,
+    select_many,
 )
 from leadpoet_verifier.economics import (
     CHAMPION_CREDIT_POLICY_ACCELERATED_LIFETIME_CAP_V1,
@@ -56,6 +57,72 @@ _ALLOCATION_V2_RETRY_GENERATIONS: dict[
 ] = {}
 _ALLOCATION_V2_RETRY_GENERATION_TTL_SECONDS = 3600.0
 _ALLOCATION_V2_RETRY_MAX_GENERATIONS = 8
+_ALLOCATION_V2_RECEIPT_TABLE = "research_lab_attested_execution_receipts_v2"
+_ALLOCATION_V2_RECEIPT_ROLE = "gateway_coordinator"
+_ALLOCATION_V2_RECEIPT_PURPOSE = "research_lab.allocation.v2"
+
+
+def _active_gateway_commit() -> str:
+    from gateway.build_info import get_build_info
+
+    commit = str(get_build_info().get("git_commit") or "").strip().lower()
+    if len(commit) not in {40, 64} or any(
+        character not in "0123456789abcdef" for character in commit
+    ):
+        raise RuntimeError("active gateway commit is unavailable for allocation retry")
+    return commit
+
+
+async def _load_durable_allocation_retry_generation(
+    *,
+    epoch_id: int,
+) -> int:
+    """Resume after failed allocation receipts from an earlier process."""
+
+    commit_sha = _active_gateway_commit()
+    rows = await select_many(
+        _ALLOCATION_V2_RECEIPT_TABLE,
+        columns=(
+            "sequence,receipt_status,failure_code,job_id,commit_sha,"
+            "epoch_id,purpose,role"
+        ),
+        filters=(
+            ("role", _ALLOCATION_V2_RECEIPT_ROLE),
+            ("purpose", _ALLOCATION_V2_RECEIPT_PURPOSE),
+            ("epoch_id", int(epoch_id)),
+            ("commit_sha", str(commit_sha)),
+            ("receipt_status", "failed"),
+        ),
+        order_by=(("sequence", True),),
+        limit=_ALLOCATION_V2_RETRY_MAX_GENERATIONS,
+    )
+    if not rows:
+        return 0
+
+    highest_sequence = -1
+    for row in rows:
+        sequence = row.get("sequence")
+        if (
+            isinstance(sequence, bool)
+            or not isinstance(sequence, int)
+            or sequence < 0
+            or row.get("role") != _ALLOCATION_V2_RECEIPT_ROLE
+            or row.get("purpose") != _ALLOCATION_V2_RECEIPT_PURPOSE
+            or int(row.get("epoch_id", -1)) != int(epoch_id)
+            or str(row.get("commit_sha") or "").lower() != str(commit_sha)
+            or row.get("receipt_status") != "failed"
+            or not str(row.get("failure_code") or "").strip()
+            or not str(row.get("job_id") or "").startswith(
+                "scoring-v2:research-lab-allocation:"
+            )
+        ):
+            raise RuntimeError("durable allocation retry receipt is invalid")
+        highest_sequence = max(highest_sequence, sequence)
+
+    generation = highest_sequence + 1
+    if generation >= _ALLOCATION_V2_RETRY_MAX_GENERATIONS:
+        raise RuntimeError("durable allocation retry generations are exhausted")
+    return generation
 
 
 def _allocation_v2_build_is_retryable(exc: BaseException) -> bool:
@@ -94,20 +161,30 @@ async def _build_allocation_v2_singleflight(
     task = _ALLOCATION_V2_INFLIGHT.get(key)
     if task is None:
         retry_state = _ALLOCATION_V2_RETRY_GENERATIONS.get(key)
-        generation = 0
+        memory_generation = 0
         if retry_state is not None:
-            retry_expires_at, generation = retry_state
+            retry_expires_at, memory_generation = retry_state
             if retry_expires_at <= loop.time():
                 _ALLOCATION_V2_RETRY_GENERATIONS.pop(key, None)
-                generation = 0
-        task = loop.create_task(
-            build_allocation_v2(
+                memory_generation = 0
+        selected_generation: list[int] = []
+
+        async def build_with_durable_generation() -> dict[str, Any]:
+            durable_generation = await _load_durable_allocation_retry_generation(
+                epoch_id=int(epoch_id),
+            )
+            generation = max(int(memory_generation), int(durable_generation))
+            if generation >= _ALLOCATION_V2_RETRY_MAX_GENERATIONS:
+                raise RuntimeError("allocation retry generations are exhausted")
+            selected_generation.append(generation)
+            return await build_allocation_v2(
                 epoch_id=int(epoch_id),
                 netuid=int(netuid),
                 policy=dict(policy),
-                allocation_sequence=int(generation),
+                allocation_sequence=generation,
             )
-        )
+
+        task = loop.create_task(build_with_durable_generation())
         _ALLOCATION_V2_INFLIGHT[key] = task
 
         def clear(completed: asyncio.Task[dict[str, Any]]) -> None:
@@ -118,14 +195,11 @@ async def _build_allocation_v2_singleflight(
             try:
                 completed.result()
             except BaseException as exc:
-                if _allocation_v2_build_is_retryable(exc):
+                if selected_generation and _allocation_v2_build_is_retryable(exc):
                     _ALLOCATION_V2_RETRY_GENERATIONS[key] = (
                         loop.time()
                         + _ALLOCATION_V2_RETRY_GENERATION_TTL_SECONDS,
-                        min(
-                            generation + 1,
-                            _ALLOCATION_V2_RETRY_MAX_GENERATIONS - 1,
-                        ),
+                        selected_generation[0] + 1,
                     )
                 return
             _ALLOCATION_V2_RETRY_GENERATIONS.pop(key, None)

--- a/tests/test_source_add_rewards.py
+++ b/tests/test_source_add_rewards.py
@@ -628,6 +628,7 @@ class TestAllocationRails:
     async def test_gateway_bundle_keeps_source_obligations_out_of_champion_inputs(self, monkeypatch):
         from gateway.research_lab import allocations as gateway_allocations
 
+        _disable_durable_allocation_retry(monkeypatch, gateway_allocations)
         source = create_leg1_reward(adapter_id="adapter:a", miner_ref="miner:a", start_epoch=100)
         source_obligation = self._source_obligation(source)
         monkeypatch.setattr(
@@ -669,6 +670,7 @@ class TestAllocationRails:
     async def test_gateway_bundle_without_source_preserves_legacy_input_shape(self, monkeypatch):
         from gateway.research_lab import allocations as gateway_allocations
 
+        _disable_durable_allocation_retry(monkeypatch, gateway_allocations)
         authority = _allocation_authority_outcome(
             epoch=105,
             netuid=71,
@@ -710,6 +712,7 @@ async def test_gateway_allocation_coalesces_only_overlapping_authority_builds(
 ):
     from gateway.research_lab import allocations as gateway_allocations
 
+    _disable_durable_allocation_retry(monkeypatch, gateway_allocations)
     policy = {
         "policy_id": "research_lab_reimbursement_policy_v1",
         "lab_cap_alpha_percent": 30.0,
@@ -768,6 +771,7 @@ async def test_gateway_allocation_coalesces_only_overlapping_authority_builds(
 async def test_gateway_allocation_retries_after_shared_build_failure(monkeypatch):
     from gateway.research_lab import allocations as gateway_allocations
 
+    _disable_durable_allocation_retry(monkeypatch, gateway_allocations)
     policy = {
         "policy_id": "research_lab_reimbursement_policy_v1",
         "lab_cap_alpha_percent": 30.0,
@@ -811,6 +815,112 @@ async def test_gateway_allocation_retries_after_shared_build_failure(monkeypatch
 
     assert calls == 2
     assert bundle["epoch"] == 106
+
+
+@pytest.mark.asyncio
+async def test_gateway_allocation_resumes_after_durable_failed_generation(
+    monkeypatch,
+):
+    from gateway.research_lab import allocations as gateway_allocations
+
+    selected_sequences = []
+
+    async def durable_generation(**_kwargs):
+        return 1
+
+    async def build(**kwargs):
+        selected_sequences.append(kwargs["allocation_sequence"])
+        return {"status": "matched"}
+
+    monkeypatch.setattr(
+        gateway_allocations,
+        "_load_durable_allocation_retry_generation",
+        durable_generation,
+    )
+    monkeypatch.setattr(gateway_allocations, "build_allocation_v2", build)
+
+    result = await gateway_allocations._build_allocation_v2_singleflight(
+        epoch_id=24940,
+        netuid=71,
+        policy={"policy_id": "durable-retry"},
+    )
+
+    assert result == {"status": "matched"}
+    assert selected_sequences == [1]
+
+
+@pytest.mark.asyncio
+async def test_durable_allocation_retry_uses_failed_receipt_sequence(monkeypatch):
+    from gateway.research_lab import allocations as gateway_allocations
+
+    commit = "a" * 40
+    observed = {}
+
+    async def load(table, **kwargs):
+        observed["table"] = table
+        observed.update(kwargs)
+        return [
+            {
+                "sequence": 0,
+                "receipt_status": "failed",
+                "failure_code": "execution_valueerror",
+                "job_id": "scoring-v2:research-lab-allocation:job-0",
+                "commit_sha": commit,
+                "epoch_id": 24940,
+                "purpose": "research_lab.allocation.v2",
+                "role": "gateway_coordinator",
+            }
+        ]
+
+    monkeypatch.setattr(gateway_allocations, "_active_gateway_commit", lambda: commit)
+    monkeypatch.setattr(gateway_allocations, "select_many", load)
+
+    generation = await gateway_allocations._load_durable_allocation_retry_generation(
+        epoch_id=24940,
+    )
+
+    assert generation == 1
+    assert observed["table"] == "research_lab_attested_execution_receipts_v2"
+    assert ("receipt_status", "failed") in observed["filters"]
+    assert ("commit_sha", commit) in observed["filters"]
+    assert "receipt_doc" not in observed["columns"]
+
+
+@pytest.mark.asyncio
+async def test_durable_allocation_retry_exhaustion_fails_closed(monkeypatch):
+    from gateway.research_lab import allocations as gateway_allocations
+
+    commit = "b" * 40
+
+    async def load(_table, **_kwargs):
+        return [
+            {
+                "sequence": 7,
+                "receipt_status": "failed",
+                "failure_code": "execution_valueerror",
+                "job_id": "scoring-v2:research-lab-allocation:job-7",
+                "commit_sha": commit,
+                "epoch_id": 24941,
+                "purpose": "research_lab.allocation.v2",
+                "role": "gateway_coordinator",
+            }
+        ]
+
+    monkeypatch.setattr(gateway_allocations, "_active_gateway_commit", lambda: commit)
+    monkeypatch.setattr(gateway_allocations, "select_many", load)
+
+    with pytest.raises(RuntimeError, match="retry generations are exhausted"):
+        await gateway_allocations._load_durable_allocation_retry_generation(
+            epoch_id=24941,
+        )
+
+
+def _disable_durable_allocation_retry(monkeypatch, gateway_allocations):
+    monkeypatch.setattr(
+        gateway_allocations,
+        "_load_durable_allocation_retry_generation",
+        lambda **_kwargs: _async_value(0),
+    )
 
 
 async def _async_value(value):


### PR DESCRIPTION
## Summary
- recover allocation retry generation from durable failed coordinator receipts
- preserve exact release and epoch scope while advancing retry sequence
- fail closed on malformed or exhausted durable retry history

## Verification
- `python3 -m py_compile gateway/research_lab/allocations.py tests/test_source_add_rewards.py`
- `python3 -m pytest -q tests/test_source_add_rewards.py tests/test_attested_allocation_api.py tests/test_allocation_endpoint_cache.py` (79 passed)
- `git diff --check origin/main...HEAD`