### PR TITLE
Canonicalize SOURCE_ADD public domain identity

### DIFF
--- a/gateway/research_lab/source_add_execution_plan.py
+++ b/gateway/research_lab/source_add_execution_plan.py
@@ -33,6 +33,8 @@ _SECRET_KEY_RE = re.compile(
     r"(?:api[_-]?key|authorization|bearer|cookie|credential|password|secret|token)",
     re.IGNORECASE,
 )
+_CANONICAL_SOURCE_DOMAIN_FIELD = "canonical_source_domain"
+_LEGACY_CANONICAL_URL_HOST_FIELD = "canonical_url_host"
 
 
 class SourceAddExecutionPlanError(ValueError):
@@ -79,14 +81,14 @@ def _public_domain(value: Any) -> str:
         or domain.endswith((".local", ".localhost", ".internal", ".example"))
     ):
         raise SourceAddExecutionPlanError(
-            "SOURCE_ADD response canonical_url_host is invalid"
+            "SOURCE_ADD response canonical source domain is invalid"
         )
     try:
         ipaddress.ip_address(domain)
     except ValueError:
         return domain
     raise SourceAddExecutionPlanError(
-        "SOURCE_ADD response canonical_url_host must not be an IP address"
+        "SOURCE_ADD response canonical source domain must not be an IP address"
     )
 
 
@@ -207,23 +209,34 @@ def normalize_source_add_execution_plan(
         seen_query_keys.add(folded)
         query[key] = value_text
 
-    projection = _exact_mapping(
-        plan["response_projection"],
-        field_name="SOURCE_ADD response projection",
-        fields=frozenset(
-            {
-                "kind",
-                "category",
-                "object_field",
-                "identity_field",
-                "expected_identity",
-                "canonical_url_field",
-                "canonical_url_host",
-                "canonical_url_path_prefix",
-                "excerpt_fields",
-            }
-        ),
-    )
+    raw_projection = plan["response_projection"]
+    projection_fields = {
+        "kind",
+        "category",
+        "object_field",
+        "identity_field",
+        "expected_identity",
+        "canonical_url_field",
+        "canonical_url_path_prefix",
+        "excerpt_fields",
+    }
+    if not isinstance(raw_projection, Mapping):
+        raise SourceAddExecutionPlanError(
+            "SOURCE_ADD response projection fields differ from the contract"
+        )
+    domain_fields = {
+        _CANONICAL_SOURCE_DOMAIN_FIELD,
+        _LEGACY_CANONICAL_URL_HOST_FIELD,
+    } & set(raw_projection)
+    if (
+        len(domain_fields) != 1
+        or set(raw_projection) != projection_fields | domain_fields
+    ):
+        raise SourceAddExecutionPlanError(
+            "SOURCE_ADD response projection fields differ from the contract"
+        )
+    projection = dict(raw_projection)
+    source_domain = _public_domain(projection[next(iter(domain_fields))])
     category = str(projection["category"] or "").strip().upper()
     categories = tuple(
         str(item or "").strip().upper() for item in intent_categories
@@ -286,9 +299,10 @@ def normalize_source_add_execution_plan(
             "identity_field": identity_field,
             "expected_identity": expected_identity,
             "canonical_url_field": canonical_url_field,
-            "canonical_url_host": _public_domain(
-                projection["canonical_url_host"]
-            ),
+            # This is a public citation-domain constraint, not the provider's
+            # private transport host. Canonicalize the legacy input name so
+            # model release metadata retains its strict host-binding ban.
+            _CANONICAL_SOURCE_DOMAIN_FIELD: source_domain,
             "canonical_url_path_prefix": path_prefix,
             "excerpt_fields": list(excerpt_fields),
         },

--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -1,5 +1,5 @@
 {
-  "baseline_commit": "0cd8f6dfde08ac321174b881e860f4d5915d8b24",
+  "baseline_commit": "149841257e72b9f0acc6b8bd62d934b2a519f896",
   "entries": [
     {
       "ast_sha256": "sha256:da4f1f7963737c796207bd8013762fdde3d22f13dc194bd8b1ccc6a7e4032fbf",
@@ -8707,7 +8707,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:263f85dd81176567ef3fa0629e16e5039c0581e1894f5e4b5419b18b4387d1d5",
-  "protected_source_commit": "0cd8f6dfde08ac321174b881e860f4d5915d8b24",
+  "manifest_hash": "sha256:05a7754b5be98571cc986482efa9f88dfe6f45200be5f3e48fd105e6d0931c31",
+  "protected_source_commit": "149841257e72b9f0acc6b8bd62d934b2a519f896",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/tests/test_provider_capabilities.py
+++ b/tests/test_provider_capabilities.py
@@ -293,7 +293,7 @@ def _builtwith_execution_plan() -> dict:
             "identity_field": "name",
             "expected_identity": "Shopify",
             "canonical_url_field": "trends_link",
-            "canonical_url_host": "trends.builtwith.com",
+            "canonical_source_domain": "trends.builtwith.com",
             "canonical_url_path_prefix": "/shop/",
             "excerpt_fields": ["description"],
         },
@@ -426,6 +426,60 @@ def test_source_add_execution_plan_is_bound_to_tested_provisioned_route():
         context,
         existing_runtime_source=_EMPTY_V8_ROUTER_RUNTIME,
     ) != []
+
+
+def test_source_add_execution_plan_canonicalizes_legacy_host_field():
+    legacy_plan = json.loads(json.dumps(_builtwith_execution_plan()))
+    projection = legacy_plan["response_projection"]
+    projection["canonical_url_host"] = projection.pop(
+        "canonical_source_domain"
+    )
+
+    normalized = normalize_source_add_planner_contract(
+        "builtwith_trends",
+        {
+            "stage": "intent_evidence",
+            "cost_class": "free",
+            "unit_cost": 0.0,
+            "max_calls": 1,
+            "max_results": 1,
+            "intent_categories": ["TECHSTACK"],
+            "execution_plan_identity": legacy_plan,
+        },
+        probe_endpoints=[_builtwith_probe_endpoint()],
+        tested_probes=[_builtwith_tested_probe()],
+    )
+
+    canonical_projection = normalized["execution_plan_identity"][
+        "response_projection"
+    ]
+    assert canonical_projection["canonical_source_domain"] == (
+        "trends.builtwith.com"
+    )
+    assert "canonical_url_host" not in canonical_projection
+
+
+def test_source_add_execution_plan_rejects_ambiguous_domain_fields():
+    plan = _builtwith_execution_plan()
+    plan["response_projection"]["canonical_url_host"] = (
+        "trends.builtwith.com"
+    )
+
+    with pytest.raises(ValueError, match="fields differ from the contract"):
+        normalize_source_add_planner_contract(
+            "builtwith_trends",
+            {
+                "stage": "intent_evidence",
+                "cost_class": "free",
+                "unit_cost": 0.0,
+                "max_calls": 1,
+                "max_results": 1,
+                "intent_categories": ["TECHSTACK"],
+                "execution_plan_identity": plan,
+            },
+            probe_endpoints=[_builtwith_probe_endpoint()],
+            tested_probes=[_builtwith_tested_probe()],
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- accept the legacy SOURCE_ADD response host field only at gateway ingress
- normalize persisted/protected execution plans to the public canonical domain field
- reject ambiguous dual-field routing contracts

## Verification
- 529 SOURCE_ADD/protected tests passed
- 128 rebenchmark/allocation/weight regressions passed
- clean BuiltWith Leg 1 E2E passed through 20 reward epochs, allocation/settlement, and primary/audit handoff
- production fingerprint unchanged; disposable stack cleaned