### PR TITLE
Add safe Arena scoring readiness checks and recovery diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ provisioning is required for validators, and there is no audit-validator role.
 
 Follow [the normal Arena validator setup](docs/arena_normal_validator_weights.md)
 for local wallet configuration, sandbox setup, restart, and verification.
+Use `--check-scoring-only` to diagnose local scoring setup without accessing
+wallets or the chain; the separate installed-runtime probe verifies sandbox
+execution. The normal `--check-only` command verifies wallet and chain readiness.
 
 
 ## License

--- a/docs/arena_normal_validator_weights.md
+++ b/docs/arena_normal_validator_weights.md
@@ -63,6 +63,10 @@ credentials are separate and remain in the gateway broker.
 Weights start independently, before scoring setup. An empty queue, missing
 runsc, scoring setup error, or scoring-loop error causes scoring to wait/retry,
 not the weight loop to stop. Scoring works again when its dependency recovers.
+Known host failures include a safe reason and the configured local path in
+logs. Provider exception text and runtime subprocess output are not logged.
+`scoring loop resumed` means polling recovered; an accepted completion is still
+needed to prove that actual Arena work succeeded.
 
 ## Weight submission
 
@@ -130,6 +134,18 @@ service, which runs this same entry point as root, or run the command below
 from a root shell with the validator's wallet path set explicitly. An ordinary
 unprivileged shell can submit weights but cannot launch this sandbox as
 configured. This is an existing sandbox requirement, not a signing mode.
+Root inside a restricted container may still lack the required mount and
+namespace capabilities; use the installed-runtime probe below to verify them.
+
+Install the complete matching gVisor package or release bundle. Current releases
+can require the companion `gvisor-bin/` directory beside `runsc`; copying only
+the executable may leave an incomplete installation. Follow the
+[official gVisor installation instructions](https://gvisor.dev/docs/user_guide/install/).
+Select its actual absolute path with `LAB_ARENA_RUNSC_PATH` in the service's
+configuration, or with `--arena-runsc-path`. The command-line flag takes
+precedence, then the environment, then `/usr/local/bin/runsc`. The validator
+does not search `PATH` or download a replacement binary. For an installation
+at `/usr/bin/runsc`, explicitly configure that path instead.
 
 For Finney SN71, the validator includes the public RPC endpoint, gateway URL,
 and trusted gateway signing-key hash. No API keys or public-configuration
@@ -181,12 +197,84 @@ Test networks require their matching epoch mapping and an explicit
 
 Append `--check-only` to verify local signing access, the gateway key pin,
 and finalized chain identity without broadcasting or claiming work.
+This check does not verify scoring. Keep it as the mandatory service startup
+check so a missing scoring dependency cannot stop weight submission.
 `--once` runs one scoring poll and one weight cycle; it is not a substitute
 for a continuously supervised process or finalized reveal verification.
 
 Run only one process per hotkey. Keep the same weight state directory across
 updates and retries. Never put provider keys or wallet seed values in service
 configuration, logs, or Git.
+
+## Diagnose scoring setup
+
+Run `--check-scoring-only` with the same interpreter, runtime path, work path,
+and account as the validator. It checks Linux x86_64, the selected executable,
+rootful service identity, a five-second `runsc --version` invocation, and runner
+directory access, including `sandboxes`, `runs`, `images`, `sources`, and the
+fixed `/tmp` socket root. It creates missing named runner directories with private
+permissions and removes only its own temporary write probes. Existing runner
+root permissions, wallets, journals, and cached files are preserved. Existing
+`sandboxes` and `runs` directories retain the normal private-mode requirement.
+Configured work-directory symlinks, including parent components, are rejected
+without following or replacing them. The fixed OS `/tmp` alias is resolved and
+probed without changing shared-directory permissions.
+
+For a service installation, from the release checkout:
+
+```bash
+sudo /absolute/path/to/.venv-arena/bin/python \
+  scripts/run_arena_validator.py \
+  --environment-file /absolute/path/to/arena-validator-service.env \
+  --check-scoring-only
+```
+
+Use your installed interpreter and service environment file. The command reads
+no wallet, contacts no gateway or chain, claims no work, and broadcasts nothing.
+It exits nonzero with a reason on failure. Success explicitly reports
+`sandbox_execution=not_checked`; it does not prove mounts, sandbox execution,
+gateway authorization, or accepted scoring. This mode is mutually exclusive
+with `--check-only` and `--once`.
+
+| Reason | Required action |
+| --- | --- |
+| `runsc_path_invalid` | Set the absolute path to the installed executable. |
+| `runsc_missing` | Install runsc or correct the configured path. |
+| `runsc_not_executable` | Check the file type, execute permissions, parent access, and noexec mounts. |
+| `runsc_unusable` | Check executable architecture and the complete matching installation. |
+| `runsc_probe_timeout` | Investigate why the installed runtime's version check hangs. |
+| `runsc_probe_cleanup_failed` | Inspect the host for a stuck version-check process; forced cleanup could not be confirmed. |
+| `unsupported_host` | Use Linux x86_64 for this Arena integration. |
+| `root_required` | Use the configured rootful service with the existing wallet path. |
+| `unsafe_work_directory` | Inspect the reported path; preserve its contents and correct the configuration. |
+| `work_directory_unwritable` | Check ownership, permissions, read-only mounts, and available storage. |
+| `sandbox_launch_failed` | Run the installed-runtime probe and investigate sandbox capabilities. |
+
+After host checks pass, exercise the actual installation with the existing
+probe from the same release and with equivalent service privileges:
+
+```bash
+sudo /absolute/path/to/.venv-arena/bin/python \
+  scripts/_lab_arena_runsc_probe_ci.py \
+  --runsc-path /usr/local/bin/runsc
+```
+
+Substitute the exact runtime path used by the validator. Always pass
+`--runsc-path` when diagnosing an installed service: omitting it downloads a
+separate runtime for CI and can conceal a broken service installation.
+`--dry-run` validates only the probe plan. A real pass ends with
+`LAB_ARENA_RUNSC_PROBE_SUCCESS` and covers execution, worker sockets, read-only
+filesystem behavior, timeout, output limits, the agent entrypoint, and cleanup.
+For networking it checks the `--network=none` command and a failed outbound
+connection smoke test. An unreachable destination can also make that connection
+fail, so this test alone does not independently prove network isolation.
+The probe uses local provider fixtures and no production leases or credentials.
+
+Then verify a real eligible Arena job reaches an accepted completion, and
+independently verify finalized weight reveal for that validator. An empty queue
+or a live process proves neither. `included_pending_reveal` means the commitment
+is included while reveal confirmation remains pending. Preserve all weight
+journals through repairs and restarts. Check every affected validator separately.
 
 ## Deployment
 

--- a/docs/v2_deployment_verification_checklist.md
+++ b/docs/v2_deployment_verification_checklist.md
@@ -21,6 +21,7 @@ python3.11 -m pytest -q \
   tests/test_arena_validator.py \
   tests/test_local_weight_signer.py \
   tests/test_arena_validator_local_runtime.py \
+  tests/test_arena_scoring_readiness.py \
   tests/test_arena_validator_launcher.py \
   tests/test_arena_validator_restart.py \
   tests/test_arena_reveal_chain_source.py \
@@ -89,6 +90,11 @@ source. A manifest generated from an uncommitted working tree is not sufficient.
 Code push and deployment are separate actions. Follow the authorized deployment
 scope. Before replacing a working process, run the normal validator's
 `--check-only` command and preserve its state directory.
+For a scoring-runtime repair, also run `--check-scoring-only` and the real
+installed-runtime probe described in `docs/arena_normal_validator_weights.md`.
+Keep scoring checks separate from the mandatory service startup check: a
+scoring failure must not stop weights. A successful host check or probe does
+not prove that a real Arena completion was accepted.
 
 The normal validator requires no enclave image or KMS recipient policy. Apply
 migration 208 before deploying the new scoring authorization. Keep the existing

--- a/lab_arena/runner.py
+++ b/lab_arena/runner.py
@@ -41,10 +41,11 @@ from lab_arena import integrity
 from lab_arena import contracts, images, leased_images, operations, runtime, scoring, shim, source_bundle
 from lab_arena.contracts import ArenaContractError
 from lab_arena.output import OutputInvalid, output_document_from_bytes
+from lab_arena.runtime_host import DEFAULT_RUNNER_SOCKET_ROOT, RuntimeHostError, runtime_host_diagnostic
 
 DEFAULT_MAX_PARALLEL_RUNS = contracts.RUNNER_SLOT_CEILING
 MAX_PARALLEL_ENV = "LAB_ARENA_MAX_PARALLEL_RUNS"
-DEFAULT_SOCKET_ROOT = "/tmp"
+DEFAULT_SOCKET_ROOT = str(DEFAULT_RUNNER_SOCKET_ROOT)
 AGENT_ENTRYPOINT_PATH = Path(__file__).with_name("agent_entrypoint.py").resolve()
 MAX_REFUSED_FRAMES = 25  # after this many refused calls the worker answers a run's frames locally
 # A request on the worker socket is either a length-prefixed operation frame
@@ -1759,8 +1760,9 @@ class Runner:
             self.completed.append({"run_id": lease["run_id"], "result": result})
         except Exception as exc:  # the attempt fails closed; the service expires the lease
             self.abandoned += 1
+            detail = runtime_host_diagnostic(exc) if isinstance(exc, RuntimeHostError) else type(exc).__name__
             print(
-                "Lab Arena run abandoned: %s" % type(exc).__name__,
+                "Lab Arena run abandoned: %s" % detail,
                 file=sys.stderr,
                 flush=True,
             )
@@ -1768,7 +1770,7 @@ class Runner:
                 {
                     "run_id": lease.get("run_id"),
                     "error": type(exc).__name__,
-                    "detail": str(exc)[:200],
+                    "detail": (detail if isinstance(exc, RuntimeHostError) else str(exc))[:200],
                 }
             )
         finally:

--- a/lab_arena/runtime.py
+++ b/lab_arena/runtime.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import json
 import os
-import platform
 import re
 import resource
 import shutil
@@ -45,6 +44,10 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from lab_arena import contracts
 from lab_arena.operations import SCRAPINGDOG_RUNTIME_HANDLE
+from lab_arena.runtime_host import (
+    ArenaRuntimeError, RuntimeHostError, require_linux_x86_64,
+    require_rootful_runtime, require_runsc_executable,
+)
 
 SANDBOX_MODEL_DIR = "/model"
 SANDBOX_AGENT_DIR = "/agent"
@@ -104,14 +107,6 @@ _ENV_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
 ProcessRunner = Callable[..., Any]
 
 
-class ArenaRuntimeError(RuntimeError):
-    """Base runtime failure; always fail the ICP attempt closed."""
-
-
-class RuntimeHostError(ArenaRuntimeError):
-    """The host cannot run the Arena runtime."""
-
-
 class SandboxSpecError(ArenaRuntimeError):
     """A sandbox specification is invalid."""
 
@@ -122,27 +117,6 @@ class SandboxOutputError(ArenaRuntimeError):
 
 class SandboxCleanupError(ArenaRuntimeError):
     """Sandbox, mount, or bundle cleanup did not complete."""
-
-
-# ---------------------------------------------------------------------------
-# Runtime host
-# ---------------------------------------------------------------------------
-
-
-def require_runsc_executable(path: Path) -> Path:
-    """Require a regular executable runsc file without pinning its identity."""
-
-    binary = Path(path)
-    if not binary.is_file() or not os.access(binary, os.X_OK):
-        raise RuntimeHostError("runsc executable is unavailable")
-    return binary
-
-
-def require_linux_x86_64() -> None:
-    system = platform.system()
-    machine = platform.machine().lower()
-    if system != "Linux" or machine not in ("x86_64", "amd64"):
-        raise RuntimeHostError("Arena runtime requires Linux x86_64 (host is %s %s)" % (system, machine))
 
 
 # ---------------------------------------------------------------------------
@@ -826,11 +800,11 @@ def run_sandbox(
             pid_file_mode = os.lstat(pid_file).st_mode
         except OSError as exc:
             raise RuntimeHostError(
-                "runsc exited before sandbox creation completed"
+                reason="sandbox_launch_failed", runsc_path=config.runsc_path,
             ) from exc
         if not stat.S_ISREG(pid_file_mode):
             raise RuntimeHostError(
-                "runsc exited before sandbox creation completed"
+                reason="sandbox_launch_failed", runsc_path=config.runsc_path,
             )
         cpu_after, max_rss = rusage()
         output_bytes: Optional[bytes] = None
@@ -893,7 +867,7 @@ def run_sandbox(
 
 
 class RunscRuntime:
-    """Host-checked runtime: constructing it proves Linux x86_64 and the binary."""
+    """Host checks cover Linux x86_64, root and the selected executable."""
 
     def __init__(
         self,
@@ -906,6 +880,7 @@ class RunscRuntime:
         require_linux_x86_64()
         self.config = config
         require_runsc_executable(config.runsc_path)
+        require_rootful_runtime()
         self._process_runner = process_runner
         self._clock = clock
         self._sleep = sleep

--- a/lab_arena/runtime_host.py
+++ b/lab_arena/runtime_host.py
@@ -1,0 +1,273 @@
+"""Local scoring readiness, independent of wallets, chain clients and providers."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import platform
+import re
+import secrets
+import signal
+import stat
+import subprocess
+from pathlib import Path
+
+RUNSC_CHECK_TIMEOUT_SECONDS = 5
+RUNSC_CHECK_CLEANUP_SECONDS = 2
+DEFAULT_RUNNER_SOCKET_ROOT = Path("/tmp")
+_REASONS = {
+    "runtime_host_error": "the host cannot run the Arena sandbox",
+    "runsc_path_invalid": "configure an absolute path to the installed runsc executable",
+    "runsc_missing": "install runsc or correct its configured path",
+    "runsc_not_executable": "runsc must be a regular executable file",
+    "runsc_unusable": "the installed runsc could not execute; check its architecture and complete installation",
+    "runsc_probe_timeout": "the installed runsc did not respond to its bounded version check",
+    "runsc_probe_cleanup_failed": "the version check could not be stopped and reaped; inspect the host before retrying",
+    "unsupported_host": "Arena scoring requires Linux x86_64",
+    "root_required": "Arena scoring requires the configured rootful service",
+    "unsafe_work_directory": "runner directories must be real directories at a dedicated path",
+    "work_directory_unwritable": "check runner directory ownership, permissions and available storage",
+    "sandbox_launch_failed": "runsc exited before sandbox creation completed",
+}
+_LOG_PATH = re.compile(r"/[A-Za-z0-9_./ -]{0,511}\Z")
+
+
+class ArenaRuntimeError(RuntimeError):
+    """Base runtime failure; always fail the ICP attempt closed."""
+
+
+class RuntimeHostError(ArenaRuntimeError):
+    """A host failure with a closed, credential-free public diagnostic."""
+
+    def __init__(
+        self, message="", *, reason="runtime_host_error", runsc_path=None, work_dir=None
+    ):
+        # Preserve existing callers' exception text, but never log that text.
+        super().__init__(
+            message or _REASONS.get(reason, _REASONS["runtime_host_error"])
+        )
+        self.reason = reason if reason in _REASONS else "runtime_host_error"
+        self.runsc_path = runsc_path
+        self.work_dir = work_dir
+
+
+def scoring_host_details(*, runsc_path=None, work_dir=None) -> str:
+    """Only bounded local paths are public; never format arbitrary metadata."""
+    fields = []
+    for name, path in (("runsc_path", runsc_path), ("work_dir", work_dir)):
+        if path is not None:
+            value = str(path)
+            if _LOG_PATH.fullmatch(value):
+                fields.append("%s=%s" % (name, json.dumps(value)))
+    return " ".join(fields)
+
+
+def runtime_host_diagnostic(error: RuntimeHostError) -> str:
+    reason = error.reason if error.reason in _REASONS else "runtime_host_error"
+    details = scoring_host_details(runsc_path=error.runsc_path, work_dir=error.work_dir)
+    return "reason=%s%s hint=%s" % (
+        reason,
+        " " + details if details else "",
+        json.dumps(_REASONS[reason]),
+    )
+
+
+def require_linux_x86_64() -> None:
+    if platform.system() != "Linux" or platform.machine().lower() not in (
+        "x86_64",
+        "amd64",
+    ):
+        raise RuntimeHostError(reason="unsupported_host")
+
+
+def require_rootful_runtime() -> None:
+    if getattr(os, "geteuid", lambda: -1)() != 0:
+        raise RuntimeHostError(reason="root_required")
+
+
+def require_runsc_executable(path: Path) -> Path:
+    """Check the explicitly selected binary; never search PATH or install one."""
+    binary = Path(path)
+    if not binary.is_absolute():
+        raise RuntimeHostError(reason="runsc_path_invalid")
+    try:
+        metadata = binary.stat()
+    except ValueError:
+        raise RuntimeHostError(reason="runsc_path_invalid") from None
+    except FileNotFoundError:
+        raise RuntimeHostError(reason="runsc_missing", runsc_path=binary) from None
+    except OSError:
+        raise RuntimeHostError(
+            reason="runsc_not_executable", runsc_path=binary
+        ) from None
+    if not stat.S_ISREG(metadata.st_mode) or not os.access(binary, os.X_OK):
+        raise RuntimeHostError(reason="runsc_not_executable", runsc_path=binary)
+    return binary
+
+
+def check_runsc_launch(binary: Path) -> None:
+    """A bounded version check proves execution, not sandbox capability."""
+    try:
+        process = subprocess.Popen(
+            [str(binary), "--version"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env={"PATH": "/usr/local/bin:/usr/bin:/bin"},
+            start_new_session=True,
+        )
+    except OSError as exc:
+        reason = (
+            "runsc_not_executable"
+            if exc.errno in (errno.EACCES, errno.EPERM)
+            else "runsc_unusable"
+        )
+        raise RuntimeHostError(reason=reason, runsc_path=binary) from None
+    try:
+        returncode = process.wait(timeout=RUNSC_CHECK_TIMEOUT_SECONDS)
+    except BaseException as exc:
+        # A broken installation may spawn helpers before hanging. Kill the
+        # entire task-owned group, then reap the version process on all exits.
+        try:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait(timeout=RUNSC_CHECK_CLEANUP_SECONDS)
+        except (OSError, subprocess.TimeoutExpired):
+            raise RuntimeHostError(
+                reason="runsc_probe_cleanup_failed", runsc_path=binary
+            ) from None
+        if isinstance(exc, subprocess.TimeoutExpired):
+            raise RuntimeHostError(
+                reason="runsc_probe_timeout", runsc_path=binary
+            ) from None
+        raise
+    if returncode != 0:
+        raise RuntimeHostError(reason="runsc_unusable", runsc_path=binary)
+
+
+def _open_directory_tree(path: Path, *, create: bool) -> int:
+    """Walk from / using no-follow opens, including every parent component."""
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    descriptor = os.open(path.anchor, flags)
+    try:
+        for name in path.parts[1:]:
+            if create:
+                try:
+                    os.mkdir(name, mode=0o700, dir_fd=descriptor)
+                except FileExistsError:
+                    pass  # The no-follow directory open checks existing types.
+            child = os.open(name, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _probe_directory_write(descriptor: int) -> None:
+    # Use directory descriptors so a renamed path cannot redirect the probe.
+    probe_name = ".arena-readiness-" + secrets.token_hex(12)
+    probe = os.open(
+        probe_name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        0o600,
+        dir_fd=descriptor,
+    )
+    try:
+        os.write(probe, b"arena-readiness\n")
+    finally:
+        os.close(probe)
+        os.unlink(probe_name, dir_fd=descriptor)
+
+
+def _directory_failure(exc: OSError, directory: Path) -> RuntimeHostError:
+    reason = (
+        "unsafe_work_directory"
+        if exc.errno in (errno.EEXIST, errno.ENOTDIR, errno.ELOOP)
+        else "work_directory_unwritable"
+    )
+    return RuntimeHostError(reason=reason, work_dir=directory)
+
+
+def prepare_runner_directories(work_dir: Path) -> None:
+    """Check every mutable runner directory without loading or evicting caches."""
+    root = Path(work_dir).absolute()
+    if (
+        str(root)
+        in (
+            "/",
+            "/home",
+            "/root",
+            "/var",
+            "/var/lib",
+            "/tmp",
+            "/var/tmp",
+            "/usr",
+            "/etc",
+            "/opt",
+        )
+        or ".." in root.parts
+        or "\x00" in str(root)
+    ):
+        raise RuntimeHostError(reason="unsafe_work_directory", work_dir=root)
+    directory = root
+    root_descriptor = None
+    try:
+        root_descriptor = _open_directory_tree(root, create=True)
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        for name in (None, "sandboxes", "runs", "images", "sources"):
+            directory = root if name is None else root / name
+            if name is not None:
+                try:
+                    os.mkdir(name, mode=0o700, dir_fd=root_descriptor)
+                except FileExistsError:
+                    pass  # The no-follow directory open below checks its type.
+            descriptor = (
+                os.dup(root_descriptor)
+                if name is None
+                else os.open(name, flags, dir_fd=root_descriptor)
+            )
+            try:
+                if name in ("sandboxes", "runs"):
+                    os.fchmod(descriptor, 0o700)
+                _probe_directory_write(descriptor)
+            finally:
+                os.close(descriptor)
+    except OSError as exc:
+        raise _directory_failure(exc, directory) from None
+    except ValueError:
+        raise RuntimeHostError(reason="unsafe_work_directory") from None
+    finally:
+        if root_descriptor is not None:
+            os.close(root_descriptor)
+
+
+def check_runner_socket_directory() -> None:
+    """Probe the fixed OS temporary directory without changing its permissions."""
+    directory = DEFAULT_RUNNER_SOCKET_ROOT
+    descriptor = None
+    try:
+        # /tmp is a trusted OS alias on some hosts (including macOS test hosts).
+        # Configurable work paths above never get this symlink-resolution exception.
+        resolved = directory.resolve(strict=True)
+        descriptor = _open_directory_tree(resolved, create=False)
+        _probe_directory_write(descriptor)
+    except OSError as exc:
+        raise _directory_failure(exc, directory) from None
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def prepare_scoring_host(runsc_path: Path, work_dir: Path) -> None:
+    """Shared setup for scoring startup and the offline host-readiness command."""
+    require_linux_x86_64()
+    binary = require_runsc_executable(runsc_path)
+    require_rootful_runtime()
+    check_runsc_launch(binary)
+    prepare_runner_directories(work_dir)
+    check_runner_socket_directory()

--- a/lab_arena/validator.py
+++ b/lab_arena/validator.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, Mapping, Optional, Protocol, Sequence
 
 from lab_arena import contracts
 from lab_arena.contracts import document_hash
+from lab_arena.runtime_host import RuntimeHostError, runtime_host_diagnostic
 
 MAX_ARENA_WEIGHT_ATTEMPTS = 3
 FINNEY_SN71_API_BASE_URL = "https://gateway.subnet71.com"
@@ -552,7 +553,7 @@ class ArenaWeightOrchestrator:
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run one normal Leadpoet Arena validator", add_help=True)
-    parser.add_argument("--netuid", type=int, default=int(os.environ.get("LAB_ARENA_NETUID", "71")))
+    parser.add_argument("--netuid", type=int)
     parser.add_argument("--subtensor.network", "--subtensor_network", dest="subtensor_network", default=os.environ.get("LAB_ARENA_NETWORK", "finney"), help="Chain identity (finney or test); use --subtensor.chain_endpoint for a local node")
     parser.add_argument("--subtensor.chain_endpoint", dest="chain_endpoint", default=os.environ.get("LAB_ARENA_CHAIN_ENDPOINT", ""), help="Explicit ws:// or wss:// RPC URL; defaults to the selected network's public endpoint")
     parser.add_argument("--wallet.name", dest="wallet_name", default=os.environ.get("LAB_ARENA_WALLET_NAME", "default"))
@@ -561,9 +562,11 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--arena-api-base-url", dest="api_base_url", default=os.environ.get("LAB_ARENA_API_BASE_URL", ""))
     parser.add_argument("--arena-work-dir", dest="work_dir", default=os.environ.get("LAB_ARENA_RUNNER_WORK_DIR", "/var/lib/lab-arena/runner"))
     parser.add_argument("--arena-runsc-path", dest="runsc_path", default=os.environ.get("LAB_ARENA_RUNSC_PATH", "/usr/local/bin/runsc"))
-    parser.add_argument("--arena-poll-seconds", dest="poll_seconds", type=int, default=int(os.environ.get("LAB_ARENA_VALIDATOR_POLL_SECONDS", "30")))
-    parser.add_argument("--check-only", action="store_true")
-    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--arena-poll-seconds", dest="poll_seconds", type=int)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--check-only", action="store_true", help="Check wallet, gateway key and chain readiness; scoring is not checked")
+    mode.add_argument("--check-scoring-only", action="store_true", help="Check local scoring host setup without wallets, chain access or claims; no sandbox is executed")
+    mode.add_argument("--once", action="store_true")
     return parser
 
 
@@ -630,16 +633,27 @@ def run_validator_loops(*, orchestrator, runner_factory, epoch_supplier, stop,
     weights = threading.Thread(target=weight_loop, name="arena-weight-loop", daemon=False)
     weights.start()
     runner = None
+    scoring_failed = False
     try:
         while not stop.is_set():
             try:
                 if runner is None:
                     runner = runner_factory()
                 taken = runner.run_once(stop_event=stop)
+                if scoring_failed:
+                    print("Arena validator scoring loop resumed; sandbox completion is reported separately",
+                          flush=True)
+                    scoring_failed = False
             except Exception as exc:
-                # No exception text: provider errors can contain credential-bearing URLs.
-                print("Arena validator scoring cycle failed: type=%s; weights continue"
-                      % type(exc).__name__, file=sys.stderr, flush=True)
+                scoring_failed = True
+                if isinstance(exc, RuntimeHostError):
+                    print("Arena validator scoring unavailable: phase=%s %s; weights continue"
+                          % ("setup" if runner is None else "cycle", runtime_host_diagnostic(exc)),
+                          file=sys.stderr, flush=True)
+                else:
+                    # Arbitrary provider errors can contain credential-bearing URLs.
+                    print("Arena validator scoring cycle failed: type=%s; weights continue"
+                          % type(exc).__name__, file=sys.stderr, flush=True)
                 if runner is not None:
                     try:
                         runner.close()
@@ -667,7 +681,33 @@ def run_validator_loops(*, orchestrator, runner_factory, epoch_supplier, stop,
 
 
 def main(argv=None) -> int:
-    args = _parser().parse_args(argv)
+    parser = _parser()
+    args = parser.parse_args(argv)
+    if args.check_scoring_only:
+        from lab_arena.runtime_host import prepare_scoring_host, scoring_host_details
+
+        try:
+            prepare_scoring_host(Path(args.runsc_path), Path(args.work_dir))
+        except RuntimeHostError as exc:
+            print("Arena scoring host checks failed: %s" % runtime_host_diagnostic(exc),
+                  file=sys.stderr, flush=True)
+            return 1
+        print("Arena scoring host checks passed: %s; sandbox_execution=not_checked"
+              % scoring_host_details(runsc_path=args.runsc_path, work_dir=args.work_dir), flush=True)
+        return 0
+
+    # Scoring-only checks do not depend on chain or loop configuration.
+    for field, variable, fallback in (
+        ("netuid", "LAB_ARENA_NETUID", "71"),
+        ("poll_seconds", "LAB_ARENA_VALIDATOR_POLL_SECONDS", "30"),
+    ):
+        if getattr(args, field) is None:
+            try:
+                value = int(os.environ.get(variable, fallback))
+            except ValueError:
+                parser.error("%s must be an integer" % variable)
+            setattr(args, field, value)
+
     from lab_arena import chain as chain_module
     from lab_arena.local_weight_signer import (
         _http_rpc_endpoint, build_local_weight_signer, load_public_chain_signing_profile,

--- a/lab_arena/wiring.py
+++ b/lab_arena/wiring.py
@@ -35,6 +35,7 @@ from lab_arena.source_bundle import MAX_SOURCE_ARCHIVE_BYTES
 from lab_arena.store import ArenaStore, PostgrestTransport
 from lab_arena.submission_runtime import SubmissionProviderKeys
 from lab_arena.code_review_runtime import SubmissionCodeReviewer
+from lab_arena.runtime_host import prepare_scoring_host
 
 
 _DIRECT_URLOPEN = urllib.request.build_opener(urllib.request.ProxyHandler({})).open
@@ -483,6 +484,9 @@ def build_service_from_environment(mode: str):
 
 
 def build_runner_from_environment(args, *, keypair=None):
+    # Keep the CLI readiness check and real scoring setup on the same path.
+    # This runs only inside the retryable scoring loop, never the weight loop.
+    prepare_scoring_host(Path(args.runsc_path), Path(args.work_dir))
     from lab_arena import runner as runner_module
 
     if keypair is None:
@@ -497,11 +501,6 @@ def build_runner_from_environment(args, *, keypair=None):
     runner_root = Path(args.work_dir)
     sandbox_work = runner_root / "sandboxes"
     runs_work = runner_root / "runs"
-    for directory in (sandbox_work, runs_work):
-        directory.mkdir(parents=True, exist_ok=True)
-        if directory.is_symlink() or not directory.is_dir():
-            raise runtime.RuntimeHostError("runner work directory is unsafe")
-        directory.chmod(0o700)
     config = runtime.RuntimeConfig(runsc_path=Path(args.runsc_path), work_dir=sandbox_work)
     sandbox_runtime = runtime.RunscRuntime(config)
     identity = runner_module.RunnerIdentity(hotkey=keypair.ss58_address, sign=lambda message: keypair.sign(message.encode("utf-8")).hex())

--- a/tests/lab_arena/test_lab_arena_runner.py
+++ b/tests/lab_arena/test_lab_arena_runner.py
@@ -373,12 +373,13 @@ def test_model_failures_map_to_terminal_causes_with_no_output_hash(tmp_path, kin
     assert api.completions[0]["body"]["output"] is None
 
 
-def test_runtime_host_error_abandons_the_lease_without_a_model_result(tmp_path):
+def test_runtime_host_error_abandons_the_lease_without_a_model_result(tmp_path, capsys):
     class HostFailureRuntime:
         @staticmethod
         def run_icp(_spec, **_kwargs):
             raise runtime.RuntimeHostError(
-                "runsc exited before sandbox creation completed"
+                "untrusted subprocess detail: secret-token",
+                reason="sandbox_launch_failed", runsc_path=Path("/usr/local/bin/runsc"),
             )
 
     api = FakeApi([lease()])
@@ -389,6 +390,10 @@ def test_runtime_host_error_abandons_the_lease_without_a_model_result(tmp_path):
     assert runner_.abandoned == 1
     assert api.completions == []
     assert runner_.completed[0]["error"] == "RuntimeHostError"
+    diagnostic = capsys.readouterr().err
+    assert "reason=sandbox_launch_failed" in diagnostic
+    assert "secret-token" not in diagnostic
+    assert "secret-token" not in runner_.completed[0]["detail"]
 
 
 def test_real_broker_openrouter_error_response_maps_to_provider_error_not_model_error(tmp_path):

--- a/tests/test_arena_scoring_readiness.py
+++ b/tests/test_arena_scoring_readiness.py
@@ -1,0 +1,467 @@
+"""Scoring host checks must be useful without touching wallets or production."""
+
+import builtins
+import errno
+import stat
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from lab_arena import runtime_host as host, validator
+
+
+@pytest.fixture
+def scoring_host(tmp_path, monkeypatch):
+    monkeypatch.setattr(host.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(host.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(host.os, "geteuid", lambda: 0)
+    binary = tmp_path / "runsc"
+    binary.write_text("#!/bin/sh\nexit 0\n")
+    binary.chmod(0o755)
+    return binary, tmp_path / "runner"
+
+
+def test_scoring_check_needs_no_wallet_chain_gateway_or_signing_key(
+    scoring_host, monkeypatch, capsys
+):
+    binary, work = scoring_host
+    monkeypatch.setenv("LAB_ARENA_API_BASE_URL", "https://unreachable.invalid")
+    monkeypatch.setenv("LAB_ARENA_SIGNING_KEY_HASH", "not-a-key")
+    monkeypatch.setenv("LAB_ARENA_CHAIN_ENDPOINT", "not-a-node")
+    monkeypatch.setenv("LAB_ARENA_NETUID", "not-an-integer")
+    monkeypatch.setenv("LAB_ARENA_VALIDATOR_POLL_SECONDS", "not-an-integer")
+    monkeypatch.setenv("LAB_ARENA_RUNSC_PATH", str(binary))
+    monkeypatch.setenv("LAB_ARENA_RUNNER_WORK_DIR", str(work))
+    original_import = builtins.__import__
+
+    def local_only(name, globals=None, locals=None, fromlist=(), level=0):
+        blocked = ("chain", "local_weight_signer", "wiring", "runtime")
+        if name.startswith("bittensor") or name in tuple(
+            "lab_arena." + item for item in blocked
+        ):
+            pytest.fail("scoring host check imported " + name)
+        if name == "lab_arena" and any(item in blocked for item in fromlist):
+            pytest.fail("scoring host check imported production wiring")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", local_only)
+    monkeypatch.setattr(
+        validator, "load_local_hotkey", lambda *_: pytest.fail("wallet accessed")
+    )
+    monkeypatch.setattr(
+        validator,
+        "run_validator_loops",
+        lambda **_: pytest.fail("production loops started"),
+    )
+
+    assert validator.main(["--check-scoring-only"]) == 0
+    output = capsys.readouterr()
+    assert "host checks passed" in output.out
+    assert "sandbox_execution=not_checked" in output.out
+    assert str(binary) in output.out
+    assert not output.err
+    assert sorted(path.name for path in work.iterdir()) == [
+        "images",
+        "runs",
+        "sandboxes",
+        "sources",
+    ]
+
+
+def test_explicit_runsc_path_wins_over_environment_and_path_search(
+    scoring_host, monkeypatch
+):
+    binary, work = scoring_host
+    monkeypatch.setenv("LAB_ARENA_RUNSC_PATH", "/missing/runsc")
+    monkeypatch.setenv("PATH", "/missing")
+    assert (
+        validator.main(
+            [
+                "--check-scoring-only",
+                "--arena-runsc-path",
+                str(binary),
+                "--arena-work-dir",
+                str(work),
+            ]
+        )
+        == 0
+    )
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["--check-scoring-only", "--check-only"],
+        ["--check-scoring-only", "--once"],
+    ],
+)
+def test_readiness_modes_cannot_claim_or_broadcast(arguments):
+    with pytest.raises(SystemExit) as failure:
+        validator._parser().parse_args(arguments)
+    assert failure.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "kind,reason",
+    [
+        ("missing", "runsc_missing"),
+        ("non_executable", "runsc_not_executable"),
+        ("directory", "runsc_not_executable"),
+        ("relative", "runsc_path_invalid"),
+        ("bad_executable", "runsc_unusable"),
+        ("nonzero", "runsc_unusable"),
+        ("non_root", "root_required"),
+        ("wrong_cpu", "unsupported_host"),
+        ("wrong_os", "unsupported_host"),
+    ],
+)
+def test_host_failures_have_actionable_reasons_without_mutating_work(
+    scoring_host, monkeypatch, capsys, kind, reason
+):
+    binary, work = scoring_host
+    if kind == "missing":
+        binary.unlink()
+    elif kind == "non_executable":
+        binary.chmod(0o644)
+    elif kind == "directory":
+        binary.unlink()
+        binary.mkdir()
+    elif kind == "relative":
+        binary = Path("runsc")
+    elif kind == "bad_executable":
+        binary.write_text("not an executable file\n")
+    elif kind == "nonzero":
+        binary.write_text("#!/bin/sh\necho secret-stderr >&2\nexit 1\n")
+    elif kind == "non_root":
+        monkeypatch.setattr(host.os, "geteuid", lambda: 1000)
+    elif kind == "wrong_cpu":
+        monkeypatch.setattr(host.platform, "machine", lambda: "aarch64")
+    elif kind == "wrong_os":
+        monkeypatch.setattr(host.platform, "system", lambda: "Darwin")
+    assert (
+        validator.main(
+            [
+                "--check-scoring-only",
+                "--arena-runsc-path",
+                str(binary),
+                "--arena-work-dir",
+                str(work),
+            ]
+        )
+        == 1
+    )
+    output = capsys.readouterr()
+    assert "reason=" + reason in output.err
+    assert "Traceback" not in output.err and "secret-stderr" not in output.err
+    assert "passed" not in output.out
+    assert not work.exists()
+
+
+def test_runtime_version_check_has_no_provider_environment(scoring_host, monkeypatch):
+    binary, work = scoring_host
+    binary.write_text('#!/bin/sh\ntest -z "${OPENROUTER_API_KEY+x}"\n')
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-secret-never-forward")
+    host.prepare_scoring_host(binary, work)
+
+
+def test_runtime_version_check_times_out(scoring_host, monkeypatch):
+    binary, work = scoring_host
+    binary.write_text("#!/bin/sh\nexec /bin/sleep 60\n")
+    monkeypatch.setattr(host, "RUNSC_CHECK_TIMEOUT_SECONDS", 0.02)
+    with pytest.raises(host.RuntimeHostError) as failure:
+        host.prepare_scoring_host(binary, work)
+    assert failure.value.reason == "runsc_probe_timeout"
+    assert not work.exists()
+
+
+def test_version_check_cleanup_timeout_has_safe_diagnostics(
+    scoring_host, monkeypatch, capsys
+):
+    binary, work = scoring_host
+    waits = []
+    kills = []
+
+    class HungProcess:
+        pid = 123
+
+        def wait(self, *, timeout):
+            waits.append(timeout)
+            raise subprocess.TimeoutExpired("secret-command", timeout)
+
+    monkeypatch.setattr(host.subprocess, "Popen", lambda *_a, **_kw: HungProcess())
+    monkeypatch.setattr(host.os, "killpg", lambda *args: kills.append(args))
+    assert (
+        validator.main(
+            [
+                "--check-scoring-only",
+                "--arena-runsc-path",
+                str(binary),
+                "--arena-work-dir",
+                str(work),
+            ]
+        )
+        == 1
+    )
+    output = capsys.readouterr().err
+    assert "reason=runsc_probe_cleanup_failed" in output
+    assert "secret-command" not in output and "Traceback" not in output
+    assert waits == [host.RUNSC_CHECK_TIMEOUT_SECONDS, host.RUNSC_CHECK_CLEANUP_SECONDS]
+    assert kills == [(123, signal.SIGKILL)]
+    assert not work.exists()
+
+
+def test_hanging_version_check_terminates_helpers_and_reaps_parent(
+    scoring_host, monkeypatch
+):
+    binary, work = scoring_host
+    child_file = binary.parent / "helper.pid"
+    binary.write_text(
+        "#!%s\nimport subprocess, time\n" % sys.executable
+        + "child = subprocess.Popen(['/bin/sleep', '60'])\n"
+        + "with open(%r, 'w') as output: output.write(str(child.pid))\n"
+        % str(child_file)
+        + "time.sleep(60)\n"
+    )
+    real_popen = subprocess.Popen
+    parents = []
+
+    def record_process(*args, **kwargs):
+        process = real_popen(*args, **kwargs)
+        parents.append(process)
+        return process
+
+    monkeypatch.setattr(host.subprocess, "Popen", record_process)
+    monkeypatch.setattr(host, "RUNSC_CHECK_TIMEOUT_SECONDS", 1)
+    with pytest.raises(host.RuntimeHostError) as failure:
+        host.prepare_scoring_host(binary, work)
+    assert failure.value.reason == "runsc_probe_timeout"
+    assert parents[0].returncode == -signal.SIGKILL
+    child_pid = int(child_file.read_text())
+    # An orphan may briefly remain as an init-owned zombie, but must not run.
+    with real_popen(
+        ["ps", "-o", "stat=", "-p", str(child_pid)], stdout=subprocess.PIPE
+    ) as inspection:
+        status = inspection.communicate(timeout=2)[0].decode().strip()
+    assert not status or status.startswith("Z")
+    assert not work.exists()
+
+
+def test_runtime_constructor_rejects_non_root_even_with_a_valid_binary(
+    scoring_host, monkeypatch
+):
+    from lab_arena import runtime
+
+    binary, work = scoring_host
+    monkeypatch.setattr(host.os, "geteuid", lambda: 1000)
+    with pytest.raises(host.RuntimeHostError) as failure:
+        runtime.RunscRuntime(runtime.RuntimeConfig(runsc_path=binary, work_dir=work))
+    assert failure.value.reason == "root_required"
+
+
+def test_service_environment_runs_scoring_check_without_touching_weight_journal(
+    scoring_host, tmp_path, monkeypatch
+):
+    from scripts import run_arena_validator
+
+    binary, work = scoring_host
+    state = tmp_path / "state"
+    state.mkdir()
+    journal = state / "epoch-1-signed.json"
+    journal.write_bytes(b"existing signed transaction bytes\n")
+    settings = {
+        "LAB_ARENA_RUNSC_PATH": str(binary),
+        "LAB_ARENA_RUNNER_WORK_DIR": str(work),
+        "LAB_ARENA_VALIDATOR_STATE_DIR": str(state),
+    }
+    for key in settings:
+        monkeypatch.setenv(key, "/missing/ambient-setting")
+    environment = tmp_path / "service.env"
+    environment.write_text("".join('%s="%s"\n' % item for item in settings.items()))
+    environment.chmod(0o600)
+    # Exercise the real env-file ownership check under the test account;
+    # privileged-host behavior is covered separately by the host tests.
+    monkeypatch.setattr(host.os, "geteuid", lambda: environment.stat().st_uid)
+    monkeypatch.setattr(host, "require_rootful_runtime", lambda: None)
+    assert (
+        run_arena_validator.main(
+            ["--environment-file", str(environment), "--check-scoring-only"]
+        )
+        == 0
+    )
+    assert journal.read_bytes() == b"existing signed transaction bytes\n"
+    assert list(state.iterdir()) == [journal]
+
+
+def test_executable_on_noexec_mount_is_classified(scoring_host, monkeypatch):
+    binary, work = scoring_host
+
+    def denied(*_args, **_kwargs):
+        raise PermissionError(errno.EACCES, "sensitive system error")
+
+    monkeypatch.setattr(host.subprocess, "Popen", denied)
+    with pytest.raises(host.RuntimeHostError) as failure:
+        host.prepare_scoring_host(binary, work)
+    assert failure.value.reason == "runsc_not_executable"
+    assert "sensitive" not in host.runtime_host_diagnostic(failure.value)
+
+
+@pytest.mark.parametrize("location", ["root", "sandboxes", "runs", "images", "sources"])
+def test_directory_symlinks_fail_without_touching_target(tmp_path, location):
+    target = tmp_path / "target"
+    target.mkdir(mode=0o755)
+    sentinel = target / "keep"
+    sentinel.write_bytes(b"existing user data")
+    before = target.stat().st_mode
+    work = tmp_path / "runner"
+    if location == "root":
+        work.symlink_to(target, target_is_directory=True)
+    else:
+        work.mkdir()
+        (work / location).symlink_to(target, target_is_directory=True)
+    with pytest.raises(host.RuntimeHostError) as failure:
+        host.prepare_runner_directories(work)
+    assert failure.value.reason == "unsafe_work_directory"
+    assert sentinel.read_bytes() == b"existing user data"
+    assert target.stat().st_mode == before
+    assert sorted(path.name for path in target.iterdir()) == ["keep"]
+
+
+def test_directory_write_failure_preserves_existing_files(tmp_path, monkeypatch):
+    work = tmp_path / "runner"
+    work.mkdir()
+    sentinel = work / "keep"
+    sentinel.write_bytes(b"existing user data")
+
+    def disk_full(*_args, **_kwargs):
+        raise OSError(errno.ENOSPC, "secret system detail")
+
+    monkeypatch.setattr(host.os, "write", disk_full)
+    with pytest.raises(host.RuntimeHostError) as failure:
+        host.prepare_runner_directories(work)
+    assert failure.value.reason == "work_directory_unwritable"
+    assert sentinel.read_bytes() == b"existing user data"
+    assert sorted(path.name for path in work.iterdir()) == ["keep"]
+
+
+def test_existing_runner_root_permissions_and_files_survive_checks(tmp_path):
+    work = tmp_path / "runner"
+    work.mkdir(mode=0o750)
+    (work / "keep").write_text("existing cache")
+    before = stat.S_IMODE(work.stat().st_mode)
+    host.prepare_runner_directories(work)
+    assert stat.S_IMODE(work.stat().st_mode) == before
+    assert (work / "keep").read_text() == "existing cache"
+    for name in ("sandboxes", "runs", "images", "sources"):
+        assert stat.S_IMODE((work / name).stat().st_mode) == 0o700
+        assert not list((work / name).iterdir())
+
+
+@pytest.mark.parametrize("path", ["/", "/tmp", "/var/tmp", "/var/lib", "/etc"])
+def test_broad_work_paths_are_rejected_before_mutation(path, monkeypatch):
+    monkeypatch.setattr(
+        host.os, "open", lambda *_args, **_kwargs: pytest.fail("broad path opened")
+    )
+    with pytest.raises(host.RuntimeHostError) as failure:
+        host.prepare_runner_directories(Path(path))
+    assert failure.value.reason == "unsafe_work_directory"
+
+
+def test_symlinked_work_parent_is_rejected_without_creating_target(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir(mode=0o755)
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+    before = target.stat().st_mode
+    with pytest.raises(host.RuntimeHostError) as failure:
+        host.prepare_runner_directories(link / "runner")
+    assert failure.value.reason == "unsafe_work_directory"
+    assert target.stat().st_mode == before
+    assert not list(target.iterdir())
+
+
+@pytest.mark.parametrize(
+    "field,reason", [("runsc", "runsc_path_invalid"), ("work", "unsafe_work_directory")]
+)
+def test_malformed_paths_have_safe_diagnostics(scoring_host, capsys, field, reason):
+    binary, work = scoring_host
+    malformed = "/tmp/\x00secret-token"
+    assert (
+        validator.main(
+            [
+                "--check-scoring-only",
+                "--arena-runsc-path",
+                malformed if field == "runsc" else str(binary),
+                "--arena-work-dir",
+                malformed if field == "work" else str(work),
+            ]
+        )
+        == 1
+    )
+    output = capsys.readouterr().err
+    assert "reason=" + reason in output
+    assert "Traceback" not in output and "secret-token" not in output
+
+
+def test_socket_directory_check_preserves_shared_permissions_and_files(
+    tmp_path, monkeypatch
+):
+    sockets = tmp_path / "sockets"
+    sockets.mkdir(mode=0o1777)
+    (sockets / "keep").write_text("existing")
+    before = sockets.stat().st_mode
+    monkeypatch.setattr(host, "DEFAULT_RUNNER_SOCKET_ROOT", sockets)
+    host.check_runner_socket_directory()
+    assert sockets.stat().st_mode == before
+    assert [path.name for path in sockets.iterdir()] == ["keep"]
+
+
+def test_readonly_socket_directory_has_actionable_failure(tmp_path, monkeypatch):
+    sockets = tmp_path / "sockets"
+    sockets.mkdir()
+    monkeypatch.setattr(host, "DEFAULT_RUNNER_SOCKET_ROOT", sockets)
+
+    def readonly(_descriptor):
+        raise OSError(errno.EROFS, "sensitive mount detail")
+
+    monkeypatch.setattr(host, "_probe_directory_write", readonly)
+    with pytest.raises(host.RuntimeHostError) as failure:
+        host.check_runner_socket_directory()
+    assert failure.value.reason == "work_directory_unwritable"
+    assert "sensitive" not in host.runtime_host_diagnostic(failure.value)
+
+
+def test_diagnostic_never_logs_freeform_exception_text_or_unsafe_paths():
+    error = host.RuntimeHostError(
+        "https://provider.invalid?key=secret-token",
+        reason="runsc_missing",
+        runsc_path="/tmp/runsc\nsecret-token",
+        work_dir="https://provider.invalid?key=secret-token",
+    )
+    rendered = host.runtime_host_diagnostic(error)
+    assert "reason=runsc_missing" in rendered
+    assert "secret-token" not in rendered
+    assert "provider.invalid" not in rendered
+    assert "\n" not in rendered
+    unknown = host.RuntimeHostError("secret-token", reason="secret-token")
+    assert "secret-token" not in host.runtime_host_diagnostic(unknown)
+
+
+def test_normal_runner_uses_the_same_checks_before_wallet_access(monkeypatch):
+    from types import SimpleNamespace
+    from lab_arena import wiring
+
+    args = SimpleNamespace(runsc_path="/missing/runsc", work_dir="/unused/runner")
+    calls = []
+
+    def fail_before_wallet(binary, work):
+        calls.append((binary, work))
+        raise host.RuntimeHostError(reason="runsc_missing", runsc_path=binary)
+
+    monkeypatch.setattr(wiring, "prepare_scoring_host", fail_before_wallet)
+    with pytest.raises(host.RuntimeHostError) as failure:
+        wiring.build_runner_from_environment(args)
+    assert failure.value.reason == "runsc_missing"
+    assert calls == [(Path(args.runsc_path), Path(args.work_dir))]

--- a/tests/test_arena_validator_local_runtime.py
+++ b/tests/test_arena_validator_local_runtime.py
@@ -214,3 +214,50 @@ def test_local_hotkey_rejects_symlink(tmp_path):
 
     with pytest.raises(validator.ArenaValidatorError, match="private regular file"):
         validator.load_local_hotkey(args)
+
+
+def test_host_failure_recovers_without_stopping_weights_or_logging_secrets(capsys):
+    from lab_arena.runtime_host import RuntimeHostError
+
+    stop = _ImmediateStop()
+    orchestrator = _WeightRecorder()
+    factories = []
+
+    class Runner:
+        def run_once(self, *, stop_event):
+            assert orchestrator.second_run.wait(1)
+            stop_event.set()
+            return 0
+
+        def close(self):
+            return None
+
+    def factory():
+        factories.append(1)
+        if len(factories) == 1:
+            raise RuntimeHostError("https://provider.invalid?key=secret-token",
+                                   reason="runsc_missing", runsc_path=Path("/usr/local/bin/runsc"))
+        return Runner()
+
+    validator.run_validator_loops(orchestrator=orchestrator, runner_factory=factory,
+                                  epoch_supplier=lambda: 1, stop=stop, once=False)
+    output = capsys.readouterr()
+    assert "phase=setup reason=runsc_missing" in output.err
+    assert "/usr/local/bin/runsc" in output.err and "weights continue" in output.err
+    assert "secret-token" not in output.err + output.out
+    assert "scoring loop resumed" in output.out
+    assert "sandbox completion is reported separately" in output.out
+    assert orchestrator.runs >= 2
+
+
+def test_generic_scoring_error_still_hides_provider_details(capsys):
+    def factory():
+        raise RuntimeError("https://provider.invalid?key=secret-token")
+
+    orchestrator = _WeightRecorder()
+    validator.run_validator_loops(orchestrator=orchestrator, runner_factory=factory,
+                                  epoch_supplier=lambda: 1, stop=_ImmediateStop(), once=True)
+    output = capsys.readouterr()
+    assert "type=RuntimeError; weights continue" in output.err
+    assert "secret-token" not in output.err
+    assert orchestrator.runs >= 1

--- a/tests/test_arena_validator_startup.py
+++ b/tests/test_arena_validator_startup.py
@@ -140,6 +140,7 @@ def _clear_startup_environment(monkeypatch):
     for name in (
         "LAB_ARENA_NETWORK",
         "LAB_ARENA_NETUID",
+        "LAB_ARENA_VALIDATOR_POLL_SECONDS",
         "LAB_ARENA_CHAIN_ENDPOINT",
         "LAB_ARENA_API_BASE_URL",
         "LAB_ARENA_SIGNING_KEY_HASH",
@@ -153,6 +154,10 @@ def test_advertised_finney71_check_only_uses_public_defaults_and_stops_at_readin
     monkeypatch, startup_harness, capsys
 ):
     _clear_startup_environment(monkeypatch)
+    monkeypatch.setattr(
+        "lab_arena.runtime_host.prepare_scoring_host",
+        lambda *_args: pytest.fail("wallet readiness must not depend on scoring setup"),
+    )
 
     assert validator.main([
         "--netuid", "71", "--subtensor.network", "finney",
@@ -211,6 +216,36 @@ def test_environment_endpoint_is_used_when_flag_is_absent(monkeypatch, startup_h
     assert chain.config.endpoint == "wss://env.example:443"
     signer_config = startup_harness.captured["signer_args"][-1]["chain_config"]
     assert signer_config.endpoint == "wss://env.example:443"
+
+
+@pytest.mark.parametrize("variable", ["LAB_ARENA_NETUID", "LAB_ARENA_VALIDATOR_POLL_SECONDS"])
+def test_invalid_service_numeric_environment_fails_without_echoing_value(
+    monkeypatch, startup_harness, capsys, variable
+):
+    _clear_startup_environment(monkeypatch)
+    monkeypatch.setenv(variable, "secret-malformed-setting")
+    with pytest.raises(SystemExit) as failure:
+        validator.main(["--check-only"])
+    assert failure.value.code == 2
+    output = capsys.readouterr().err
+    assert variable + " must be an integer" in output
+    assert "secret-malformed-setting" not in output and "Traceback" not in output
+    assert startup_harness.captured["wallet_args"] == []
+
+
+@pytest.mark.parametrize("explicit_flags", [False, True])
+def test_service_numeric_settings_keep_flag_environment_precedence(
+    monkeypatch, startup_harness, explicit_flags
+):
+    _clear_startup_environment(monkeypatch)
+    monkeypatch.setenv("LAB_ARENA_NETUID", "invalid" if explicit_flags else "71")
+    monkeypatch.setenv("LAB_ARENA_VALIDATOR_POLL_SECONDS", "invalid" if explicit_flags else "45")
+    args = ["--once"]
+    if explicit_flags:
+        args += ["--netuid", "71", "--arena-poll-seconds", "45"]
+    assert validator.main(args) == 0
+    assert startup_harness.captured["connect_configs"][-1].netuid == 71
+    assert startup_harness.captured["loops"][-1]["poll_seconds"] == 45
 
 
 def test_loopback_ws_endpoint_is_allowed(monkeypatch, startup_harness):

--- a/tests/test_local_weight_signer.py
+++ b/tests/test_local_weight_signer.py
@@ -72,7 +72,8 @@ def test_https_transport_converts_wss_and_binds_strict_json_rpc():
         )
 
     transport = HttpsJsonRpcTransport(
-        "wss://chain.example:443", timeout_seconds=9, opener=open_request
+        "wss://chain.example:443", timeout_seconds=9, opener=open_request,
+        clock=lambda: 100.0,  # Request construction must not depend on scheduling latency.
     )
     assert transport.call(method="chain_getBlockHash", params=[3], request_id=7) == "0xabc"
     assert observed == {


### PR DESCRIPTION
Validators currently reduce local scoring setup failures to `RuntimeHostError`, leaving operators unable to tell whether the configured runsc binary, service account, or work directories need repair. Add safe reason codes and an offline `--check-scoring-only` command that uses the same host checks as normal scoring setup. It checks the selected executable, Linux x86_64/rootful requirements, bounded version execution and cleanup, and mutable runner directories without accessing wallets, the chain, or production work.

Scoring failures continue to retry independently of weights. Logs distinguish setup failure and recovery without exposing provider exceptions or subprocess output. Documentation explains complete runsc installation, exact runtime-path precedence, the existing installed-runtime probe, and the separate evidence needed for accepted scoring and finalized weight reveal.

Validation:

- Required validator safety gate: 452 passed, 5 skipped in 20.24 seconds (120-second budget).
- Focused startup, runtime, runner, bundle and probe tests: 155 passed in 30.65 seconds.
- Changed Python files compile; focused undefined/unused-symbol checks and `git diff --check` pass.
- Independent review findings addressed, including directory symlinks, malformed settings and bounded subprocess cleanup. A pre-existing RPC request test now uses its injected clock to avoid scheduler-dependent timeout assertions; production RPC code is unchanged.

Real Linux gVisor execution, the exact restart rehearsal, and live scoring/finalized reveal on affected validators are unverified. This branch has not been deployed. Host readiness success explicitly says `sandbox_execution=not_checked`.
