### PR TITLE
Fix Arena sandbox entrypoint permissions

### DIFF
--- a/gateway/tee/protected_workflows.json
+++ b/gateway/tee/protected_workflows.json
@@ -2472,7 +2472,7 @@
       "symbol": "_FALLBACK_CONTEXTS"
     },
     {
-      "ast_sha256": "sha256:a54161fe5b84b9ea31c0b6cf09a46f9f3ab7b721365eb06b2c4188da77209db2",
+      "ast_sha256": "sha256:7881d9d72f7cc070bbdbb6b5c20810bfe9753d40e3c7022cd554d252472dc1ea",
       "path": "gateway/tee/prepare_active_release_lineage_v2.py",
       "symbol": "__module__"
     },
@@ -2492,7 +2492,7 @@
       "symbol": "_load_active_source_add_graphs_v2"
     },
     {
-      "ast_sha256": "sha256:4a8854e00f879f836300e946b6445542a8b65cc08737d90ac489999af88a8f8b",
+      "ast_sha256": "sha256:c8b59c3b107c7090547d853a67e24753266b4797bfc7970411e44cd77cfdf5a3",
       "path": "gateway/tee/prepare_active_release_lineage_v2.py",
       "symbol": "main"
     },
@@ -2507,7 +2507,7 @@
       "symbol": "prepare_validator_final_active_lineage_v2"
     },
     {
-      "ast_sha256": "sha256:a7dc72034f849b2374eb6418fb7c91ff4abaf4a82cfecfbf65f683e32599e0ed",
+      "ast_sha256": "sha256:041db7bc938b3c14a4404a96680ade44c543c6cb2f534b07b9077e87ef9c5892",
       "path": "gateway/tee/prepare_active_release_lineage_v2.py",
       "symbol": "prepare_validator_initial_active_lineage_v2"
     },
@@ -4682,7 +4682,7 @@
       "symbol": "inspect_exact_host_gateway_runtime"
     }
   ],
-  "manifest_hash": "sha256:88188e494c75015383583468b2f1a9cab29cb9bc50ce11d4ed40ce3cdca97ed0",
-  "protected_source_commit": "4a1a7a73532a7870c987c8003bfe5171d7528c29",
+  "manifest_hash": "sha256:8c5d9c021a8ae7d0dbd72a37257b5c090fbf491461612424f9ddd3b36910893a",
+  "protected_source_commit": "c339dc48c297b5c9a22a7a56414bd48a57bafd5f",
   "schema_version": "leadpoet.protected_workflows.v2"
 }

--- a/lab_arena/runner.py
+++ b/lab_arena/runner.py
@@ -67,6 +67,7 @@ DEFAULT_SOURCE_CACHE_MAX_BYTES = 2 * 1024 * 1024 * 1024
 DEFAULT_SOURCE_CACHE_MAX_ENTRIES = 64
 MAX_REQUIREMENTS_BYTES = 64 * 1024
 MAX_REQUIREMENTS = 128
+MAX_AGENT_ENTRYPOINT_BYTES = 1024 * 1024
 MAX_DEPENDENCY_BYTES = 512 * 1024 * 1024
 MAX_DEPENDENCY_FILES = 20_000
 DEPENDENCY_INSTALL_TIMEOUT_SECONDS = 300
@@ -85,6 +86,60 @@ class AgentDependencyError(RunnerError):
 
 class SignatureFn(Protocol):
     def __call__(self, message: str) -> str: ...
+
+
+def _stage_agent_entrypoint(source_path: Path, run_dir: Path) -> Path:
+    """Copy the trusted entrypoint without changing its deployed permissions."""
+
+    source_flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK
+    destination = Path(run_dir) / "agent-entrypoint.py"
+    source_fd = destination_fd = None
+    destination_created = False
+    try:
+        source_fd = os.open(Path(source_path), source_flags)
+        source_info = os.fstat(source_fd)
+        if (
+            not stat.S_ISREG(source_info.st_mode)
+            or source_info.st_size <= 0
+            or source_info.st_size > MAX_AGENT_ENTRYPOINT_BYTES
+        ):
+            raise RunnerError("trusted agent entrypoint is not a bounded regular file")
+        with os.fdopen(source_fd, "rb") as source_file:
+            source_fd = None
+            content = source_file.read(MAX_AGENT_ENTRYPOINT_BYTES + 1)
+        if len(content) != source_info.st_size:
+            raise RunnerError("trusted agent entrypoint changed during staging")
+        destination_fd = os.open(
+            destination,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+            0o600,
+        )
+        destination_created = True
+        with os.fdopen(destination_fd, "wb") as destination_file:
+            destination_fd = None
+            if destination_file.write(content) != len(content):
+                raise RunnerError("trusted agent entrypoint could not be staged")
+            destination_file.flush()
+            os.fchmod(destination_file.fileno(), 0o444)
+    except RunnerError:
+        if destination_created:
+            try:
+                destination.unlink()
+            except FileNotFoundError:
+                pass
+        raise
+    except OSError as exc:
+        if destination_created:
+            try:
+                destination.unlink()
+            except FileNotFoundError:
+                pass
+        raise RunnerError("trusted agent entrypoint could not be staged safely") from exc
+    finally:
+        for descriptor in (destination_fd, source_fd):
+            if descriptor is not None:
+                os.close(descriptor)
+    return destination
 
 
 # ---------------------------------------------------------------------------
@@ -1185,6 +1240,11 @@ class AssignmentExecutor:
                 }
                 extra_environment = {}
             (input_dir / runtime.INPUT_FILE_NAME).write_text(json.dumps(input_document, sort_keys=True), encoding="utf-8")
+            staged_agent_entrypoint = (
+                None
+                if scoring_run
+                else _stage_agent_entrypoint(config.agent_entrypoint_path, run_dir)
+            )
             # Both assignment kinds use the service-selected trusted Python
             # image. Execute assignments add the admitted source bundle under
             # read-only mounts; no miner image metadata is accepted.
@@ -1214,7 +1274,7 @@ class AssignmentExecutor:
                     source_dir=source_dir,
                     dependency_dir=dependency_dir,
                     agent_entrypoint_path=(
-                        None if scoring_run else config.agent_entrypoint_path
+                        staged_agent_entrypoint
                     ),
                     entry_command=runtime.SCORER_ENTRY_COMMAND if scoring_run else runtime.AGENT_ENTRY_COMMAND,
                     working_dir=runtime.SCORER_WORKING_DIR if scoring_run else runtime.AGENT_WORKING_DIR,

--- a/tests/lab_arena/test_lab_arena_runner.py
+++ b/tests/lab_arena/test_lab_arena_runner.py
@@ -10,6 +10,7 @@ import json
 import os
 import shutil
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
@@ -147,9 +148,22 @@ class BridgingRuntime:
         self.exit_code = exit_code
         self.calls = calls
         self.specs: List[runtime.SandboxSpec] = []
+        self.entrypoint_snapshots: List[Dict[str, Any]] = []
 
     def run_icp(self, spec, **_):
         self.specs.append(spec)
+        if spec.agent_entrypoint_path is not None:
+            details = os.lstat(spec.agent_entrypoint_path)
+            self.entrypoint_snapshots.append(
+                {
+                    "bytes": spec.agent_entrypoint_path.read_bytes(),
+                    "gid": details.st_gid,
+                    "mode": stat.S_IMODE(details.st_mode),
+                    "path": spec.agent_entrypoint_path,
+                    "regular": stat.S_ISREG(details.st_mode),
+                    "uid": details.st_uid,
+                }
+            )
         os.environ[shim.WORKER_SOCKET_ENV] = str(spec.socket_path)
         try:
             for _ in range(self.calls):
@@ -198,9 +212,112 @@ def test_accepted_run_bridges_provider_calls_and_returns_a_small_result(tmp_path
     assert spec.entry_command == runtime.AGENT_ENTRY_COMMAND and spec.working_dir == runtime.AGENT_WORKING_DIR
     assert spec.source_dir is not None and (spec.source_dir / "harness.py").is_file()
     assert spec.dependency_dir is not None
-    assert spec.agent_entrypoint_path == rn.AGENT_ENTRYPOINT_PATH
+    assert spec.agent_entrypoint_path != rn.AGENT_ENTRYPOINT_PATH
+    assert sandbox.entrypoint_snapshots[0]["bytes"] == rn.AGENT_ENTRYPOINT_PATH.read_bytes()
+    assert sandbox.entrypoint_snapshots[0]["mode"] == 0o444
+    assert sandbox.entrypoint_snapshots[0]["regular"] is True
+    assert not spec.agent_entrypoint_path.exists()
     assert not spec.input_dir.exists()  # run directory cleaned
     assert runner_.abandoned == 0
+
+
+def test_execute_stages_restrictive_trusted_entrypoint_without_mutating_source(tmp_path):
+    deployed_parent = tmp_path / "deployed" / "lab_arena"
+    deployed_parent.mkdir(parents=True)
+    deployed_parent.chmod(0o700)
+    deployed_entrypoint = deployed_parent / "agent_entrypoint.py"
+    entrypoint_bytes = b"trusted_entrypoint = True\n"
+    deployed_entrypoint.write_bytes(entrypoint_bytes)
+    deployed_entrypoint.chmod(0o600)
+    source_before = deployed_entrypoint.stat()
+    parent_before = deployed_parent.stat()
+
+    api = FakeApi([lease()])
+    sandbox = BridgingRuntime(output={"companies": [valid_company(1)]}, calls=0)
+    (tmp_path / "work").mkdir()
+    config = make_config(tmp_path, api, sandbox)
+    config.agent_entrypoint_path = deployed_entrypoint
+
+    assert rn.Runner(config).run_once() == 1
+
+    snapshot = sandbox.entrypoint_snapshots[0]
+    assert snapshot["bytes"] == entrypoint_bytes
+    assert snapshot["mode"] == 0o444
+    assert snapshot["regular"] is True
+    assert snapshot["uid"] == os.geteuid()
+    assert snapshot["gid"] == os.getegid()
+    assert snapshot["mode"] & stat.S_IROTH
+    assert not snapshot["path"].exists()
+    source_after = deployed_entrypoint.stat()
+    parent_after = deployed_parent.stat()
+    assert deployed_entrypoint.read_bytes() == entrypoint_bytes
+    assert (
+        source_after.st_dev,
+        source_after.st_ino,
+        source_after.st_uid,
+        source_after.st_gid,
+        stat.S_IMODE(source_after.st_mode),
+        source_after.st_size,
+        source_after.st_mtime_ns,
+    ) == (
+        source_before.st_dev,
+        source_before.st_ino,
+        source_before.st_uid,
+        source_before.st_gid,
+        stat.S_IMODE(source_before.st_mode),
+        source_before.st_size,
+        source_before.st_mtime_ns,
+    )
+    assert stat.S_IMODE(parent_after.st_mode) == stat.S_IMODE(parent_before.st_mode) == 0o700
+
+
+def test_trusted_entrypoint_staging_rejects_symlink_source(tmp_path):
+    source = tmp_path / "agent_entrypoint.py"
+    source.write_text("trusted_entrypoint = True\n", encoding="utf-8")
+    link = tmp_path / "entrypoint-link.py"
+    link.symlink_to(source)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    with pytest.raises(rn.RunnerError, match="could not be staged safely"):
+        rn._stage_agent_entrypoint(link, run_dir)
+
+    assert not (run_dir / "agent-entrypoint.py").exists()
+
+
+def test_trusted_entrypoint_staging_preserves_existing_destination(tmp_path):
+    source = tmp_path / "agent_entrypoint.py"
+    source.write_text("trusted_entrypoint = True\n", encoding="utf-8")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    destination = run_dir / "agent-entrypoint.py"
+    destination.write_bytes(b"pre-existing-data")
+
+    with pytest.raises(rn.RunnerError, match="could not be staged safely"):
+        rn._stage_agent_entrypoint(source, run_dir)
+
+    assert destination.read_bytes() == b"pre-existing-data"
+
+
+def test_trusted_entrypoint_staging_rejects_fifo_without_blocking(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "agent-entrypoint.py"
+    os.mkfifo(source)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    real_open = os.open
+
+    def require_nonblocking_source(path, flags, *args, **kwargs):
+        if Path(path) == source:
+            assert flags & os.O_NONBLOCK
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", require_nonblocking_source)
+    with pytest.raises(rn.RunnerError, match="not a bounded regular file"):
+        rn._stage_agent_entrypoint(source, run_dir)
+
+    assert not (run_dir / "agent-entrypoint.py").exists()
 
 
 @pytest.mark.parametrize("kind,expected", [


### PR DESCRIPTION
## Scope
Fix confirmed hosted miner execution failure: stage trusted entrypoint as read-only sandbox-readable file in the existing private run directory. Do not alter deployed Git permissions or miner protocol. Refresh existing infrastructure protected-workflow record for the reviewed recovery source.

## Verification
108 focused tests passed in21.70s; compilation, diff and native protected-workflow verifier passed. Real gVisor imports succeeded for both exact cached baseline and submitted Pydantic source/deps. Full hosted round1 preserved and cancelled after all40 attempts failed before provider calls. New real submission and scoring round follows deployment. No live scoring success claimed yet.