### PR TITLE
Fix accepted LinkedIn slug rejection during miner scoring

### DIFF
--- a/gateway/qualification/models.py
+++ b/gateway/qualification/models.py
@@ -229,7 +229,7 @@ _PROMPT_REGISTRABLE_DOMAIN_RE = re.compile(
     re.ASCII,
 )
 _PROMPT_LINKEDIN_COMPANY_SLUG_RE = re.compile(
-    r"[a-z0-9](?:[a-z0-9_-]{0,98}[a-z0-9])?",
+    r"[a-z0-9][a-z0-9_-]{0,99}",
     re.ASCII,
 )
 

--- a/scripts/configure_lab_arena_production.py
+++ b/scripts/configure_lab_arena_production.py
@@ -25,6 +25,9 @@ DEFAULT_SSH_KEY = Path.home() / ".ssh" / "leadpoet-2026-07-28.pem"
 AUTH_ENV = "LEADPOET_LAB_ARENA_PRODUCTION_APPLY"
 KNOWN_ACCOUNTS = frozenset({"187445349696", "493765492819"})
 KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DIGEST_REFERENCE_RE = re.compile(
+    r"(?=.{1,512}\Z)(?=[^\s\x00-\x1f\x7f]+\Z)[^/@\s]+/[^@\s]+@sha256:[0-9a-f]{64}\Z"
+)
 
 
 class ConfigurationError(RuntimeError):
@@ -71,6 +74,17 @@ def _required_alias(values: Mapping[str, str], name: str) -> str:
     if not value:
         raise ConfigurationError("required existing value is missing: %s" % name)
     return value
+
+
+def _validate_scorer_image(image: str) -> str:
+    """Validate a registry-qualified image pinned to a sha256 digest.
+
+    Keep this bounded syntax check dependency-free. The service performs the
+    authoritative registry resolution and image validation on startup.
+    """
+    if not isinstance(image, str) or not _DIGEST_REFERENCE_RE.fullmatch(image):
+        raise ConfigurationError("scorer image must be a valid sha256 digest reference")
+    return image
 
 
 def gateway_updates(values: Mapping[str, str], args: argparse.Namespace, service_key: str) -> dict[str, str]:
@@ -201,6 +215,9 @@ else:
         values[key] = raw_value
 
 updates = dict(request["updates"])
+if request["role"] == "scorer_image_only":
+    if set(updates) != {"LAB_ARENA_SCORER_IMAGE"} or request.get("aliases") or request.get("service_key"):
+        fail("scorer_image_scope_invalid")
 if request["role"] in ("gateway", "miner_credentials"):
     for source, target in request["aliases"].items():
         raw_value = str(values.get(source) or "").strip()
@@ -418,6 +435,7 @@ def build_parser() -> argparse.ArgumentParser:
     scope.add_argument("--prepare-runner", action="store_true", help="inspect or create the dedicated host-only runner signer")
     scope.add_argument("--miner-credentials-only", action="store_true", help="configure only the gateway miner KMS key from its existing Research Lab key")
     scope.add_argument("--testnet-proxy", choices=("enabled", "disabled"), default=None, help="configure only the fixed testnet gateway route; does not start a service or change mainnet")
+    scope.add_argument("--scorer-image-only", action="store_true", help="configure only the gateway scorer image")
     parser.add_argument("--miner-credential-kms-key-id", default=None, help="override the miner KMS key; an empty value disables admission during staged deployment")
     parser.add_argument("--service-key-fd", "--service-jwt-fd", dest="service_key_fd", type=int, help="inherited descriptor containing only the scoped service key")
     parser.add_argument("--ssh-key", type=Path, default=Path(os.getenv("LEADPOET_LAB_ARENA_SSH_KEY") or DEFAULT_SSH_KEY))
@@ -444,9 +462,11 @@ def _validate_args(args: argparse.Namespace) -> None:
         raise ConfigurationError("--daily-cutoff-utc must be between 0 and 23")
     if not args.ssh_key.is_file():
         raise ConfigurationError("SSH key does not exist")
-    narrow_scope = args.prepare_runner or args.miner_credentials_only or args.testnet_proxy is not None
+    narrow_scope = args.prepare_runner or args.miner_credentials_only or args.testnet_proxy is not None or args.scorer_image_only
     if args.miner_credential_kms_key_id is not None and not args.miner_credentials_only:
         raise ConfigurationError("--miner-credential-kms-key-id requires --miner-credentials-only")
+    if args.scorer_image_only:
+        _validate_scorer_image(str(args.scorer_image or ""))
     if not narrow_scope and args.service_key_fd is None:
         raise ConfigurationError("--service-key-fd is required for configuration")
     for name in (() if narrow_scope else ("bucket", "scorer_image", "runner_hotkey", "baseline_hotkey", "chain_endpoint", "api_base_url")):
@@ -468,6 +488,15 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "secret_id": GATEWAY_SECRET, "allowed_accounts": args.allowed_account,
                 "apply": args.apply, "role": "testnet_proxy", "aliases": {},
                 "updates": {"LAB_ARENA_TESTNET_ENABLED": "true" if args.testnet_proxy == "enabled" else "false"},
+            }
+            result = _ssh(args.gateway_host, args.ssh_key, request)
+            print(json.dumps({"ok": True, "targets": [result]}, separators=(",", ":")))
+            return 0
+        if args.scorer_image_only:
+            request = {
+                "secret_id": GATEWAY_SECRET, "allowed_accounts": args.allowed_account,
+                "apply": args.apply, "role": "scorer_image_only", "aliases": {},
+                "updates": {"LAB_ARENA_SCORER_IMAGE": args.scorer_image},
             }
             result = _ssh(args.gateway_host, args.ssh_key, request)
             print(json.dumps({"ok": True, "targets": [result]}, separators=(",", ":")))

--- a/tests/lab_arena/test_lab_arena_scoring.py
+++ b/tests/lab_arena/test_lab_arena_scoring.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -24,6 +25,31 @@ def make_icp(position: int) -> dict:
 
 def company(index: int, bucket: str = "51-200") -> dict:
     return {"company_name": "Co %d" % index, "company_website": "https://co%d.example.com" % index, "industry": "Software", "employee_count": bucket, "country": "United States", "intent_signals": []}
+
+
+def public_company(company_linkedin: str) -> dict:
+    return {
+        "company_name": "Acme",
+        "company_website": "https://acme.example.com",
+        "company_linkedin": company_linkedin,
+        "industry": "Software",
+        "employee_count": "51-200",
+        "company_stage": "Series A",
+        "country": "United States",
+        "state": "",
+        "fit_summary": "Matches the requested software profile.",
+        "fit_evidence_urls": ["https://acme.example.com/about"],
+        "intent_signals": [
+            {
+                "matched_icp_signal": 0,
+                "description": "Announced a funding round",
+                "date": "2026-09-01",
+                "why_now": "Recent funding creates a timely opportunity.",
+                "url": "https://acme.example.com/news/funding",
+                "snippet": "The company announced new funding.",
+            }
+        ],
+    }
 
 
 def breakdown(score: float, reason: str = "") -> dict:
@@ -86,6 +112,74 @@ def runs_for(submissions, stage=1, *, outputs=None, causes=None):
 
 
 _ICPS = {position: make_icp(position) for position in range(30)}
+
+
+@pytest.mark.parametrize(
+    ("path_kind", "slug"),
+    [("company", "acme-"), ("in", "acme_"), ("company", ("a" * 99) + "_")],
+)
+def test_public_company_linkedin_with_trailing_separator_reaches_real_scorer_model(
+    path_kind, slug
+):
+    from gateway.qualification.models import (
+        CompanyOutput,
+        candidate_company_prompt_identity,
+    )
+    from qualification.competition_models import CompetitionCompany
+    from qualification.scoring.competition import _normalized_company
+
+    linkedin = "https://www.linkedin.com/%s/%s" % (path_kind, slug)
+    public = json.loads(
+        CompetitionCompany.model_validate(
+            public_company(linkedin)
+        ).model_dump_json()
+    )
+    internal = CompanyOutput(**_normalized_company(public))
+    identity = candidate_company_prompt_identity(
+        company_name=internal.company_name,
+        company_website=internal.company_website,
+        company_linkedin=internal.company_linkedin,
+    )
+
+    assert public["company_linkedin"] == linkedin
+    assert json.loads(internal.model_dump_json())["company_linkedin"] == linkedin
+    assert identity["company_linkedin"] == slug
+
+
+def test_ordinary_scorer_linkedin_slug_is_unchanged():
+    from gateway.qualification.models import candidate_linkedin_prompt_slug
+
+    assert candidate_linkedin_prompt_slug(
+        "https://linkedin.com/company/acme-42", "company_linkedin"
+    ) == "acme-42"
+
+
+def test_internal_scorer_company_allows_missing_linkedin():
+    from gateway.qualification.models import CompanyOutput
+    from qualification.scoring.competition import _normalized_company
+
+    projected = _normalized_company(public_company(""))
+    projected.pop("company_linkedin")
+    assert CompanyOutput(**projected).company_linkedin == ""
+
+
+@pytest.mark.parametrize(
+    "linkedin",
+    [
+        "https://linkedin.com/company/acme%2Fposts",
+        "https://linkedin.com/company/acme%5Cposts",
+        "https://evil-linkedin.com/company/acme-",
+        "https://linkedin.com/company/" + ("a" * 100) + "-",
+        "https://linkedin.com/company/acme%0A-",
+        "https://linkedin.com/company/acme%252Fsystem%253Aignore",
+        "https://linkedin.com/company/caf\N{LATIN SMALL LETTER E WITH ACUTE}-",
+    ],
+)
+def test_scorer_linkedin_slug_still_rejects_unsafe_shapes(linkedin):
+    from gateway.qualification.models import candidate_linkedin_prompt_slug
+
+    with pytest.raises(ValueError):
+        candidate_linkedin_prompt_slug(linkedin, "company_linkedin")
 
 
 def test_policy_is_plain_and_binds_environment_fail_closed():

--- a/tests/test_configure_lab_arena_production.py
+++ b/tests/test_configure_lab_arena_production.py
@@ -73,6 +73,82 @@ def test_daily_cutoff_accepts_hour_six_and_rejects_out_of_range(tmp_path):
         MODULE._validate_args(parsed)
 
 
+def test_scorer_image_only_requires_a_digest_pinned_registry_reference(tmp_path):
+    key = tmp_path / "key"
+    key.write_text("fixture")
+    valid = "registry.example/team/scorer:v2@sha256:" + "a" * 64
+    parsed = MODULE.build_parser().parse_args([
+        "--scorer-image-only", "--scorer-image", valid,
+        "--allowed-account", "493765492819", "--ssh-key", str(key),
+    ])
+    MODULE._validate_args(parsed)
+    for image in (
+        "registry.example/team/scorer:v2",
+        "registry.example/team/scorer@sha256:short",
+        "scorer@sha256:" + "a" * 64,
+        "registry.example/@sha256:" + "a" * 64,
+    ):
+        parsed.scorer_image = image
+        with pytest.raises(MODULE.ConfigurationError, match="scorer image"):
+            MODULE._validate_args(parsed)
+
+
+def test_scorer_image_only_scope_is_mutually_exclusive():
+    with pytest.raises(SystemExit):
+        MODULE.build_parser().parse_args([
+            "--scorer-image-only", "--testnet-proxy", "enabled",
+            "--allowed-account", "493765492819",
+        ])
+
+
+def test_scorer_image_only_check_updates_only_the_scorer_image(monkeypatch, tmp_path, capsys):
+    key = tmp_path / "key"
+    key.write_text("fixture")
+    image = "registry.example/team/scorer@sha256:" + "b" * 64
+    calls = []
+    monkeypatch.setattr(MODULE, "_read_fd", lambda fd: pytest.fail("must not read service key"))
+    monkeypatch.setattr(MODULE, "_ssh", lambda host, ssh_key, request: calls.append((host, request)) or {"ok": True})
+    assert MODULE.main([
+        "--scorer-image-only", "--scorer-image", image, "--check",
+        "--allowed-account", "493765492819", "--ssh-key", str(key),
+    ]) == 0
+    assert len(calls) == 1
+    assert calls[0][0] == MODULE.GATEWAY_HOST
+    assert calls[0][1]["role"] == "scorer_image_only"
+    assert calls[0][1]["updates"] == {"LAB_ARENA_SCORER_IMAGE": image}
+    assert calls[0][1]["aliases"] == {}
+    assert calls[0][1]["apply"] is False
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+
+
+def test_scorer_image_only_apply_keeps_authorization_gate_and_scope(monkeypatch, tmp_path):
+    key = tmp_path / "key"
+    key.write_text("fixture")
+    image = "registry.example/team/scorer@sha256:" + "c" * 64
+    monkeypatch.delenv(MODULE.AUTH_ENV, raising=False)
+    monkeypatch.setattr(MODULE, "_ssh", lambda *args: pytest.fail("unauthorized remote call"))
+    assert MODULE.main([
+        "--scorer-image-only", "--scorer-image", image, "--apply",
+        "--allowed-account", "493765492819", "--ssh-key", str(key),
+    ]) == 2
+
+
+def test_scorer_image_only_apply_sends_exactly_one_target(monkeypatch, tmp_path):
+    key = tmp_path / "key"
+    key.write_text("fixture")
+    image = "registry.example/team/scorer@sha256:" + "d" * 64
+    calls = []
+    monkeypatch.setenv(MODULE.AUTH_ENV, "1")
+    monkeypatch.setattr(MODULE, "_ssh", lambda host, ssh_key, request: calls.append((host, request)) or {"ok": True, "applied": True})
+    assert MODULE.main([
+        "--scorer-image-only", "--scorer-image", image, "--apply",
+        "--allowed-account", "493765492819", "--ssh-key", str(key),
+    ]) == 0
+    assert len(calls) == 1
+    assert calls[0][1]["apply"] is True
+    assert set(calls[0][1]["updates"]) == {"LAB_ARENA_SCORER_IMAGE"}
+
+
 def test_validator_uses_dedicated_host_only_runner_wallet():
     updates = MODULE.validator_updates(args())
     assert updates["LAB_ARENA_WALLET_NAME"] == "arena_runner"
@@ -304,6 +380,32 @@ def test_remote_fake_aws_noops_when_current_document_already_matches(tmp_path):
     result, state = _run_remote_with_fake_aws(tmp_path, raw, return_state=True)
     assert result["unchanged"] is True
     assert state == {"current": "initial", "versions": {"initial": raw}}
+
+
+def test_remote_scorer_image_scope_updates_only_the_scorer_key(tmp_path):
+    source = {"KEEP": "same", "LAB_ARENA_MODE": "live", "LAB_ARENA_SCORER_IMAGE": "old"}
+    updated = json.loads(_run_remote_with_fake_aws(
+        tmp_path, json.dumps(source), request_override={
+            "role": "scorer_image_only", "updates": {
+                "LAB_ARENA_SCORER_IMAGE": "registry.example/team/scorer@sha256:" + "e" * 64,
+            }, "aliases": {}, "service_key": "",
+        }
+    ))
+    assert updated["LAB_ARENA_SCORER_IMAGE"].endswith("e" * 64)
+    assert updated["KEEP"] == "same"
+    assert updated["LAB_ARENA_MODE"] == "live"
+
+
+def test_remote_scorer_image_scope_rejects_unrelated_targets(tmp_path):
+    result = _run_remote_with_fake_aws(
+        tmp_path, json.dumps({"KEEP": "same"}), expect_success=False,
+        request_override={
+            "role": "scorer_image_only", "updates": {
+                "LAB_ARENA_SCORER_IMAGE": "new", "KEEP": "must-not-change",
+            }, "aliases": {}, "service_key": "",
+        }
+    )
+    assert result == {"ok": False, "code": "scorer_image_scope_invalid"}
 
 
 def test_prepare_runner_is_standalone_and_does_not_read_or_write_config(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Scope
The real hosted testnet miner path exposed a deterministic scorer contract mismatch. A public company result with a LinkedIn slug ending in an ASCII hyphen or underscore passed admission but failed both judge attempts before any provider call.

Allow those two safe slug endings. Keep the host, path, length, ASCII and prompt safety checks. Add a narrow operator mode to replace only the trusted scorer image without changing credentials, baseline settings or validator configuration. No miner protocol, scoring weights, receipts or attestation changes.

## Verification
88 focused scoring, scorer entrypoint, exclusion/reverification and configuration tests passed in 3.09 seconds. JSON round-trip, compilation and diff checks passed. Existing failed live round is preserved. A rebuilt native judge image, canonical deployment and a fresh real miner/gateway/Supabase/testnet-validator round follow this merge.