### PR TITLE
Handle Docker blank lines in validator recovery

### DIFF
--- a/scripts/restart_attested_release_local.sh
+++ b/scripts/restart_attested_release_local.sh
@@ -1539,6 +1539,12 @@ validator_active_commit() {
      docker info >/dev/null
      inspect_output=\$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' \
        leadpoet-validator-main 2>&1) || {
+       while [[ \"\$inspect_output\" == [[:space:]]* ]]; do
+         inspect_output=\"\${inspect_output:1}\"
+       done
+       while [[ \"\$inspect_output\" == *[[:space:]] ]]; do
+         inspect_output=\"\${inspect_output%?}\"
+       done
        if [ \"\$inspect_output\" = 'Error: No such object: leadpoet-validator-main' ]; then
          exit 44
        fi

--- a/tests/test_attested_release_restart_operator.py
+++ b/tests/test_attested_release_restart_operator.py
@@ -1755,6 +1755,63 @@ def test_validator_only_operator_rejects_unknown_runtime_probe_failure(
     assert "validator_start" not in observed
 
 
+@pytest.mark.parametrize(
+    ("inspect_message", "expected_status"),
+    (
+        ("Error: No such object: leadpoet-validator-main", 44),
+        ("permission denied", 1),
+        ("Cannot connect to the Docker daemon", 1),
+        ("Error: No such object: leadpoet-validator-main\nextra", 1),
+    ),
+)
+def test_validator_active_commit_classifies_only_whitespace_wrapped_absence(
+    tmp_path: Path,
+    inspect_message: str,
+    expected_status: int,
+) -> None:
+    source = SCRIPT.read_text(encoding="utf-8")
+    start = source.index("validator_active_commit() {")
+    function = source[start : source.index("\n}\n", start) + 2]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker = bin_dir / "docker"
+    docker.write_text(
+        "#!/bin/bash\n"
+        "if [ \"$1\" = info ]; then exit 0; fi\n"
+        "printf '\\n'\n"
+        "printf '%s\\n' \"$VALIDATOR_INSPECT_MESSAGE\" >&2\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    ssh = bin_dir / "ssh"
+    ssh.write_text(
+        '#!/bin/bash\ncommand="${!#}"\nexec bash -c "$command"\n',
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+    ssh.chmod(0o755)
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "ssh_common=(); VALIDATOR_KEY=unused; VALIDATOR_HOST=unused\n"
+            + function
+            + "\nvalidator_active_commit",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": str(bin_dir) + os.pathsep + os.environ["PATH"],
+            "VALIDATOR_INSPECT_MESSAGE": inspect_message,
+        },
+    )
+    assert result.returncode == expected_status
+    if expected_status != 44:
+        assert inspect_message in result.stderr
+
+
 def test_validator_only_operator_rejects_unhealthy_matching_gateway(
     tmp_path: Path,
     dependency_complete_readiness_python: Path,

--- a/tests/test_validator_restart_wrapper_v2.py
+++ b/tests/test_validator_restart_wrapper_v2.py
@@ -4,6 +4,8 @@ import shutil
 import subprocess
 import sys
 
+import pytest
+
 
 def test_restart_preserves_all_tracked_diffs_before_pull():
     script = Path("validator_restart.sh").read_text(encoding="utf-8")
@@ -651,6 +653,41 @@ def test_validator_restart_uses_bounded_active_release_handoff_before_shutdown()
     assert "Validator remains running; production shutdown has not started." in script[
         marker:destructive
     ]
+
+
+@pytest.mark.parametrize(
+    ("inspect_message", "expected_status"),
+    (
+        ("\nError: No such object: leadpoet-validator-main\n", 0),
+        ("\npermission denied\n", 1),
+        ("\nCannot connect to the Docker daemon\n", 1),
+        ("\nError: No such object: leadpoet-validator-main\nextra", 1),
+    ),
+)
+def test_validator_restart_trims_only_outer_inspect_whitespace(
+    inspect_message: str,
+    expected_status: int,
+) -> None:
+    script = Path("validator_restart.sh").read_text(encoding="utf-8")
+    start = script.index(
+        'VALIDATOR_RUNNING_INSPECT_ERROR="$VALIDATOR_RUNNING_INSPECT_OUTPUT"'
+    )
+    end = script.index(
+        '  if [ "$VALIDATOR_RUNNING_INSPECT_ERROR" != ', start
+    )
+    normalization = script[start:end]
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            normalization
+            + "\n[ \"$VALIDATOR_RUNNING_INSPECT_ERROR\" = "
+            + "\"Error: No such object: leadpoet-validator-main\" ]",
+        ],
+        check=False,
+        env={**os.environ, "VALIDATOR_RUNNING_INSPECT_OUTPUT": inspect_message},
+    )
+    assert result.returncode == expected_status
 
 
 def test_standalone_active_release_sidecars_use_bounded_nofollow_reads() -> None:

--- a/validator_restart.sh
+++ b/validator_restart.sh
@@ -1450,7 +1450,14 @@ if VALIDATOR_RUNNING_INSPECT_OUTPUT="$(
     --running-validator-commit "$VALIDATOR_RUNNING_DEPLOY_SHA"
   )
 else
-  if [ "$VALIDATOR_RUNNING_INSPECT_OUTPUT" != "Error: No such object: leadpoet-validator-main" ]; then
+  VALIDATOR_RUNNING_INSPECT_ERROR="$VALIDATOR_RUNNING_INSPECT_OUTPUT"
+  while [[ "$VALIDATOR_RUNNING_INSPECT_ERROR" == [[:space:]]* ]]; do
+    VALIDATOR_RUNNING_INSPECT_ERROR="${VALIDATOR_RUNNING_INSPECT_ERROR:1}"
+  done
+  while [[ "$VALIDATOR_RUNNING_INSPECT_ERROR" == *[[:space:]] ]]; do
+    VALIDATOR_RUNNING_INSPECT_ERROR="${VALIDATOR_RUNNING_INSPECT_ERROR%?}"
+  done
+  if [ "$VALIDATOR_RUNNING_INSPECT_ERROR" != "Error: No such object: leadpoet-validator-main" ]; then
     printf '%s\n' "$VALIDATOR_RUNNING_INSPECT_OUTPUT" >&2
     echo "ERROR: validator runtime state could not be established safely" >&2
     exit 1


### PR DESCRIPTION
Trim only surrounding whitespace before exact missing-container comparison in both canonical classifiers. The real Docker CLI emits a newline on stdout and the exact missing-object error on stderr. Permission, daemon, and extra-message errors still fail closed.

112 focused tests passed in47.51s, including materially executed shell classifiers with the observed output and fail-closed negatives. Shell syntax, Python compilation, and diff-check passed. No miner protocol or runtime artifact changes.